### PR TITLE
[#13870] Add DateTimePicker component

### DIFF
--- a/src/web/app/components/datetimepicker/datetimepicker.component.html
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.html
@@ -1,0 +1,17 @@
+<tm-datepicker
+  [date]="date"
+  [isDisabled]="isDisabled"
+  [minDate]="minDate"
+  [maxDate]="maxDate"
+  (dateChangeCallback)="onDateChange($event)"
+></tm-datepicker>
+<tm-timepicker
+  [date]="date"
+  [time]="time"
+  [isDisabled]="isDisabled"
+  [minDate]="minDate"
+  [maxDate]="maxDate"
+  [minTime]="minTime"
+  [maxTime]="maxTime"
+  (timeChange)="onTimeChange($event)"
+></tm-timepicker>

--- a/src/web/app/components/datetimepicker/datetimepicker.component.spec.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.spec.ts
@@ -47,6 +47,34 @@ describe('DatetimepickerComponent', () => {
     expect(component.time).toBe(initialTime);
   });
 
+  it('should reuse date and time object references when Date input has the same timestamp', () => {
+    const initialDate = component.date;
+    const initialTime = component.time;
+
+    component.dateTime = new Date(2026, 4, 26, 14, 30);
+
+    expect(component.date).toBe(initialDate);
+    expect(component.time).toBe(initialTime);
+  });
+
+  it('should reuse bounds object references when Date bounds have the same timestamps', () => {
+    component.minDateTime = new Date(2026, 0, 2, 3, 45);
+    component.maxDateTime = new Date(2026, 11, 31, 23, 59);
+
+    const initialMinDate = component.minDate;
+    const initialMinTime = component.minTime;
+    const initialMaxDate = component.maxDate;
+    const initialMaxTime = component.maxTime;
+
+    component.minDateTime = new Date(2026, 0, 2, 3, 45);
+    component.maxDateTime = new Date(2026, 11, 31, 23, 59);
+
+    expect(component.minDate).toBe(initialMinDate);
+    expect(component.minTime).toBe(initialMinTime);
+    expect(component.maxDate).toBe(initialMaxDate);
+    expect(component.maxTime).toBe(initialMaxTime);
+  });
+
   it('should not emit when date change keeps the same Date value', () => {
     const dateTimeChangeSpy = vi.spyOn(component.dateTimeChange, 'emit');
 

--- a/src/web/app/components/datetimepicker/datetimepicker.component.spec.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DatetimepickerComponent } from './datetimepicker.component';
+import { DatepickerComponent } from '../datepicker/datepicker.component';
+import { TimepickerComponent } from '../timepicker/timepicker.component';
+
+describe('DatetimepickerComponent', () => {
+  let component: DatetimepickerComponent;
+  let fixture: ComponentFixture<DatetimepickerComponent>;
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatetimepickerComponent);
+    component = fixture.componentInstance;
+    component.dateTime = new Date(2026, 4, 26, 14, 30);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('onDateChange: should emit updated Date when date changes', () => {
+    const dateTimeChangeSpy = vi.spyOn(component.dateTimeChange, 'emit');
+
+    component.onDateChange({ year: 2026, month: 6, day: 1 });
+
+    expect(dateTimeChangeSpy).toHaveBeenCalledWith(new Date(2026, 5, 1, 14, 30));
+    expect(component.dateTime).toEqual(new Date(2026, 5, 1, 14, 30));
+  });
+
+  it('onTimeChange: should emit updated Date when time changes', () => {
+    const dateTimeChangeSpy = vi.spyOn(component.dateTimeChange, 'emit');
+
+    component.onTimeChange({ hour: 23, minute: 59 });
+
+    expect(dateTimeChangeSpy).toHaveBeenCalledWith(new Date(2026, 4, 26, 23, 59));
+    expect(component.dateTime).toEqual(new Date(2026, 4, 26, 23, 59));
+  });
+
+  it('should derive date and time bounds from Date inputs', () => {
+    component.minDateTime = new Date(2026, 0, 2, 3, 45);
+    component.maxDateTime = new Date(2026, 11, 31, 23, 59);
+
+    expect(component.minDate).toEqual({ year: 2026, month: 1, day: 2 });
+    expect(component.minTime).toEqual({ hour: 3, minute: 45 });
+    expect(component.maxDate).toEqual({ year: 2026, month: 12, day: 31 });
+    expect(component.maxTime).toEqual({ hour: 23, minute: 59 });
+  });
+
+  it('should pass disabled state to inner pickers', () => {
+    component.isDisabled = true;
+    fixture.detectChanges();
+
+    const datepicker = fixture.debugElement.query(By.directive(DatepickerComponent)).componentInstance;
+    const timepicker = fixture.debugElement.query(By.directive(TimepickerComponent)).componentInstance;
+
+    expect(datepicker.isDisabled).toBe(true);
+    expect(timepicker.isDisabled).toBe(true);
+  });
+});

--- a/src/web/app/components/datetimepicker/datetimepicker.component.spec.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.spec.ts
@@ -37,6 +37,25 @@ describe('DatetimepickerComponent', () => {
     expect(component.dateTime).toEqual(new Date(2026, 4, 26, 23, 59));
   });
 
+  it('should reuse date and time object references while inputs are unchanged', () => {
+    const initialDate = component.date;
+    const initialTime = component.time;
+
+    fixture.detectChanges();
+
+    expect(component.date).toBe(initialDate);
+    expect(component.time).toBe(initialTime);
+  });
+
+  it('should not emit when date change keeps the same Date value', () => {
+    const dateTimeChangeSpy = vi.spyOn(component.dateTimeChange, 'emit');
+
+    component.onDateChange({ year: 2026, month: 5, day: 26 });
+
+    expect(dateTimeChangeSpy).not.toHaveBeenCalled();
+    expect(component.dateTime).toEqual(new Date(2026, 4, 26, 14, 30));
+  });
+
   it('should derive date and time bounds from Date inputs', () => {
     component.minDateTime = new Date(2026, 0, 2, 3, 45);
     component.maxDateTime = new Date(2026, 11, 31, 23, 59);

--- a/src/web/app/components/datetimepicker/datetimepicker.component.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.ts
@@ -1,0 +1,93 @@
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { DateTimeService } from '../../../services/datetime.service';
+import { DateFormat, TimeFormat, getDefaultDateFormat, getDefaultTimeFormat } from '../../../types/datetime-const';
+import { DatepickerComponent } from '../datepicker/datepicker.component';
+import { TimepickerComponent } from '../timepicker/timepicker.component';
+
+/**
+ * Date and time picker component that combines date and time values into a single Date.
+ */
+@Component({
+  selector: 'tm-datetimepicker',
+  templateUrl: './datetimepicker.component.html',
+  imports: [DatepickerComponent, TimepickerComponent],
+})
+export class DatetimepickerComponent {
+  private datetimeService = inject(DateTimeService);
+
+  @Input()
+  dateTime?: Date;
+
+  @Input()
+  isDisabled = false;
+
+  @Input()
+  minDateTime?: Date;
+
+  @Input()
+  maxDateTime?: Date;
+
+  @Output()
+  dateTimeChange: EventEmitter<Date> = new EventEmitter<Date>();
+
+  get date(): DateFormat {
+    if (!this.dateTime) {
+      return getDefaultDateFormat();
+    }
+    const [date] = this.datetimeService.convertDateToDateFormatAndTimeFormat(this.dateTime);
+    return date;
+  }
+
+  get time(): TimeFormat {
+    if (!this.dateTime) {
+      return getDefaultTimeFormat();
+    }
+    const [, time] = this.datetimeService.convertDateToDateFormatAndTimeFormat(this.dateTime);
+    return time;
+  }
+
+  get minDate(): DateFormat | undefined {
+    return this.getDateFormat(this.minDateTime);
+  }
+
+  get minTime(): TimeFormat | undefined {
+    return this.getTimeFormat(this.minDateTime);
+  }
+
+  get maxDate(): DateFormat | undefined {
+    return this.getDateFormat(this.maxDateTime);
+  }
+
+  get maxTime(): TimeFormat | undefined {
+    return this.getTimeFormat(this.maxDateTime);
+  }
+
+  onDateChange(newDate: DateFormat): void {
+    this.updateDateTime(newDate, this.time);
+  }
+
+  onTimeChange(newTime: TimeFormat): void {
+    this.updateDateTime(this.date, newTime);
+  }
+
+  private updateDateTime(date: DateFormat, time: TimeFormat): void {
+    this.dateTime = this.datetimeService.convertDateFormatAndTimeFormatToDate(date, time);
+    this.dateTimeChange.emit(this.dateTime);
+  }
+
+  private getDateFormat(dateTime?: Date): DateFormat | undefined {
+    if (!dateTime) {
+      return undefined;
+    }
+    const [date] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+    return date;
+  }
+
+  private getTimeFormat(dateTime?: Date): TimeFormat | undefined {
+    if (!dateTime) {
+      return undefined;
+    }
+    const [, time] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+    return time;
+  }
+}

--- a/src/web/app/components/datetimepicker/datetimepicker.component.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.ts
@@ -21,6 +21,10 @@ export class DatetimepickerComponent {
 
   @Input()
   set dateTime(dateTime: Date | undefined) {
+    if (this.hasSameTimestamp(this.internalDateTime, dateTime)) {
+      return;
+    }
+
     this.internalDateTime = dateTime;
     [this.date, this.time] = this.getDateTimeFormatsWithDefaults(dateTime);
   }
@@ -34,6 +38,10 @@ export class DatetimepickerComponent {
 
   @Input()
   set minDateTime(minDateTime: Date | undefined) {
+    if (this.hasSameTimestamp(this.internalMinDateTime, minDateTime)) {
+      return;
+    }
+
     this.internalMinDateTime = minDateTime;
     [this.minDate, this.minTime] = this.getOptionalDateTimeFormats(minDateTime);
   }
@@ -44,6 +52,10 @@ export class DatetimepickerComponent {
 
   @Input()
   set maxDateTime(maxDateTime: Date | undefined) {
+    if (this.hasSameTimestamp(this.internalMaxDateTime, maxDateTime)) {
+      return;
+    }
+
     this.internalMaxDateTime = maxDateTime;
     [this.maxDate, this.maxTime] = this.getOptionalDateTimeFormats(maxDateTime);
   }
@@ -72,7 +84,7 @@ export class DatetimepickerComponent {
 
   private updateDateTime(date: DateFormat, time: TimeFormat): void {
     const updatedDateTime = this.datetimeService.convertDateFormatAndTimeFormatToDate(date, time);
-    if (this.internalDateTime?.getTime() === updatedDateTime.getTime()) {
+    if (this.hasSameTimestamp(this.internalDateTime, updatedDateTime)) {
       return;
     }
 
@@ -94,5 +106,12 @@ export class DatetimepickerComponent {
       return [undefined, undefined];
     }
     return this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+  }
+
+  private hasSameTimestamp(previousDateTime?: Date, nextDateTime?: Date): boolean {
+    if (!previousDateTime || !nextDateTime) {
+      return previousDateTime === nextDateTime;
+    }
+    return previousDateTime.getTime() === nextDateTime.getTime();
   }
 }

--- a/src/web/app/components/datetimepicker/datetimepicker.component.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.ts
@@ -15,52 +15,52 @@ import { TimepickerComponent } from '../timepicker/timepicker.component';
 export class DatetimepickerComponent {
   private datetimeService = inject(DateTimeService);
 
+  private internalDateTime?: Date;
+  private internalMinDateTime?: Date;
+  private internalMaxDateTime?: Date;
+
   @Input()
-  dateTime?: Date;
+  set dateTime(dateTime: Date | undefined) {
+    this.internalDateTime = dateTime;
+    [this.date, this.time] = this.getDateTimeFormatsWithDefaults(dateTime);
+  }
+
+  get dateTime(): Date | undefined {
+    return this.internalDateTime;
+  }
 
   @Input()
   isDisabled = false;
 
   @Input()
-  minDateTime?: Date;
+  set minDateTime(minDateTime: Date | undefined) {
+    this.internalMinDateTime = minDateTime;
+    [this.minDate, this.minTime] = this.getOptionalDateTimeFormats(minDateTime);
+  }
+
+  get minDateTime(): Date | undefined {
+    return this.internalMinDateTime;
+  }
 
   @Input()
-  maxDateTime?: Date;
+  set maxDateTime(maxDateTime: Date | undefined) {
+    this.internalMaxDateTime = maxDateTime;
+    [this.maxDate, this.maxTime] = this.getOptionalDateTimeFormats(maxDateTime);
+  }
+
+  get maxDateTime(): Date | undefined {
+    return this.internalMaxDateTime;
+  }
 
   @Output()
   dateTimeChange: EventEmitter<Date> = new EventEmitter<Date>();
 
-  get date(): DateFormat {
-    if (!this.dateTime) {
-      return getDefaultDateFormat();
-    }
-    const [date] = this.datetimeService.convertDateToDateFormatAndTimeFormat(this.dateTime);
-    return date;
-  }
-
-  get time(): TimeFormat {
-    if (!this.dateTime) {
-      return getDefaultTimeFormat();
-    }
-    const [, time] = this.datetimeService.convertDateToDateFormatAndTimeFormat(this.dateTime);
-    return time;
-  }
-
-  get minDate(): DateFormat | undefined {
-    return this.getDateFormat(this.minDateTime);
-  }
-
-  get minTime(): TimeFormat | undefined {
-    return this.getTimeFormat(this.minDateTime);
-  }
-
-  get maxDate(): DateFormat | undefined {
-    return this.getDateFormat(this.maxDateTime);
-  }
-
-  get maxTime(): TimeFormat | undefined {
-    return this.getTimeFormat(this.maxDateTime);
-  }
+  date: DateFormat = getDefaultDateFormat();
+  time: TimeFormat = getDefaultTimeFormat();
+  minDate?: DateFormat;
+  minTime?: TimeFormat;
+  maxDate?: DateFormat;
+  maxTime?: TimeFormat;
 
   onDateChange(newDate: DateFormat): void {
     this.updateDateTime(newDate, this.time);
@@ -71,23 +71,28 @@ export class DatetimepickerComponent {
   }
 
   private updateDateTime(date: DateFormat, time: TimeFormat): void {
-    this.dateTime = this.datetimeService.convertDateFormatAndTimeFormatToDate(date, time);
-    this.dateTimeChange.emit(this.dateTime);
+    const updatedDateTime = this.datetimeService.convertDateFormatAndTimeFormatToDate(date, time);
+    if (this.internalDateTime?.getTime() === updatedDateTime.getTime()) {
+      return;
+    }
+
+    this.date = date;
+    this.time = time;
+    this.internalDateTime = updatedDateTime;
+    this.dateTimeChange.emit(updatedDateTime);
   }
 
-  private getDateFormat(dateTime?: Date): DateFormat | undefined {
+  private getDateTimeFormatsWithDefaults(dateTime?: Date): [DateFormat, TimeFormat] {
     if (!dateTime) {
-      return undefined;
+      return [getDefaultDateFormat(), getDefaultTimeFormat()];
     }
-    const [date] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
-    return date;
+    return this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
   }
 
-  private getTimeFormat(dateTime?: Date): TimeFormat | undefined {
+  private getOptionalDateTimeFormats(dateTime?: Date): [DateFormat | undefined, TimeFormat | undefined] {
     if (!dateTime) {
-      return undefined;
+      return [undefined, undefined];
     }
-    const [, time] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
-    return time;
+    return this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
   }
 }

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -275,28 +275,16 @@
                 </label>
               </div>
             </div>
-            <div class="row text-center align-items-center">
-              <div id="submission-start-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
+            <div id="submission-start-date" class="row text-center align-items-center">
+              <div id="submission-start-time" class="col-12">
+                <tm-datetimepicker
+                  class="d-flex align-items-center justify-content-center gap-2"
                   [isDisabled]="!model.isEditable"
-                  (dateChangeCallback)="triggerSubmissionOpeningDateModelChange('submissionStartDate', $event)"
-                  [minDate]="minDateForSubmissionStart"
-                  [maxDate]="maxDateForSubmissionStart"
-                  [date]="model.submissionStartDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="submission-start-time"
-                  [isDisabled]="!model.isEditable"
-                  (timeChange)="triggerSubmissionOpeningTimeModelChange('submissionStartTime', $event)"
-                  [minDate]="minDateForSubmissionStart"
-                  [maxDate]="maxDateForSubmissionStart"
-                  [date]="model.submissionStartDate"
-                  [minTime]="minTimeForSubmissionStart"
-                  [maxTime]="maxTimeForSubmissionStart"
-                  [time]="model.submissionStartTime"
-                ></tm-timepicker>
+                  [dateTime]="submissionStartDateTime"
+                  [minDateTime]="minDateTimeForSubmissionStart"
+                  [maxDateTime]="maxDateTimeForSubmissionStart"
+                  (dateTimeChange)="triggerSubmissionOpeningDateTimeModelChange($event)"
+                ></tm-datetimepicker>
               </div>
             </div>
           </div>
@@ -308,28 +296,16 @@
                 </label>
               </div>
             </div>
-            <div class="row align-items-center">
-              <div id="submission-end-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
+            <div id="submission-end-date" class="row align-items-center">
+              <div id="submission-end-time" class="col-12">
+                <tm-datetimepicker
+                  class="d-flex align-items-center justify-content-center gap-2"
                   [isDisabled]="!model.isEditable"
-                  (dateChangeCallback)="triggerModelChange('submissionEndDate', $event)"
-                  [minDate]="minDateForSubmissionEnd"
-                  [maxDate]="maxDateForSubmissionEnd"
-                  [date]="model.submissionEndDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="submission-end-time"
-                  [isDisabled]="!model.isEditable"
-                  (timeChange)="triggerModelChange('submissionEndTime', $event)"
-                  [minDate]="minDateForSubmissionEnd"
-                  [maxDate]="maxDateForSubmissionEnd"
-                  [date]="model.submissionEndDate"
-                  [minTime]="minTimeForSubmissionEnd"
-                  [maxTime]="maxTimeForSubmissionEnd"
-                  [time]="model.submissionEndTime"
-                ></tm-timepicker>
+                  [dateTime]="submissionEndDateTime"
+                  [minDateTime]="minDateTimeForSubmissionEnd"
+                  [maxDateTime]="maxDateTimeForSubmissionEnd"
+                  (dateTimeChange)="triggerDateTimeModelChange('submissionEndDate', 'submissionEndTime', $event)"
+                ></tm-datetimepicker>
               </div>
             </div>
           </div>
@@ -436,27 +412,19 @@
                   </label>
                 </div>
               </div>
-              <div id="session-visibility-date" class="col-md-6">
-                <tm-datepicker
-                  [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
-                  (dateChangeCallback)="triggerModelChange('customSessionVisibleDate', $event)"
-                  [minDate]="minDateForSessionVisible"
-                  [maxDate]="maxDateForSessionVisible"
-                  [date]="model.customSessionVisibleDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-4">
-                <tm-timepicker
-                  id="session-visibility-time"
-                  [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
-                  (timeChange)="triggerModelChange('customSessionVisibleTime', $event)"
-                  [minDate]="minDateForSessionVisible"
-                  [maxDate]="maxDateForSessionVisible"
-                  [date]="model.customSessionVisibleDate"
-                  [minTime]="minTimeForSessionVisible"
-                  [maxTime]="maxTimeForSessionVisible"
-                  [time]="model.customSessionVisibleTime"
-                ></tm-timepicker>
+              <div id="session-visibility-date" class="col-md-10">
+                <div id="session-visibility-time">
+                  <tm-datetimepicker
+                    class="d-flex align-items-center gap-2"
+                    [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
+                    [dateTime]="customSessionVisibleDateTime"
+                    [minDateTime]="minDateTimeForSessionVisible"
+                    [maxDateTime]="maxDateTimeForSessionVisible"
+                    (dateTimeChange)="
+                      triggerDateTimeModelChange('customSessionVisibleDate', 'customSessionVisibleTime', $event)
+                    "
+                  ></tm-datetimepicker>
+                </div>
               </div>
             </div>
             <div class="row mt-md-1 ms-md-3">
@@ -505,24 +473,18 @@
                   </label>
                 </div>
               </div>
-              <div id="response-visibility-date" class="col-md-6">
-                <tm-datepicker
-                  [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
-                  (dateChangeCallback)="triggerModelChange('customResponseVisibleDate', $event)"
-                  [minDate]="minDateForResponseVisible"
-                  [date]="model.customResponseVisibleDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-4">
-                <tm-timepicker
-                  id="response-visibility-time"
-                  [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
-                  (timeChange)="triggerModelChange('customResponseVisibleTime', $event)"
-                  [minDate]="minDateForResponseVisible"
-                  [date]="model.customResponseVisibleDate"
-                  [minTime]="minTimeForResponseVisible"
-                  [time]="model.customResponseVisibleTime"
-                ></tm-timepicker>
+              <div id="response-visibility-date" class="col-md-10">
+                <div id="response-visibility-time">
+                  <tm-datetimepicker
+                    class="d-flex align-items-center gap-2"
+                    [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
+                    [dateTime]="customResponseVisibleDateTime"
+                    [minDateTime]="minDateTimeForResponseVisible"
+                    (dateTimeChange)="
+                      triggerDateTimeModelChange('customResponseVisibleDate', 'customResponseVisibleTime', $event)
+                    "
+                  ></tm-datetimepicker>
+                </div>
               </div>
             </div>
             <div class="row mt-md-2 ms-md-1">

--- a/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.spec.ts
@@ -137,6 +137,37 @@ describe('SessionEditFormComponent', () => {
     });
   });
 
+  it('should emit modelChange event with updated date and time fields when triggerDateTimeModelChange is called', () => {
+    const modelChangeSpy = vi.spyOn(component.modelChange, 'emit');
+    const dateTime = new Date(2026, 6, 12, 9, 0);
+
+    component.triggerDateTimeModelChange('submissionEndDate', 'submissionEndTime', dateTime);
+
+    expect(modelChangeSpy).toHaveBeenCalledWith({
+      ...component.model,
+      submissionEndDate: { year: 2026, month: 7, day: 12 },
+      submissionEndTime: { hour: 9, minute: 0 },
+    });
+  });
+
+  it('should emit modelChange event and adjust visibility when submission opening datetime changes', () => {
+    const modelChangeSpy = vi.spyOn(component.modelChange, 'emit');
+    const dateTime = new Date(2026, 6, 12, 9, 0);
+
+    component.model.customSessionVisibleDate = { year: 2026, month: 7, day: 13 };
+    component.model.customSessionVisibleTime = { hour: 10, minute: 0 };
+
+    component.triggerSubmissionOpeningDateTimeModelChange(dateTime);
+
+    expect(modelChangeSpy).toHaveBeenCalledWith({
+      ...component.model,
+      submissionStartDate: { year: 2026, month: 7, day: 12 },
+      submissionStartTime: { hour: 9, minute: 0 },
+      customSessionVisibleDate: { year: 2026, month: 7, day: 12 },
+      customSessionVisibleTime: { hour: 9, minute: 0 },
+    });
+  });
+
   it('should emit modelChange event when a valid course ID is provided', () => {
     const newCourseId = 'testId1';
     const courseCandidates: Course[] = [

--- a/src/web/app/components/session-edit-form/session-edit-form.component.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.ts
@@ -26,13 +26,12 @@ import {
 import { FEEDBACK_SESSION_NAME_MAX_LENGTH } from '../../../types/field-validator';
 import { AjaxLoadingComponent } from '../ajax-loading/ajax-loading.component';
 import { DatePickerFormatter } from '../datepicker/datepicker-formatter';
-import { DatepickerComponent } from '../datepicker/datepicker.component';
+import { DatetimepickerComponent } from '../datetimepicker/datetimepicker.component';
 import { RichTextEditorComponent } from '../rich-text-editor/rich-text-editor.component';
 import { SimpleModalType } from '../simple-modal/simple-modal-type';
 import { PublishStatusNamePipe } from '../teammates-common/publish-status-name.pipe';
 import { SubmissionStatusNamePipe } from '../teammates-common/submission-status-name.pipe';
 import { TeammatesRouterDirective } from '../teammates-router/teammates-router.directive';
-import { TimepickerComponent } from '../timepicker/timepicker.component';
 
 /**
  * Form to Add/Edit feedback sessions.
@@ -49,8 +48,7 @@ import { TimepickerComponent } from '../timepicker/timepicker.component';
     NgbTooltip,
     NgClass,
     RichTextEditorComponent,
-    DatepickerComponent,
-    TimepickerComponent,
+    DatetimepickerComponent,
     SubmissionStatusNamePipe,
     PublishStatusNamePipe,
     NgbCollapse,
@@ -257,6 +255,56 @@ export class SessionEditFormComponent {
   }
 
   /**
+   * Triggers the change of the model when submission opening datetime changes.
+   */
+  triggerSubmissionOpeningDateTimeModelChange(dateTime: Date): void {
+    const [date, convertedTime] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+    let time: TimeFormat = convertedTime;
+    const minDate: DateFormat = this.minDateForSubmissionStart;
+    const minTime: TimeFormat = this.minTimeForSubmissionStart;
+
+    if (
+      DateTimeService.compareDateFormat(date, minDate) === 0 &&
+      DateTimeService.compareTimeFormat(time, minTime) === -1
+    ) {
+      this.configureSubmissionOpeningTime(minTime);
+      time = minTime;
+    }
+
+    const updatedModel: SessionEditFormModel = {
+      ...this.model,
+      submissionStartDate: date,
+      submissionStartTime: time,
+    };
+
+    const submissionDateTime = this.combineDateAndTime(date, time);
+    const visibilityDateTime = this.combineDateAndTime(
+      updatedModel.customSessionVisibleDate,
+      updatedModel.customSessionVisibleTime,
+    );
+
+    if (submissionDateTime.isBefore(visibilityDateTime)) {
+      updatedModel.customSessionVisibleDate = date;
+      updatedModel.customSessionVisibleTime = time;
+    }
+
+    this.modelChange.emit(updatedModel);
+  }
+
+  /**
+   * Triggers the change of date and time fields from a single Date.
+   */
+  triggerDateTimeModelChange(dateField: string, timeField: string, dateTime: Date): void {
+    const [date, time] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+
+    this.modelChange.emit({
+      ...this.model,
+      [dateField]: date,
+      [timeField]: time,
+    });
+  }
+
+  /**
    * Configures the session visible date and time to ensure it is not after submission opening time.
    */
   configureSessionVisibleDateTime(date: DateFormat, time: TimeFormat): void {
@@ -299,6 +347,27 @@ export class SessionEditFormComponent {
   get minDateForSubmissionStart(): DateFormat {
     const twoHoursBeforeNow = moment().tz(this.model.timeZone).subtract(2, 'hours');
     return this.datetimeService.getDateInstance(twoHoursBeforeNow);
+  }
+
+  get submissionStartDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.model.submissionStartDate,
+      this.model.submissionStartTime,
+    );
+  }
+
+  get minDateTimeForSubmissionStart(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.minDateForSubmissionStart,
+      this.minTimeForSubmissionStart,
+    );
+  }
+
+  get maxDateTimeForSubmissionStart(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.maxDateForSubmissionStart,
+      this.maxTimeForSubmissionStart,
+    );
   }
 
   /**
@@ -344,6 +413,27 @@ export class SessionEditFormComponent {
     return submissionStartDate.isAfter(oneHourBeforeNow)
       ? this.model.submissionStartDate
       : this.datetimeService.getDateInstance(oneHourBeforeNow);
+  }
+
+  get submissionEndDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.model.submissionEndDate,
+      this.model.submissionEndTime,
+    );
+  }
+
+  get minDateTimeForSubmissionEnd(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.minDateForSubmissionEnd,
+      this.minTimeForSubmissionEnd,
+    );
+  }
+
+  get maxDateTimeForSubmissionEnd(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.maxDateForSubmissionEnd,
+      this.maxTimeForSubmissionEnd,
+    );
   }
 
   /**
@@ -401,6 +491,27 @@ export class SessionEditFormComponent {
       .getMomentInstanceFromDate(this.model.submissionStartDate)
       .subtract(30, 'days');
     return this.datetimeService.getDateInstance(thirtyDaysBeforeSubmissionStartDate);
+  }
+
+  get customSessionVisibleDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.model.customSessionVisibleDate,
+      this.model.customSessionVisibleTime,
+    );
+  }
+
+  get minDateTimeForSessionVisible(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.minDateForSessionVisible,
+      this.minTimeForSessionVisible,
+    );
+  }
+
+  get maxDateTimeForSessionVisible(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.maxDateForSessionVisible,
+      this.maxTimeForSessionVisible,
+    );
   }
 
   /**
@@ -490,6 +601,20 @@ export class SessionEditFormComponent {
       default:
         return getDefaultDateFormat();
     }
+  }
+
+  get customResponseVisibleDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.model.customResponseVisibleDate,
+      this.model.customResponseVisibleTime,
+    );
+  }
+
+  get minDateTimeForResponseVisible(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.minDateForResponseVisible,
+      this.minTimeForResponseVisible,
+    );
   }
 
   /**

--- a/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
@@ -283,166 +283,165 @@ exports[`AdminNotificationsPageComponent > should snap when notification edit fo
                   </div>
                   <div
                     class="row text-center align-items-center"
+                    id="notification-start-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-start-date"
+                      class="col-12"
+                      id="notification-start-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-start-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -465,166 +464,165 @@ exports[`AdminNotificationsPageComponent > should snap when notification edit fo
                   </div>
                   <div
                     class="row align-items-center"
+                    id="notification-end-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-end-date"
+                      class="col-12"
+                      id="notification-end-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-end-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -957,166 +955,165 @@ exports[`AdminNotificationsPageComponent > should snap when notifications are lo
                   </div>
                   <div
                     class="row text-center align-items-center"
+                    id="notification-start-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-start-date"
+                      class="col-12"
+                      id="notification-start-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-start-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -1139,166 +1136,165 @@ exports[`AdminNotificationsPageComponent > should snap when notifications are lo
                   </div>
                   <div
                     class="row align-items-center"
+                    id="notification-end-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-end-date"
+                      class="col-12"
+                      id="notification-end-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-end-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -1638,166 +1634,165 @@ exports[`AdminNotificationsPageComponent > should snap when notifications failed
                   </div>
                   <div
                     class="row text-center align-items-center"
+                    id="notification-start-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-start-date"
+                      class="col-12"
+                      id="notification-start-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-start-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -1820,166 +1815,165 @@ exports[`AdminNotificationsPageComponent > should snap when notifications failed
                   </div>
                   <div
                     class="row align-items-center"
+                    id="notification-end-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-end-date"
+                      class="col-12"
+                      id="notification-end-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-end-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -2317,166 +2311,165 @@ exports[`AdminNotificationsPageComponent > should snap with default view 1`] = `
                   </div>
                   <div
                     class="row text-center align-items-center"
+                    id="notification-start-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-start-date"
+                      class="col-12"
+                      id="notification-start-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-start-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -2499,166 +2492,165 @@ exports[`AdminNotificationsPageComponent > should snap with default view 1`] = `
                   </div>
                   <div
                     class="row align-items-center"
+                    id="notification-end-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="notification-end-date"
+                      class="col-12"
+                      id="notification-end-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="notification-end-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/__snapshots__/notification-edit-form.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/__snapshots__/notification-edit-form.component.spec.ts.snap
@@ -271,171 +271,170 @@ exports[`NotificationEditFormComponent > should snap with default view 1`] = `
               </div>
               <div
                 class="row text-center align-items-center"
+                id="notification-start-date"
               >
                 <div
-                  class="col-md-7 col-xs-center"
-                  id="notification-start-date"
+                  class="col-12"
+                  id="notification-start-time"
                 >
-                  <tm-datepicker>
-                    <div
-                      class="input-group"
-                    >
-                      <input
-                        aria-label="Date"
-                        class="form-control ng-untouched ng-pristine ng-valid"
-                        ngbdatepicker=""
-                        readonly=""
-                        type="text"
-                      />
-                      <button
-                        aria-label="Change date"
-                        class="btn btn-light input-group-text"
-                        type="button"
-                      >
-                        <i
-                          class="fas fa-calendar-alt"
-                        />
-                      </button>
-                    </div>
-                  </tm-datepicker>
-                </div>
-                <div
-                  class="col-md-5"
-                >
-                  <tm-timepicker
-                    id="notification-start-time"
+                  <tm-datetimepicker
+                    class="d-flex align-items-center justify-content-center gap-2"
                   >
-                    <select
-                      aria-label="Select time"
-                      class="form-control form-select ng-untouched ng-pristine ng-valid"
-                    >
-                      <option
-                        value="1: Object"
+                    <tm-datepicker>
+                      <div
+                        class="input-group"
                       >
-                         01:00H 
-                      </option>
-                      <option
-                        value="2: Object"
+                        <input
+                          aria-label="Date"
+                          class="form-control ng-untouched ng-pristine ng-valid"
+                          ngbdatepicker=""
+                          readonly=""
+                          type="text"
+                        />
+                        <button
+                          aria-label="Change date"
+                          class="btn btn-light input-group-text"
+                          type="button"
+                        >
+                          <i
+                            class="fas fa-calendar-alt"
+                          />
+                        </button>
+                      </div>
+                    </tm-datepicker>
+                    <tm-timepicker>
+                      <select
+                        aria-label="Select time"
+                        class="form-control form-select ng-untouched ng-pristine ng-valid"
                       >
-                         02:00H 
-                      </option>
-                      <option
-                        value="3: Object"
-                      >
-                         03:00H 
-                      </option>
-                      <option
-                        value="4: Object"
-                      >
-                         04:00H 
-                      </option>
-                      <option
-                        value="5: Object"
-                      >
-                         05:00H 
-                      </option>
-                      <option
-                        value="6: Object"
-                      >
-                         06:00H 
-                      </option>
-                      <option
-                        value="7: Object"
-                      >
-                         07:00H 
-                      </option>
-                      <option
-                        value="8: Object"
-                      >
-                         08:00H 
-                      </option>
-                      <option
-                        value="9: Object"
-                      >
-                         09:00H 
-                      </option>
-                      <option
-                        value="10: Object"
-                      >
-                         10:00H 
-                      </option>
-                      <option
-                        value="11: Object"
-                      >
-                         11:00H 
-                      </option>
-                      <option
-                        value="12: Object"
-                      >
-                         12:00H 
-                      </option>
-                      <option
-                        value="13: Object"
-                      >
-                         13:00H 
-                      </option>
-                      <option
-                        value="14: Object"
-                      >
-                         14:00H 
-                      </option>
-                      <option
-                        value="15: Object"
-                      >
-                         15:00H 
-                      </option>
-                      <option
-                        value="16: Object"
-                      >
-                         16:00H 
-                      </option>
-                      <option
-                        value="17: Object"
-                      >
-                         17:00H 
-                      </option>
-                      <option
-                        value="18: Object"
-                      >
-                         18:00H 
-                      </option>
-                      <option
-                        value="19: Object"
-                      >
-                         19:00H 
-                      </option>
-                      <option
-                        value="20: Object"
-                      >
-                         20:00H 
-                      </option>
-                      <option
-                        value="21: Object"
-                      >
-                         21:00H 
-                      </option>
-                      <option
-                        value="22: Object"
-                      >
-                         22:00H 
-                      </option>
-                      <option
-                        value="23: Object"
-                      >
-                         23:00H 
-                      </option>
-                      <option
-                        value="0: Object"
-                      >
-                        23:59H
-                      </option>
-                      <option
-                        value="24: Object"
-                      >
-                        00:00H
-                      </option>
-                    </select>
-                  </tm-timepicker>
+                        <option
+                          value="1: Object"
+                        >
+                           01:00H 
+                        </option>
+                        <option
+                          value="2: Object"
+                        >
+                           02:00H 
+                        </option>
+                        <option
+                          value="3: Object"
+                        >
+                           03:00H 
+                        </option>
+                        <option
+                          value="4: Object"
+                        >
+                           04:00H 
+                        </option>
+                        <option
+                          value="5: Object"
+                        >
+                           05:00H 
+                        </option>
+                        <option
+                          value="6: Object"
+                        >
+                           06:00H 
+                        </option>
+                        <option
+                          value="7: Object"
+                        >
+                           07:00H 
+                        </option>
+                        <option
+                          value="8: Object"
+                        >
+                           08:00H 
+                        </option>
+                        <option
+                          value="9: Object"
+                        >
+                           09:00H 
+                        </option>
+                        <option
+                          value="10: Object"
+                        >
+                           10:00H 
+                        </option>
+                        <option
+                          value="11: Object"
+                        >
+                           11:00H 
+                        </option>
+                        <option
+                          value="12: Object"
+                        >
+                           12:00H 
+                        </option>
+                        <option
+                          value="13: Object"
+                        >
+                           13:00H 
+                        </option>
+                        <option
+                          value="14: Object"
+                        >
+                           14:00H 
+                        </option>
+                        <option
+                          value="15: Object"
+                        >
+                           15:00H 
+                        </option>
+                        <option
+                          value="16: Object"
+                        >
+                           16:00H 
+                        </option>
+                        <option
+                          value="17: Object"
+                        >
+                           17:00H 
+                        </option>
+                        <option
+                          value="18: Object"
+                        >
+                           18:00H 
+                        </option>
+                        <option
+                          value="19: Object"
+                        >
+                           19:00H 
+                        </option>
+                        <option
+                          value="20: Object"
+                        >
+                           20:00H 
+                        </option>
+                        <option
+                          value="21: Object"
+                        >
+                           21:00H 
+                        </option>
+                        <option
+                          value="22: Object"
+                        >
+                           22:00H 
+                        </option>
+                        <option
+                          value="23: Object"
+                        >
+                           23:00H 
+                        </option>
+                        <option
+                          value="0: Object"
+                        >
+                          23:59H
+                        </option>
+                        <option
+                          value="24: Object"
+                        >
+                          00:00H
+                        </option>
+                      </select>
+                    </tm-timepicker>
+                  </tm-datetimepicker>
                 </div>
               </div>
             </div>
@@ -458,171 +457,170 @@ exports[`NotificationEditFormComponent > should snap with default view 1`] = `
               </div>
               <div
                 class="row align-items-center"
+                id="notification-end-date"
               >
                 <div
-                  class="col-md-7 col-xs-center"
-                  id="notification-end-date"
+                  class="col-12"
+                  id="notification-end-time"
                 >
-                  <tm-datepicker>
-                    <div
-                      class="input-group"
-                    >
-                      <input
-                        aria-label="Date"
-                        class="form-control ng-untouched ng-pristine ng-valid"
-                        ngbdatepicker=""
-                        readonly=""
-                        type="text"
-                      />
-                      <button
-                        aria-label="Change date"
-                        class="btn btn-light input-group-text"
-                        type="button"
-                      >
-                        <i
-                          class="fas fa-calendar-alt"
-                        />
-                      </button>
-                    </div>
-                  </tm-datepicker>
-                </div>
-                <div
-                  class="col-md-5"
-                >
-                  <tm-timepicker
-                    id="notification-end-time"
+                  <tm-datetimepicker
+                    class="d-flex align-items-center justify-content-center gap-2"
                   >
-                    <select
-                      aria-label="Select time"
-                      class="form-control form-select ng-untouched ng-pristine ng-valid"
-                    >
-                      <option
-                        value="1: Object"
+                    <tm-datepicker>
+                      <div
+                        class="input-group"
                       >
-                         01:00H 
-                      </option>
-                      <option
-                        value="2: Object"
+                        <input
+                          aria-label="Date"
+                          class="form-control ng-untouched ng-pristine ng-valid"
+                          ngbdatepicker=""
+                          readonly=""
+                          type="text"
+                        />
+                        <button
+                          aria-label="Change date"
+                          class="btn btn-light input-group-text"
+                          type="button"
+                        >
+                          <i
+                            class="fas fa-calendar-alt"
+                          />
+                        </button>
+                      </div>
+                    </tm-datepicker>
+                    <tm-timepicker>
+                      <select
+                        aria-label="Select time"
+                        class="form-control form-select ng-untouched ng-pristine ng-valid"
                       >
-                         02:00H 
-                      </option>
-                      <option
-                        value="3: Object"
-                      >
-                         03:00H 
-                      </option>
-                      <option
-                        value="4: Object"
-                      >
-                         04:00H 
-                      </option>
-                      <option
-                        value="5: Object"
-                      >
-                         05:00H 
-                      </option>
-                      <option
-                        value="6: Object"
-                      >
-                         06:00H 
-                      </option>
-                      <option
-                        value="7: Object"
-                      >
-                         07:00H 
-                      </option>
-                      <option
-                        value="8: Object"
-                      >
-                         08:00H 
-                      </option>
-                      <option
-                        value="9: Object"
-                      >
-                         09:00H 
-                      </option>
-                      <option
-                        value="10: Object"
-                      >
-                         10:00H 
-                      </option>
-                      <option
-                        value="11: Object"
-                      >
-                         11:00H 
-                      </option>
-                      <option
-                        value="12: Object"
-                      >
-                         12:00H 
-                      </option>
-                      <option
-                        value="13: Object"
-                      >
-                         13:00H 
-                      </option>
-                      <option
-                        value="14: Object"
-                      >
-                         14:00H 
-                      </option>
-                      <option
-                        value="15: Object"
-                      >
-                         15:00H 
-                      </option>
-                      <option
-                        value="16: Object"
-                      >
-                         16:00H 
-                      </option>
-                      <option
-                        value="17: Object"
-                      >
-                         17:00H 
-                      </option>
-                      <option
-                        value="18: Object"
-                      >
-                         18:00H 
-                      </option>
-                      <option
-                        value="19: Object"
-                      >
-                         19:00H 
-                      </option>
-                      <option
-                        value="20: Object"
-                      >
-                         20:00H 
-                      </option>
-                      <option
-                        value="21: Object"
-                      >
-                         21:00H 
-                      </option>
-                      <option
-                        value="22: Object"
-                      >
-                         22:00H 
-                      </option>
-                      <option
-                        value="23: Object"
-                      >
-                         23:00H 
-                      </option>
-                      <option
-                        value="0: Object"
-                      >
-                        23:59H
-                      </option>
-                      <option
-                        value="24: Object"
-                      >
-                        00:00H
-                      </option>
-                    </select>
-                  </tm-timepicker>
+                        <option
+                          value="1: Object"
+                        >
+                           01:00H 
+                        </option>
+                        <option
+                          value="2: Object"
+                        >
+                           02:00H 
+                        </option>
+                        <option
+                          value="3: Object"
+                        >
+                           03:00H 
+                        </option>
+                        <option
+                          value="4: Object"
+                        >
+                           04:00H 
+                        </option>
+                        <option
+                          value="5: Object"
+                        >
+                           05:00H 
+                        </option>
+                        <option
+                          value="6: Object"
+                        >
+                           06:00H 
+                        </option>
+                        <option
+                          value="7: Object"
+                        >
+                           07:00H 
+                        </option>
+                        <option
+                          value="8: Object"
+                        >
+                           08:00H 
+                        </option>
+                        <option
+                          value="9: Object"
+                        >
+                           09:00H 
+                        </option>
+                        <option
+                          value="10: Object"
+                        >
+                           10:00H 
+                        </option>
+                        <option
+                          value="11: Object"
+                        >
+                           11:00H 
+                        </option>
+                        <option
+                          value="12: Object"
+                        >
+                           12:00H 
+                        </option>
+                        <option
+                          value="13: Object"
+                        >
+                           13:00H 
+                        </option>
+                        <option
+                          value="14: Object"
+                        >
+                           14:00H 
+                        </option>
+                        <option
+                          value="15: Object"
+                        >
+                           15:00H 
+                        </option>
+                        <option
+                          value="16: Object"
+                        >
+                           16:00H 
+                        </option>
+                        <option
+                          value="17: Object"
+                        >
+                           17:00H 
+                        </option>
+                        <option
+                          value="18: Object"
+                        >
+                           18:00H 
+                        </option>
+                        <option
+                          value="19: Object"
+                        >
+                           19:00H 
+                        </option>
+                        <option
+                          value="20: Object"
+                        >
+                           20:00H 
+                        </option>
+                        <option
+                          value="21: Object"
+                        >
+                           21:00H 
+                        </option>
+                        <option
+                          value="22: Object"
+                        >
+                           22:00H 
+                        </option>
+                        <option
+                          value="23: Object"
+                        >
+                           23:00H 
+                        </option>
+                        <option
+                          value="0: Object"
+                        >
+                          23:59H
+                        </option>
+                        <option
+                          value="24: Object"
+                        >
+                          00:00H
+                        </option>
+                      </select>
+                    </tm-timepicker>
+                  </tm-datetimepicker>
                 </div>
               </div>
             </div>
@@ -925,171 +923,170 @@ exports[`NotificationEditFormComponent > should snap with notification 1`] = `
               </div>
               <div
                 class="row text-center align-items-center"
+                id="notification-start-date"
               >
                 <div
-                  class="col-md-7 col-xs-center"
-                  id="notification-start-date"
+                  class="col-12"
+                  id="notification-start-time"
                 >
-                  <tm-datepicker>
-                    <div
-                      class="input-group"
-                    >
-                      <input
-                        aria-label="Date"
-                        class="form-control ng-untouched ng-pristine ng-invalid"
-                        ngbdatepicker=""
-                        readonly=""
-                        type="text"
-                      />
-                      <button
-                        aria-label="Change date"
-                        class="btn btn-light input-group-text"
-                        type="button"
-                      >
-                        <i
-                          class="fas fa-calendar-alt"
-                        />
-                      </button>
-                    </div>
-                  </tm-datepicker>
-                </div>
-                <div
-                  class="col-md-5"
-                >
-                  <tm-timepicker
-                    id="notification-start-time"
+                  <tm-datetimepicker
+                    class="d-flex align-items-center justify-content-center gap-2"
                   >
-                    <select
-                      aria-label="Select time"
-                      class="form-control form-select ng-untouched ng-pristine ng-valid"
-                    >
-                      <option
-                        value="1: Object"
+                    <tm-datepicker>
+                      <div
+                        class="input-group"
                       >
-                         01:00H 
-                      </option>
-                      <option
-                        value="2: Object"
+                        <input
+                          aria-label="Date"
+                          class="form-control ng-untouched ng-pristine ng-valid"
+                          ngbdatepicker=""
+                          readonly=""
+                          type="text"
+                        />
+                        <button
+                          aria-label="Change date"
+                          class="btn btn-light input-group-text"
+                          type="button"
+                        >
+                          <i
+                            class="fas fa-calendar-alt"
+                          />
+                        </button>
+                      </div>
+                    </tm-datepicker>
+                    <tm-timepicker>
+                      <select
+                        aria-label="Select time"
+                        class="form-control form-select ng-untouched ng-pristine ng-valid"
                       >
-                         02:00H 
-                      </option>
-                      <option
-                        value="3: Object"
-                      >
-                         03:00H 
-                      </option>
-                      <option
-                        value="4: Object"
-                      >
-                         04:00H 
-                      </option>
-                      <option
-                        value="5: Object"
-                      >
-                         05:00H 
-                      </option>
-                      <option
-                        value="6: Object"
-                      >
-                         06:00H 
-                      </option>
-                      <option
-                        value="7: Object"
-                      >
-                         07:00H 
-                      </option>
-                      <option
-                        value="8: Object"
-                      >
-                         08:00H 
-                      </option>
-                      <option
-                        value="9: Object"
-                      >
-                         09:00H 
-                      </option>
-                      <option
-                        value="10: Object"
-                      >
-                         10:00H 
-                      </option>
-                      <option
-                        value="11: Object"
-                      >
-                         11:00H 
-                      </option>
-                      <option
-                        value="12: Object"
-                      >
-                         12:00H 
-                      </option>
-                      <option
-                        value="13: Object"
-                      >
-                         13:00H 
-                      </option>
-                      <option
-                        value="14: Object"
-                      >
-                         14:00H 
-                      </option>
-                      <option
-                        value="15: Object"
-                      >
-                         15:00H 
-                      </option>
-                      <option
-                        value="16: Object"
-                      >
-                         16:00H 
-                      </option>
-                      <option
-                        value="17: Object"
-                      >
-                         17:00H 
-                      </option>
-                      <option
-                        value="18: Object"
-                      >
-                         18:00H 
-                      </option>
-                      <option
-                        value="19: Object"
-                      >
-                         19:00H 
-                      </option>
-                      <option
-                        value="20: Object"
-                      >
-                         20:00H 
-                      </option>
-                      <option
-                        value="21: Object"
-                      >
-                         21:00H 
-                      </option>
-                      <option
-                        value="22: Object"
-                      >
-                         22:00H 
-                      </option>
-                      <option
-                        value="23: Object"
-                      >
-                         23:00H 
-                      </option>
-                      <option
-                        value="0: Object"
-                      >
-                        23:59H
-                      </option>
-                      <option
-                        value="24: Object"
-                      >
-                        00:00H
-                      </option>
-                    </select>
-                  </tm-timepicker>
+                        <option
+                          value="1: Object"
+                        >
+                           01:00H 
+                        </option>
+                        <option
+                          value="2: Object"
+                        >
+                           02:00H 
+                        </option>
+                        <option
+                          value="3: Object"
+                        >
+                           03:00H 
+                        </option>
+                        <option
+                          value="4: Object"
+                        >
+                           04:00H 
+                        </option>
+                        <option
+                          value="5: Object"
+                        >
+                           05:00H 
+                        </option>
+                        <option
+                          value="6: Object"
+                        >
+                           06:00H 
+                        </option>
+                        <option
+                          value="7: Object"
+                        >
+                           07:00H 
+                        </option>
+                        <option
+                          value="8: Object"
+                        >
+                           08:00H 
+                        </option>
+                        <option
+                          value="9: Object"
+                        >
+                           09:00H 
+                        </option>
+                        <option
+                          value="10: Object"
+                        >
+                           10:00H 
+                        </option>
+                        <option
+                          value="11: Object"
+                        >
+                           11:00H 
+                        </option>
+                        <option
+                          value="12: Object"
+                        >
+                           12:00H 
+                        </option>
+                        <option
+                          value="13: Object"
+                        >
+                           13:00H 
+                        </option>
+                        <option
+                          value="14: Object"
+                        >
+                           14:00H 
+                        </option>
+                        <option
+                          value="15: Object"
+                        >
+                           15:00H 
+                        </option>
+                        <option
+                          value="16: Object"
+                        >
+                           16:00H 
+                        </option>
+                        <option
+                          value="17: Object"
+                        >
+                           17:00H 
+                        </option>
+                        <option
+                          value="18: Object"
+                        >
+                           18:00H 
+                        </option>
+                        <option
+                          value="19: Object"
+                        >
+                           19:00H 
+                        </option>
+                        <option
+                          value="20: Object"
+                        >
+                           20:00H 
+                        </option>
+                        <option
+                          value="21: Object"
+                        >
+                           21:00H 
+                        </option>
+                        <option
+                          value="22: Object"
+                        >
+                           22:00H 
+                        </option>
+                        <option
+                          value="23: Object"
+                        >
+                           23:00H 
+                        </option>
+                        <option
+                          value="0: Object"
+                        >
+                          23:59H
+                        </option>
+                        <option
+                          value="24: Object"
+                        >
+                          00:00H
+                        </option>
+                      </select>
+                    </tm-timepicker>
+                  </tm-datetimepicker>
                 </div>
               </div>
             </div>
@@ -1112,171 +1109,170 @@ exports[`NotificationEditFormComponent > should snap with notification 1`] = `
               </div>
               <div
                 class="row align-items-center"
+                id="notification-end-date"
               >
                 <div
-                  class="col-md-7 col-xs-center"
-                  id="notification-end-date"
+                  class="col-12"
+                  id="notification-end-time"
                 >
-                  <tm-datepicker>
-                    <div
-                      class="input-group"
-                    >
-                      <input
-                        aria-label="Date"
-                        class="form-control ng-untouched ng-pristine ng-invalid"
-                        ngbdatepicker=""
-                        readonly=""
-                        type="text"
-                      />
-                      <button
-                        aria-label="Change date"
-                        class="btn btn-light input-group-text"
-                        type="button"
-                      >
-                        <i
-                          class="fas fa-calendar-alt"
-                        />
-                      </button>
-                    </div>
-                  </tm-datepicker>
-                </div>
-                <div
-                  class="col-md-5"
-                >
-                  <tm-timepicker
-                    id="notification-end-time"
+                  <tm-datetimepicker
+                    class="d-flex align-items-center justify-content-center gap-2"
                   >
-                    <select
-                      aria-label="Select time"
-                      class="form-control form-select ng-untouched ng-pristine ng-valid"
-                    >
-                      <option
-                        value="1: Object"
+                    <tm-datepicker>
+                      <div
+                        class="input-group"
                       >
-                         01:00H 
-                      </option>
-                      <option
-                        value="2: Object"
+                        <input
+                          aria-label="Date"
+                          class="form-control ng-untouched ng-pristine ng-valid"
+                          ngbdatepicker=""
+                          readonly=""
+                          type="text"
+                        />
+                        <button
+                          aria-label="Change date"
+                          class="btn btn-light input-group-text"
+                          type="button"
+                        >
+                          <i
+                            class="fas fa-calendar-alt"
+                          />
+                        </button>
+                      </div>
+                    </tm-datepicker>
+                    <tm-timepicker>
+                      <select
+                        aria-label="Select time"
+                        class="form-control form-select ng-untouched ng-pristine ng-valid"
                       >
-                         02:00H 
-                      </option>
-                      <option
-                        value="3: Object"
-                      >
-                         03:00H 
-                      </option>
-                      <option
-                        value="4: Object"
-                      >
-                         04:00H 
-                      </option>
-                      <option
-                        value="5: Object"
-                      >
-                         05:00H 
-                      </option>
-                      <option
-                        value="6: Object"
-                      >
-                         06:00H 
-                      </option>
-                      <option
-                        value="7: Object"
-                      >
-                         07:00H 
-                      </option>
-                      <option
-                        value="8: Object"
-                      >
-                         08:00H 
-                      </option>
-                      <option
-                        value="9: Object"
-                      >
-                         09:00H 
-                      </option>
-                      <option
-                        value="10: Object"
-                      >
-                         10:00H 
-                      </option>
-                      <option
-                        value="11: Object"
-                      >
-                         11:00H 
-                      </option>
-                      <option
-                        value="12: Object"
-                      >
-                         12:00H 
-                      </option>
-                      <option
-                        value="13: Object"
-                      >
-                         13:00H 
-                      </option>
-                      <option
-                        value="14: Object"
-                      >
-                         14:00H 
-                      </option>
-                      <option
-                        value="15: Object"
-                      >
-                         15:00H 
-                      </option>
-                      <option
-                        value="16: Object"
-                      >
-                         16:00H 
-                      </option>
-                      <option
-                        value="17: Object"
-                      >
-                         17:00H 
-                      </option>
-                      <option
-                        value="18: Object"
-                      >
-                         18:00H 
-                      </option>
-                      <option
-                        value="19: Object"
-                      >
-                         19:00H 
-                      </option>
-                      <option
-                        value="20: Object"
-                      >
-                         20:00H 
-                      </option>
-                      <option
-                        value="21: Object"
-                      >
-                         21:00H 
-                      </option>
-                      <option
-                        value="22: Object"
-                      >
-                         22:00H 
-                      </option>
-                      <option
-                        value="23: Object"
-                      >
-                         23:00H 
-                      </option>
-                      <option
-                        value="0: Object"
-                      >
-                        23:59H
-                      </option>
-                      <option
-                        value="24: Object"
-                      >
-                        00:00H
-                      </option>
-                    </select>
-                  </tm-timepicker>
+                        <option
+                          value="1: Object"
+                        >
+                           01:00H 
+                        </option>
+                        <option
+                          value="2: Object"
+                        >
+                           02:00H 
+                        </option>
+                        <option
+                          value="3: Object"
+                        >
+                           03:00H 
+                        </option>
+                        <option
+                          value="4: Object"
+                        >
+                           04:00H 
+                        </option>
+                        <option
+                          value="5: Object"
+                        >
+                           05:00H 
+                        </option>
+                        <option
+                          value="6: Object"
+                        >
+                           06:00H 
+                        </option>
+                        <option
+                          value="7: Object"
+                        >
+                           07:00H 
+                        </option>
+                        <option
+                          value="8: Object"
+                        >
+                           08:00H 
+                        </option>
+                        <option
+                          value="9: Object"
+                        >
+                           09:00H 
+                        </option>
+                        <option
+                          value="10: Object"
+                        >
+                           10:00H 
+                        </option>
+                        <option
+                          value="11: Object"
+                        >
+                           11:00H 
+                        </option>
+                        <option
+                          value="12: Object"
+                        >
+                           12:00H 
+                        </option>
+                        <option
+                          value="13: Object"
+                        >
+                           13:00H 
+                        </option>
+                        <option
+                          value="14: Object"
+                        >
+                           14:00H 
+                        </option>
+                        <option
+                          value="15: Object"
+                        >
+                           15:00H 
+                        </option>
+                        <option
+                          value="16: Object"
+                        >
+                           16:00H 
+                        </option>
+                        <option
+                          value="17: Object"
+                        >
+                           17:00H 
+                        </option>
+                        <option
+                          value="18: Object"
+                        >
+                           18:00H 
+                        </option>
+                        <option
+                          value="19: Object"
+                        >
+                           19:00H 
+                        </option>
+                        <option
+                          value="20: Object"
+                        >
+                           20:00H 
+                        </option>
+                        <option
+                          value="21: Object"
+                        >
+                           21:00H 
+                        </option>
+                        <option
+                          value="22: Object"
+                        >
+                           22:00H 
+                        </option>
+                        <option
+                          value="23: Object"
+                        >
+                           23:00H 
+                        </option>
+                        <option
+                          value="0: Object"
+                        >
+                          23:59H
+                        </option>
+                        <option
+                          value="24: Object"
+                        >
+                          00:00H
+                        </option>
+                      </select>
+                    </tm-timepicker>
+                  </tm-datetimepicker>
                 </div>
               </div>
             </div>
@@ -1579,171 +1575,170 @@ exports[`NotificationEditFormComponent > should snap with notification that has 
               </div>
               <div
                 class="row text-center align-items-center"
+                id="notification-start-date"
               >
                 <div
-                  class="col-md-7 col-xs-center"
-                  id="notification-start-date"
+                  class="col-12"
+                  id="notification-start-time"
                 >
-                  <tm-datepicker>
-                    <div
-                      class="input-group"
-                    >
-                      <input
-                        aria-label="Date"
-                        class="form-control ng-untouched ng-pristine ng-invalid"
-                        ngbdatepicker=""
-                        readonly=""
-                        type="text"
-                      />
-                      <button
-                        aria-label="Change date"
-                        class="btn btn-light input-group-text"
-                        type="button"
-                      >
-                        <i
-                          class="fas fa-calendar-alt"
-                        />
-                      </button>
-                    </div>
-                  </tm-datepicker>
-                </div>
-                <div
-                  class="col-md-5"
-                >
-                  <tm-timepicker
-                    id="notification-start-time"
+                  <tm-datetimepicker
+                    class="d-flex align-items-center justify-content-center gap-2"
                   >
-                    <select
-                      aria-label="Select time"
-                      class="form-control form-select ng-untouched ng-pristine ng-valid"
-                    >
-                      <option
-                        value="1: Object"
+                    <tm-datepicker>
+                      <div
+                        class="input-group"
                       >
-                         01:00H 
-                      </option>
-                      <option
-                        value="2: Object"
+                        <input
+                          aria-label="Date"
+                          class="form-control ng-untouched ng-pristine ng-valid"
+                          ngbdatepicker=""
+                          readonly=""
+                          type="text"
+                        />
+                        <button
+                          aria-label="Change date"
+                          class="btn btn-light input-group-text"
+                          type="button"
+                        >
+                          <i
+                            class="fas fa-calendar-alt"
+                          />
+                        </button>
+                      </div>
+                    </tm-datepicker>
+                    <tm-timepicker>
+                      <select
+                        aria-label="Select time"
+                        class="form-control form-select ng-untouched ng-pristine ng-valid"
                       >
-                         02:00H 
-                      </option>
-                      <option
-                        value="3: Object"
-                      >
-                         03:00H 
-                      </option>
-                      <option
-                        value="4: Object"
-                      >
-                         04:00H 
-                      </option>
-                      <option
-                        value="5: Object"
-                      >
-                         05:00H 
-                      </option>
-                      <option
-                        value="6: Object"
-                      >
-                         06:00H 
-                      </option>
-                      <option
-                        value="7: Object"
-                      >
-                         07:00H 
-                      </option>
-                      <option
-                        value="8: Object"
-                      >
-                         08:00H 
-                      </option>
-                      <option
-                        value="9: Object"
-                      >
-                         09:00H 
-                      </option>
-                      <option
-                        value="10: Object"
-                      >
-                         10:00H 
-                      </option>
-                      <option
-                        value="11: Object"
-                      >
-                         11:00H 
-                      </option>
-                      <option
-                        value="12: Object"
-                      >
-                         12:00H 
-                      </option>
-                      <option
-                        value="13: Object"
-                      >
-                         13:00H 
-                      </option>
-                      <option
-                        value="14: Object"
-                      >
-                         14:00H 
-                      </option>
-                      <option
-                        value="15: Object"
-                      >
-                         15:00H 
-                      </option>
-                      <option
-                        value="16: Object"
-                      >
-                         16:00H 
-                      </option>
-                      <option
-                        value="17: Object"
-                      >
-                         17:00H 
-                      </option>
-                      <option
-                        value="18: Object"
-                      >
-                         18:00H 
-                      </option>
-                      <option
-                        value="19: Object"
-                      >
-                         19:00H 
-                      </option>
-                      <option
-                        value="20: Object"
-                      >
-                         20:00H 
-                      </option>
-                      <option
-                        value="21: Object"
-                      >
-                         21:00H 
-                      </option>
-                      <option
-                        value="22: Object"
-                      >
-                         22:00H 
-                      </option>
-                      <option
-                        value="23: Object"
-                      >
-                         23:00H 
-                      </option>
-                      <option
-                        value="0: Object"
-                      >
-                        23:59H
-                      </option>
-                      <option
-                        value="24: Object"
-                      >
-                        00:00H
-                      </option>
-                    </select>
-                  </tm-timepicker>
+                        <option
+                          value="1: Object"
+                        >
+                           01:00H 
+                        </option>
+                        <option
+                          value="2: Object"
+                        >
+                           02:00H 
+                        </option>
+                        <option
+                          value="3: Object"
+                        >
+                           03:00H 
+                        </option>
+                        <option
+                          value="4: Object"
+                        >
+                           04:00H 
+                        </option>
+                        <option
+                          value="5: Object"
+                        >
+                           05:00H 
+                        </option>
+                        <option
+                          value="6: Object"
+                        >
+                           06:00H 
+                        </option>
+                        <option
+                          value="7: Object"
+                        >
+                           07:00H 
+                        </option>
+                        <option
+                          value="8: Object"
+                        >
+                           08:00H 
+                        </option>
+                        <option
+                          value="9: Object"
+                        >
+                           09:00H 
+                        </option>
+                        <option
+                          value="10: Object"
+                        >
+                           10:00H 
+                        </option>
+                        <option
+                          value="11: Object"
+                        >
+                           11:00H 
+                        </option>
+                        <option
+                          value="12: Object"
+                        >
+                           12:00H 
+                        </option>
+                        <option
+                          value="13: Object"
+                        >
+                           13:00H 
+                        </option>
+                        <option
+                          value="14: Object"
+                        >
+                           14:00H 
+                        </option>
+                        <option
+                          value="15: Object"
+                        >
+                           15:00H 
+                        </option>
+                        <option
+                          value="16: Object"
+                        >
+                           16:00H 
+                        </option>
+                        <option
+                          value="17: Object"
+                        >
+                           17:00H 
+                        </option>
+                        <option
+                          value="18: Object"
+                        >
+                           18:00H 
+                        </option>
+                        <option
+                          value="19: Object"
+                        >
+                           19:00H 
+                        </option>
+                        <option
+                          value="20: Object"
+                        >
+                           20:00H 
+                        </option>
+                        <option
+                          value="21: Object"
+                        >
+                           21:00H 
+                        </option>
+                        <option
+                          value="22: Object"
+                        >
+                           22:00H 
+                        </option>
+                        <option
+                          value="23: Object"
+                        >
+                           23:00H 
+                        </option>
+                        <option
+                          value="0: Object"
+                        >
+                          23:59H
+                        </option>
+                        <option
+                          value="24: Object"
+                        >
+                          00:00H
+                        </option>
+                      </select>
+                    </tm-timepicker>
+                  </tm-datetimepicker>
                 </div>
               </div>
             </div>
@@ -1766,171 +1761,194 @@ exports[`NotificationEditFormComponent > should snap with notification that has 
               </div>
               <div
                 class="row align-items-center"
+                id="notification-end-date"
               >
                 <div
-                  class="col-md-7 col-xs-center"
-                  id="notification-end-date"
+                  class="col-12"
+                  id="notification-end-time"
                 >
-                  <tm-datepicker>
-                    <div
-                      class="input-group"
-                    >
-                      <input
-                        aria-label="Date"
-                        class="form-control ng-untouched ng-pristine ng-invalid"
-                        ngbdatepicker=""
-                        readonly=""
-                        type="text"
-                      />
-                      <button
-                        aria-label="Change date"
-                        class="btn btn-light input-group-text"
-                        type="button"
-                      >
-                        <i
-                          class="fas fa-calendar-alt"
-                        />
-                      </button>
-                    </div>
-                  </tm-datepicker>
-                </div>
-                <div
-                  class="col-md-5"
-                >
-                  <tm-timepicker
-                    id="notification-end-time"
+                  <tm-datetimepicker
+                    class="d-flex align-items-center justify-content-center gap-2"
                   >
-                    <select
-                      aria-label="Select time"
-                      class="form-control form-select ng-untouched ng-pristine ng-valid"
-                    >
-                      <option
-                        value="1: Object"
+                    <tm-datepicker>
+                      <div
+                        class="input-group"
                       >
-                         01:00H 
-                      </option>
-                      <option
-                        value="2: Object"
+                        <input
+                          aria-label="Date"
+                          class="form-control ng-untouched ng-pristine ng-invalid"
+                          ngbdatepicker=""
+                          readonly=""
+                          type="text"
+                        />
+                        <button
+                          aria-label="Change date"
+                          class="btn btn-light input-group-text"
+                          type="button"
+                        >
+                          <i
+                            class="fas fa-calendar-alt"
+                          />
+                        </button>
+                      </div>
+                    </tm-datepicker>
+                    <tm-timepicker>
+                      <select
+                        aria-label="Select time"
+                        class="form-control form-select ng-untouched ng-pristine ng-valid"
                       >
-                         02:00H 
-                      </option>
-                      <option
-                        value="3: Object"
-                      >
-                         03:00H 
-                      </option>
-                      <option
-                        value="4: Object"
-                      >
-                         04:00H 
-                      </option>
-                      <option
-                        value="5: Object"
-                      >
-                         05:00H 
-                      </option>
-                      <option
-                        value="6: Object"
-                      >
-                         06:00H 
-                      </option>
-                      <option
-                        value="7: Object"
-                      >
-                         07:00H 
-                      </option>
-                      <option
-                        value="8: Object"
-                      >
-                         08:00H 
-                      </option>
-                      <option
-                        value="9: Object"
-                      >
-                         09:00H 
-                      </option>
-                      <option
-                        value="10: Object"
-                      >
-                         10:00H 
-                      </option>
-                      <option
-                        value="11: Object"
-                      >
-                         11:00H 
-                      </option>
-                      <option
-                        value="12: Object"
-                      >
-                         12:00H 
-                      </option>
-                      <option
-                        value="13: Object"
-                      >
-                         13:00H 
-                      </option>
-                      <option
-                        value="14: Object"
-                      >
-                         14:00H 
-                      </option>
-                      <option
-                        value="15: Object"
-                      >
-                         15:00H 
-                      </option>
-                      <option
-                        value="16: Object"
-                      >
-                         16:00H 
-                      </option>
-                      <option
-                        value="17: Object"
-                      >
-                         17:00H 
-                      </option>
-                      <option
-                        value="18: Object"
-                      >
-                         18:00H 
-                      </option>
-                      <option
-                        value="19: Object"
-                      >
-                         19:00H 
-                      </option>
-                      <option
-                        value="20: Object"
-                      >
-                         20:00H 
-                      </option>
-                      <option
-                        value="21: Object"
-                      >
-                         21:00H 
-                      </option>
-                      <option
-                        value="22: Object"
-                      >
-                         22:00H 
-                      </option>
-                      <option
-                        value="23: Object"
-                      >
-                         23:00H 
-                      </option>
-                      <option
-                        value="0: Object"
-                      >
-                        23:59H
-                      </option>
-                      <option
-                        value="24: Object"
-                      >
-                        00:00H
-                      </option>
-                    </select>
-                  </tm-timepicker>
+                        <option
+                          disabled=""
+                          value="1: Object"
+                        >
+                           01:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="2: Object"
+                        >
+                           02:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="3: Object"
+                        >
+                           03:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="4: Object"
+                        >
+                           04:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="5: Object"
+                        >
+                           05:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="6: Object"
+                        >
+                           06:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="7: Object"
+                        >
+                           07:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="8: Object"
+                        >
+                           08:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="9: Object"
+                        >
+                           09:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="10: Object"
+                        >
+                           10:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="11: Object"
+                        >
+                           11:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="12: Object"
+                        >
+                           12:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="13: Object"
+                        >
+                           13:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="14: Object"
+                        >
+                           14:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="15: Object"
+                        >
+                           15:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="16: Object"
+                        >
+                           16:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="17: Object"
+                        >
+                           17:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="18: Object"
+                        >
+                           18:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="19: Object"
+                        >
+                           19:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="20: Object"
+                        >
+                           20:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="21: Object"
+                        >
+                           21:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="22: Object"
+                        >
+                           22:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="23: Object"
+                        >
+                           23:00H 
+                        </option>
+                        <option
+                          disabled=""
+                          value="0: Object"
+                        >
+                          23:59H
+                        </option>
+                        <option
+                          value="24: Object"
+                        >
+                          00:00H
+                        </option>
+                      </select>
+                    </tm-timepicker>
+                  </tm-datetimepicker>
                 </div>
               </div>
             </div>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
@@ -130,19 +130,13 @@
                 </label>
               </div>
             </div>
-            <div class="row text-center align-items-center">
-              <div id="notification-start-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
-                  (dateChangeCallback)="triggerModelChange('startDate', $event)"
-                  [date]="model.startDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="notification-start-time"
-                  [time]="model.startTime"
-                  (timeChange)="triggerModelChange('startTime', $event)"
-                ></tm-timepicker>
+            <div id="notification-start-date" class="row text-center align-items-center">
+              <div id="notification-start-time" class="col-12">
+                <tm-datetimepicker
+                  class="d-flex align-items-center justify-content-center gap-2"
+                  [dateTime]="startDateTime"
+                  (dateTimeChange)="triggerDateTimeModelChange('startDate', 'startTime', $event)"
+                ></tm-datetimepicker>
               </div>
             </div>
           </div>
@@ -157,20 +151,14 @@
                 </label>
               </div>
             </div>
-            <div class="row align-items-center">
-              <div id="notification-end-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
-                  (dateChangeCallback)="triggerModelChange('endDate', $event)"
-                  [minDate]="model.startDate"
-                  [date]="model.endDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="notification-end-time"
-                  [time]="model.endTime"
-                  (timeChange)="triggerModelChange('endTime', $event)"
-                ></tm-timepicker>
+            <div id="notification-end-date" class="row align-items-center">
+              <div id="notification-end-time" class="col-12">
+                <tm-datetimepicker
+                  class="d-flex align-items-center justify-content-center gap-2"
+                  [dateTime]="endDateTime"
+                  [minDateTime]="startDateTime"
+                  (dateTimeChange)="triggerDateTimeModelChange('endDate', 'endTime', $event)"
+                ></tm-datetimepicker>
               </div>
             </div>
           </div>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
@@ -11,12 +11,11 @@ import { NotificationTargetUser, NotificationStyle } from '../../../../types/api
 import { getDefaultTimeFormat, getDefaultDateFormat } from '../../../../types/datetime-const';
 import { AjaxLoadingComponent } from '../../../components/ajax-loading/ajax-loading.component';
 import { DatePickerFormatter } from '../../../components/datepicker/datepicker-formatter';
-import { DatepickerComponent } from '../../../components/datepicker/datepicker.component';
+import { DatetimepickerComponent } from '../../../components/datetimepicker/datetimepicker.component';
 import { RichTextEditorComponent } from '../../../components/rich-text-editor/rich-text-editor.component';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { NotificationStyleClassPipe } from '../../../components/teammates-common/notification-style-class.pipe';
 import { NotificationStyleDescriptionPipe } from '../../../components/teammates-common/notification-style-description.pipe';
-import { TimepickerComponent } from '../../../components/timepicker/timepicker.component';
 
 @Component({
   selector: 'tm-notification-edit-form',
@@ -28,8 +27,7 @@ import { TimepickerComponent } from '../../../components/timepicker/timepicker.c
     FormsModule,
     NgClass,
     RichTextEditorComponent,
-    DatepickerComponent,
-    TimepickerComponent,
+    DatetimepickerComponent,
     AjaxLoadingComponent,
     KeyValuePipe,
     NotificationStyleDescriptionPipe,
@@ -100,6 +98,27 @@ export class NotificationEditFormComponent {
       ...this.model,
       [field]: data,
     });
+  }
+
+  /**
+   * Triggers the change of date and time fields from a single Date.
+   */
+  triggerDateTimeModelChange(dateField: string, timeField: string, dateTime: Date): void {
+    const [date, time] = this.dateTimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+
+    this.modelChange.emit({
+      ...this.model,
+      [dateField]: date,
+      [timeField]: time,
+    });
+  }
+
+  get startDateTime(): Date {
+    return this.dateTimeService.convertDateFormatAndTimeFormatToDate(this.model.startDate, this.model.startTime);
+  }
+
+  get endDateTime(): Date {
+    return this.dateTimeService.convertDateFormatAndTimeFormatToDate(this.model.endDate, this.model.endTime);
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`InstructorHomePageComponent > should snap when courses are still loadin
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -111,7 +111,7 @@ exports[`InstructorHomePageComponent > should snap with default fields 1`] = `
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -191,7 +191,7 @@ exports[`InstructorHomePageComponent > should snap with one course with error lo
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -338,7 +338,7 @@ exports[`InstructorHomePageComponent > should snap with one course with one feed
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -931,7 +931,7 @@ exports[`InstructorHomePageComponent > should snap with one course with two feed
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -1681,7 +1681,7 @@ exports[`InstructorHomePageComponent > should snap with one course with unexpand
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -1968,7 +1968,7 @@ exports[`InstructorHomePageComponent > should snap with one course with unpopula
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"
@@ -2255,7 +2255,7 @@ exports[`InstructorHomePageComponent > should snap with one course without feedb
   numberOfSessionsCopied="0"
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   sessionEditFormModel={[Function Object]}
   simpleModalService={[Function _SimpleModalService]}
   sortOrder="0"

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -63,9 +63,13 @@ export abstract class InstructorSessionBasePageComponent {
   coursesOfModifiedSession: string[] = [];
   modifiedSession: Record<string, TweakedTimestampData> = {};
 
-  private publishUnpublishRetryAttempts: number = DEFAULT_NUMBER_OF_RETRY_ATTEMPTS;
+  private publishUnpublishRetryAttempts: number;
 
   private publishStatusName: PublishStatusNamePipe = new PublishStatusNamePipe();
+
+  constructor() {
+    this.publishUnpublishRetryAttempts = DEFAULT_NUMBER_OF_RETRY_ATTEMPTS;
+  }
 
   sessionEditFormModel: SessionEditFormModel = {
     feedbackSessionId: '',

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -38,7 +38,7 @@ exports[`InstructorSessionEditPageComponent > should snap when feedback question
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -135,7 +135,7 @@ exports[`InstructorSessionEditPageComponent > should snap when feedback question
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -232,7 +232,7 @@ exports[`InstructorSessionEditPageComponent > should snap when feedback session 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -332,7 +332,7 @@ exports[`InstructorSessionEditPageComponent > should snap when feedback session 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -429,7 +429,7 @@ exports[`InstructorSessionEditPageComponent > should snap with default fields 1`
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -526,7 +526,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -764,191 +764,190 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                   </div>
                   <div
                     class="row text-center align-items-center"
+                    id="submission-start-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="submission-start-date"
+                      class="col-12"
+                      id="submission-start-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="submission-start-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            disabled=""
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              disabled=""
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              disabled=""
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -971,191 +970,190 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                   </div>
                   <div
                     class="row align-items-center"
+                    id="submission-end-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="submission-end-date"
+                      class="col-12"
+                      id="submission-end-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="submission-end-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            disabled=""
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              disabled=""
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              disabled=""
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -1309,165 +1307,167 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       </div>
                     </div>
                     <div
-                      class="col-md-6"
+                      class="col-md-10"
                       id="session-visibility-date"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-4"
-                    >
-                      <tm-timepicker
+                      <div
                         id="session-visibility-time"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center gap-2"
                         >
-                          <option
-                            value="1: Object"
-                          >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
-                          >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
+                            >
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-valid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                disabled=""
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -1530,188 +1530,190 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       </div>
                     </div>
                     <div
-                      class="col-md-6"
+                      class="col-md-10"
                       id="response-visibility-date"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-4"
-                    >
-                      <tm-timepicker
+                      <div
                         id="response-visibility-time"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center gap-2"
                         >
-                          <option
-                            disabled=""
-                            value="1: Object"
-                          >
-                             01:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="2: Object"
-                          >
-                             02:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
+                            >
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-valid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                disabled=""
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -3792,7 +3794,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   questionEditFormModels={[Function Array]}
   route={[Function ActivatedRoute]}
   sessionEditFormModel={[Function Object]}
@@ -4027,191 +4029,190 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                   </div>
                   <div
                     class="row text-center align-items-center"
+                    id="submission-start-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="submission-start-date"
+                      class="col-12"
+                      id="submission-start-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="submission-start-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            disabled=""
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              disabled=""
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              disabled=""
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -4234,191 +4235,190 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                   </div>
                   <div
                     class="row align-items-center"
+                    id="submission-end-date"
                   >
                     <div
-                      class="col-md-7 col-xs-center"
-                      id="submission-end-date"
+                      class="col-12"
+                      id="submission-end-time"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-5"
-                    >
-                      <tm-timepicker
-                        id="submission-end-time"
+                      <tm-datetimepicker
+                        class="d-flex align-items-center justify-content-center gap-2"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
-                        >
-                          <option
-                            disabled=""
-                            value="1: Object"
+                        <tm-datepicker>
+                          <div
+                            class="input-group"
                           >
-                             01:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="2: Object"
+                            <input
+                              aria-label="Date"
+                              class="form-control ng-untouched ng-pristine ng-valid"
+                              ngbdatepicker=""
+                              readonly=""
+                              type="text"
+                            />
+                            <button
+                              aria-label="Change date"
+                              class="btn btn-light input-group-text"
+                              disabled=""
+                              type="button"
+                            >
+                              <i
+                                class="fas fa-calendar-alt"
+                              />
+                            </button>
+                          </div>
+                        </tm-datepicker>
+                        <tm-timepicker>
+                          <select
+                            aria-label="Select time"
+                            class="form-control form-select ng-untouched ng-pristine ng-valid"
                           >
-                             02:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                            <option
+                              disabled=""
+                              value="1: Object"
+                            >
+                               01:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="2: Object"
+                            >
+                               02:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="3: Object"
+                            >
+                               03:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="4: Object"
+                            >
+                               04:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="5: Object"
+                            >
+                               05:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="6: Object"
+                            >
+                               06:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="7: Object"
+                            >
+                               07:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="8: Object"
+                            >
+                               08:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="9: Object"
+                            >
+                               09:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="10: Object"
+                            >
+                               10:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="11: Object"
+                            >
+                               11:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="12: Object"
+                            >
+                               12:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="13: Object"
+                            >
+                               13:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="14: Object"
+                            >
+                               14:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="15: Object"
+                            >
+                               15:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="16: Object"
+                            >
+                               16:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="17: Object"
+                            >
+                               17:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="18: Object"
+                            >
+                               18:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="19: Object"
+                            >
+                               19:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="20: Object"
+                            >
+                               20:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="21: Object"
+                            >
+                               21:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="22: Object"
+                            >
+                               22:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="23: Object"
+                            >
+                               23:00H 
+                            </option>
+                            <option
+                              disabled=""
+                              value="0: Object"
+                            >
+                              23:59H
+                            </option>
+                          </select>
+                        </tm-timepicker>
+                      </tm-datetimepicker>
                     </div>
                   </div>
                 </div>
@@ -4572,165 +4572,167 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                       </div>
                     </div>
                     <div
-                      class="col-md-6"
+                      class="col-md-10"
                       id="session-visibility-date"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-4"
-                    >
-                      <tm-timepicker
+                      <div
                         id="session-visibility-time"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center gap-2"
                         >
-                          <option
-                            value="1: Object"
-                          >
-                             01:00H 
-                          </option>
-                          <option
-                            value="2: Object"
-                          >
-                             02:00H 
-                          </option>
-                          <option
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
+                            >
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-valid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                disabled=""
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
+                      </div>
                     </div>
                   </div>
                   <div
@@ -4793,188 +4795,190 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                       </div>
                     </div>
                     <div
-                      class="col-md-6"
+                      class="col-md-10"
                       id="response-visibility-date"
                     >
-                      <tm-datepicker>
-                        <div
-                          class="input-group"
-                        >
-                          <input
-                            aria-label="Date"
-                            class="form-control ng-untouched ng-pristine ng-valid"
-                            ngbdatepicker=""
-                            readonly=""
-                            type="text"
-                          />
-                          <button
-                            aria-label="Change date"
-                            class="btn btn-light input-group-text"
-                            disabled=""
-                            type="button"
-                          >
-                            <i
-                              class="fas fa-calendar-alt"
-                            />
-                          </button>
-                        </div>
-                      </tm-datepicker>
-                    </div>
-                    <div
-                      class="col-md-4"
-                    >
-                      <tm-timepicker
+                      <div
                         id="response-visibility-time"
                       >
-                        <select
-                          aria-label="Select time"
-                          class="form-control form-select ng-untouched ng-pristine ng-valid"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center gap-2"
                         >
-                          <option
-                            disabled=""
-                            value="1: Object"
-                          >
-                             01:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="2: Object"
-                          >
-                             02:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="3: Object"
-                          >
-                             03:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="4: Object"
-                          >
-                             04:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="5: Object"
-                          >
-                             05:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="6: Object"
-                          >
-                             06:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="7: Object"
-                          >
-                             07:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="8: Object"
-                          >
-                             08:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="9: Object"
-                          >
-                             09:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="10: Object"
-                          >
-                             10:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="11: Object"
-                          >
-                             11:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="12: Object"
-                          >
-                             12:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="13: Object"
-                          >
-                             13:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="14: Object"
-                          >
-                             14:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="15: Object"
-                          >
-                             15:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="16: Object"
-                          >
-                             16:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="17: Object"
-                          >
-                             17:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="18: Object"
-                          >
-                             18:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="19: Object"
-                          >
-                             19:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="20: Object"
-                          >
-                             20:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="21: Object"
-                          >
-                             21:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="22: Object"
-                          >
-                             22:00H 
-                          </option>
-                          <option
-                            disabled=""
-                            value="23: Object"
-                          >
-                             23:00H 
-                          </option>
-                          <option
-                            value="0: Object"
-                          >
-                            23:59H
-                          </option>
-                        </select>
-                      </tm-timepicker>
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
+                            >
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-valid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                disabled=""
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
+                            >
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
+                      </div>
                     </div>
                   </div>
                   <div

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
   extendByDeadlineOptions={[Function Map]}
   extendToDatePicker={[Function Object]}
   extendToTimePicker={[Function Object]}
-  feedbackSessionEndingTimestamp="0"
+  feedbackSessionEndingTimestampValue="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
@@ -164,7 +164,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
   extendByDeadlineOptions={[Function Map]}
   extendToDatePicker={[Function Object]}
   extendToTimePicker={[Function Object]}
-  feedbackSessionEndingTimestamp="0"
+  feedbackSessionEndingTimestampValue="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
@@ -359,7 +359,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend to 
   extendByDeadlineOptions={[Function Map]}
   extendToDatePicker={[Function Object]}
   extendToTimePicker={[Function Object]}
-  feedbackSessionEndingTimestamp="0"
+  feedbackSessionEndingTimestampValue="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
@@ -630,7 +630,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
   extendByDeadlineOptions={[Function Map]}
   extendToDatePicker={[Function Object]}
   extendToTimePicker={[Function Object]}
-  feedbackSessionEndingTimestamp="0"
+  feedbackSessionEndingTimestampValue="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
@@ -781,7 +781,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the warning mo
   extendByDeadlineOptions={[Function Map]}
   extendToDatePicker={[Function Object]}
   extendToTimePicker={[Function Object]}
-  feedbackSessionEndingTimestamp="0"
+  feedbackSessionEndingTimestampValue="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
@@ -2,13 +2,13 @@
 
 exports[`IndividualExtensionDateModalComponent > should snap with the extend by radio option 1`] = `
 <tm-individual-extension-date-modal
-  DateTime={[Function Object]}
   MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
   MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
   RadioOptions={[Function Object]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
   dateDetailPipe={[Function _FormatDateDetailPipe]}
+  datetimeService={[Function _DateTimeService]}
   extendByDatePicker={[Function Object]}
   extendByDeadlineKey={[Function String]}
   extendByDeadlineOptions={[Function Map]}
@@ -152,13 +152,13 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
 
 exports[`IndividualExtensionDateModalComponent > should snap with the extend by radio option with customize 1`] = `
 <tm-individual-extension-date-modal
-  DateTime={[Function Object]}
   MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
   MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
   RadioOptions={[Function Object]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
   dateDetailPipe={[Function _FormatDateDetailPipe]}
+  datetimeService={[Function _DateTimeService]}
   extendByDatePicker={[Function Object]}
   extendByDeadlineKey={[Function String]}
   extendByDeadlineOptions={[Function Map]}
@@ -347,13 +347,13 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
 
 exports[`IndividualExtensionDateModalComponent > should snap with the extend to radio option with timepicker 1`] = `
 <tm-individual-extension-date-modal
-  DateTime={[Function Object]}
   MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
   MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
   RadioOptions={[Function Object]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
   dateDetailPipe={[Function _FormatDateDetailPipe]}
+  datetimeService={[Function _DateTimeService]}
   extendByDatePicker={[Function Object]}
   extendByDeadlineKey=""
   extendByDeadlineOptions={[Function Map]}
@@ -429,168 +429,169 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend to 
       >
         <div
           class="input-group"
+          id="submission-end-date"
         >
-          <tm-datepicker
-            id="submission-end-date"
-          >
-            <div
-              class="input-group"
-            >
-              <input
-                aria-label="Date"
-                class="form-control ng-untouched ng-pristine ng-valid"
-                ngbdatepicker=""
-                readonly=""
-                type="text"
-              />
-              <button
-                aria-label="Change date"
-                class="btn btn-light input-group-text"
-                type="button"
-              >
-                <i
-                  class="fas fa-calendar-alt"
-                />
-              </button>
-            </div>
-          </tm-datepicker>
           <div
-            class="col-md-5"
+            id="submission-end-time"
           >
-            <tm-timepicker
-              id="submission-end-time"
+            <tm-datetimepicker
+              class="d-flex align-items-center gap-2"
             >
-              <select
-                aria-label="Select time"
-                class="form-control form-select ng-untouched ng-pristine ng-valid"
-              >
-                <option
-                  value="1: Object"
+              <tm-datepicker>
+                <div
+                  class="input-group"
                 >
-                   01:00H 
-                </option>
-                <option
-                  value="2: Object"
+                  <input
+                    aria-label="Date"
+                    class="form-control ng-untouched ng-pristine ng-valid"
+                    ngbdatepicker=""
+                    readonly=""
+                    type="text"
+                  />
+                  <button
+                    aria-label="Change date"
+                    class="btn btn-light input-group-text"
+                    type="button"
+                  >
+                    <i
+                      class="fas fa-calendar-alt"
+                    />
+                  </button>
+                </div>
+              </tm-datepicker>
+              <tm-timepicker>
+                <select
+                  aria-label="Select time"
+                  class="form-control form-select ng-untouched ng-pristine ng-valid"
                 >
-                   02:00H 
-                </option>
-                <option
-                  value="3: Object"
-                >
-                   03:00H 
-                </option>
-                <option
-                  value="4: Object"
-                >
-                   04:00H 
-                </option>
-                <option
-                  value="5: Object"
-                >
-                   05:00H 
-                </option>
-                <option
-                  value="6: Object"
-                >
-                   06:00H 
-                </option>
-                <option
-                  value="7: Object"
-                >
-                   07:00H 
-                </option>
-                <option
-                  value="8: Object"
-                >
-                   08:00H 
-                </option>
-                <option
-                  value="9: Object"
-                >
-                   09:00H 
-                </option>
-                <option
-                  value="10: Object"
-                >
-                   10:00H 
-                </option>
-                <option
-                  value="11: Object"
-                >
-                   11:00H 
-                </option>
-                <option
-                  value="12: Object"
-                >
-                   12:00H 
-                </option>
-                <option
-                  value="13: Object"
-                >
-                   13:00H 
-                </option>
-                <option
-                  value="14: Object"
-                >
-                   14:00H 
-                </option>
-                <option
-                  value="15: Object"
-                >
-                   15:00H 
-                </option>
-                <option
-                  value="16: Object"
-                >
-                   16:00H 
-                </option>
-                <option
-                  value="17: Object"
-                >
-                   17:00H 
-                </option>
-                <option
-                  value="18: Object"
-                >
-                   18:00H 
-                </option>
-                <option
-                  value="19: Object"
-                >
-                   19:00H 
-                </option>
-                <option
-                  value="20: Object"
-                >
-                   20:00H 
-                </option>
-                <option
-                  value="21: Object"
-                >
-                   21:00H 
-                </option>
-                <option
-                  value="22: Object"
-                >
-                   22:00H 
-                </option>
-                <option
-                  value="23: Object"
-                >
-                   23:00H 
-                </option>
-                <option
-                  value="0: Object"
-                >
-                  23:59H
-                </option>
-                <option
-                  value="24: Object"
-                >
-                  10:30H
-                </option>
-              </select>
-            </tm-timepicker>
+                  <option
+                    value="1: Object"
+                  >
+                     01:00H 
+                  </option>
+                  <option
+                    value="2: Object"
+                  >
+                     02:00H 
+                  </option>
+                  <option
+                    value="3: Object"
+                  >
+                     03:00H 
+                  </option>
+                  <option
+                    value="4: Object"
+                  >
+                     04:00H 
+                  </option>
+                  <option
+                    value="5: Object"
+                  >
+                     05:00H 
+                  </option>
+                  <option
+                    value="6: Object"
+                  >
+                     06:00H 
+                  </option>
+                  <option
+                    value="7: Object"
+                  >
+                     07:00H 
+                  </option>
+                  <option
+                    value="8: Object"
+                  >
+                     08:00H 
+                  </option>
+                  <option
+                    value="9: Object"
+                  >
+                     09:00H 
+                  </option>
+                  <option
+                    value="10: Object"
+                  >
+                     10:00H 
+                  </option>
+                  <option
+                    value="11: Object"
+                  >
+                     11:00H 
+                  </option>
+                  <option
+                    value="12: Object"
+                  >
+                     12:00H 
+                  </option>
+                  <option
+                    value="13: Object"
+                  >
+                     13:00H 
+                  </option>
+                  <option
+                    value="14: Object"
+                  >
+                     14:00H 
+                  </option>
+                  <option
+                    value="15: Object"
+                  >
+                     15:00H 
+                  </option>
+                  <option
+                    value="16: Object"
+                  >
+                     16:00H 
+                  </option>
+                  <option
+                    value="17: Object"
+                  >
+                     17:00H 
+                  </option>
+                  <option
+                    value="18: Object"
+                  >
+                     18:00H 
+                  </option>
+                  <option
+                    value="19: Object"
+                  >
+                     19:00H 
+                  </option>
+                  <option
+                    value="20: Object"
+                  >
+                     20:00H 
+                  </option>
+                  <option
+                    value="21: Object"
+                  >
+                     21:00H 
+                  </option>
+                  <option
+                    value="22: Object"
+                  >
+                     22:00H 
+                  </option>
+                  <option
+                    value="23: Object"
+                  >
+                     23:00H 
+                  </option>
+                  <option
+                    value="0: Object"
+                  >
+                    23:59H
+                  </option>
+                  <option
+                    value="24: Object"
+                  >
+                    10:30H
+                  </option>
+                </select>
+              </tm-timepicker>
+            </tm-datetimepicker>
           </div>
         </div>
       </div>
@@ -617,13 +618,13 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend to 
 
 exports[`IndividualExtensionDateModalComponent > should snap with the extended students 1`] = `
 <tm-individual-extension-date-modal
-  DateTime={[Function Object]}
   MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
   MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
   RadioOptions={[Function Object]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
   dateDetailPipe={[Function _FormatDateDetailPipe]}
+  datetimeService={[Function _DateTimeService]}
   extendByDatePicker={[Function Object]}
   extendByDeadlineKey=""
   extendByDeadlineOptions={[Function Map]}
@@ -768,13 +769,13 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
 
 exports[`IndividualExtensionDateModalComponent > should snap with the warning modal 1`] = `
 <tm-individual-extension-date-modal
-  DateTime={[Function Object]}
   MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
   MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
   RadioOptions={[Function Object]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
   dateDetailPipe={[Function _FormatDateDetailPipe]}
+  datetimeService={[Function _DateTimeService]}
   extendByDatePicker={[Function Object]}
   extendByDeadlineKey=""
   extendByDeadlineOptions={[Function Map]}

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
@@ -54,21 +54,14 @@
     <div>
       <small>The new deadline of the feedback session will be:</small>
       <div id="submission-start-date">
-        <div class="input-group">
-          <tm-datepicker
-            id="submission-end-date"
-            [date]="extendToDatePicker"
-            (dateChangeCallback)="onChangeDateTime($event, DateTime.DATE)"
-            [minDate]="getDateFormat(feedbackSessionEndingTimestamp)"
-          >
-          </tm-datepicker>
-          <div class="col-md-5">
-            <tm-timepicker
-              id="submission-end-time"
-              [time]="extendToTimePicker"
-              (timeChange)="onChangeDateTime($event, DateTime.TIME)"
-            >
-            </tm-timepicker>
+        <div id="submission-end-date" class="input-group">
+          <div id="submission-end-time">
+            <tm-datetimepicker
+              class="d-flex align-items-center gap-2"
+              [dateTime]="extendToDateTime"
+              [minDateTime]="minDateTimeForExtendTo"
+              (dateTimeChange)="onChangeExtendToDateTime($event)"
+            ></tm-datetimepicker>
           </div>
         </div>
       </div>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.spec.ts
@@ -160,7 +160,7 @@ describe('IndividualExtensionDateModalComponent', () => {
   });
 
   it('should keep time options enabled when switching to extend-to before date is changed', () => {
-    fixture.componentRef.setInput('feedbackSessionEndingTimestamp', Date.parse('2032-04-30T16:00:00Z'));
+    component.feedbackSessionEndingTimestamp = Date.parse('2032-04-30T16:00:00Z');
     component.radioOption = RadioOptions.EXTEND_TO;
 
     fixture.detectChanges();

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.spec.ts
@@ -1,6 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { IndividualExtensionDateModalComponent, RadioOptions } from './individual-extension-date-modal.component';
 import { SimpleModalService } from '../../../../services/simple-modal.service';
@@ -9,6 +10,7 @@ import { createMockNgbModalRef } from '../../../../test-helpers/mock-ngb-modal-r
 import { Hours, Milliseconds } from '../../../../types/datetime-const';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { FormatDateDetailPipe } from '../../../components/teammates-common/format-date-detail.pipe';
+import { TimepickerComponent } from '../../../components/timepicker/timepicker.component';
 import { Mock } from 'vitest';
 
 describe('IndividualExtensionDateModalComponent', () => {
@@ -155,6 +157,17 @@ describe('IndividualExtensionDateModalComponent', () => {
     component.extendToTimePicker = { hour: 10, minute: 30 };
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
+  });
+
+  it('should keep time options enabled when switching to extend-to before date is changed', () => {
+    fixture.componentRef.setInput('feedbackSessionEndingTimestamp', Date.parse('2032-04-30T16:00:00Z'));
+    component.radioOption = RadioOptions.EXTEND_TO;
+
+    fixture.detectChanges();
+
+    const timepicker = fixture.debugElement.query(By.directive(TimepickerComponent)).componentInstance;
+
+    expect(timepicker.isOptionDisabled({ hour: 23, minute: 59 })).toBe(false);
   });
 
   it('should snap with the warning modal', () => {

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
@@ -1,5 +1,5 @@
 import { KeyValuePipe } from '@angular/common';
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import moment from 'moment-timezone';
@@ -30,7 +30,7 @@ export enum RadioOptions {
   imports: [FormsModule, DatetimepickerComponent, KeyValuePipe],
   providers: [FormatDateDetailPipe],
 })
-export class IndividualExtensionDateModalComponent {
+export class IndividualExtensionDateModalComponent implements OnChanges {
   activeModal = inject(NgbActiveModal);
   private simpleModalService = inject(SimpleModalService);
   private dateDetailPipe = inject(FormatDateDetailPipe);
@@ -74,6 +74,12 @@ export class IndividualExtensionDateModalComponent {
 
   constructor() {
     this.RadioOptions = RadioOptions;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['feedbackSessionEndingTimestamp']) {
+      this.extendToDatePicker = this.getDateFormat(this.feedbackSessionEndingTimestamp);
+    }
   }
 
   onConfirm(): void {

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
@@ -1,5 +1,5 @@
 import { KeyValuePipe } from '@angular/common';
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import moment from 'moment-timezone';
@@ -30,7 +30,7 @@ export enum RadioOptions {
   imports: [FormsModule, DatetimepickerComponent, KeyValuePipe],
   providers: [FormatDateDetailPipe],
 })
-export class IndividualExtensionDateModalComponent implements OnChanges {
+export class IndividualExtensionDateModalComponent {
   activeModal = inject(NgbActiveModal);
   private simpleModalService = inject(SimpleModalService);
   private dateDetailPipe = inject(FormatDateDetailPipe);
@@ -43,8 +43,17 @@ export class IndividualExtensionDateModalComponent implements OnChanges {
   @Input()
   numInstructors = 0;
 
+  private feedbackSessionEndingTimestampValue = 0;
+
   @Input()
-  feedbackSessionEndingTimestamp = 0;
+  set feedbackSessionEndingTimestamp(feedbackSessionEndingTimestamp: number) {
+    this.feedbackSessionEndingTimestampValue = feedbackSessionEndingTimestamp;
+    this.extendToDatePicker = this.getDateFormat(feedbackSessionEndingTimestamp);
+  }
+
+  get feedbackSessionEndingTimestamp(): number {
+    return this.feedbackSessionEndingTimestampValue;
+  }
 
   @Input()
   feedbackSessionTimeZone = '';
@@ -74,12 +83,6 @@ export class IndividualExtensionDateModalComponent implements OnChanges {
 
   constructor() {
     this.RadioOptions = RadioOptions;
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['feedbackSessionEndingTimestamp']) {
-      this.extendToDatePicker = this.getDateFormat(this.feedbackSessionEndingTimestamp);
-    }
   }
 
   onConfirm(): void {

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
@@ -3,35 +3,31 @@ import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import moment from 'moment-timezone';
+import { DateTimeService } from '../../../../services/datetime.service';
 import { SimpleModalService } from '../../../../services/simple-modal.service';
 import { TimezoneService } from '../../../../services/timezone.service';
 import {
   DateFormat,
   TimeFormat,
   getDefaultDateFormat,
+  getDefaultTimeFormat,
   getLatestTimeFormat,
   Hours,
   Milliseconds,
 } from '../../../../types/datetime-const';
-import { DatepickerComponent } from '../../../components/datepicker/datepicker.component';
+import { DatetimepickerComponent } from '../../../components/datetimepicker/datetimepicker.component';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { FormatDateDetailPipe } from '../../../components/teammates-common/format-date-detail.pipe';
-import { TimepickerComponent } from '../../../components/timepicker/timepicker.component';
 
 export enum RadioOptions {
   EXTEND_TO = 1,
   EXTEND_BY = 2,
 }
 
-enum DateTime {
-  DATE,
-  TIME,
-}
-
 @Component({
   selector: 'tm-individual-extension-date-modal',
   templateUrl: './individual-extension-date-modal.component.html',
-  imports: [FormsModule, DatepickerComponent, TimepickerComponent, KeyValuePipe],
+  imports: [FormsModule, DatetimepickerComponent, KeyValuePipe],
   providers: [FormatDateDetailPipe],
 })
 export class IndividualExtensionDateModalComponent {
@@ -39,6 +35,7 @@ export class IndividualExtensionDateModalComponent {
   private simpleModalService = inject(SimpleModalService);
   private dateDetailPipe = inject(FormatDateDetailPipe);
   private readonly timeZoneService = inject(TimezoneService);
+  private readonly datetimeService = inject(DateTimeService);
 
   @Input()
   numStudents = 0;
@@ -57,7 +54,6 @@ export class IndividualExtensionDateModalComponent {
 
   RadioOptions!: typeof RadioOptions;
   radioOption: RadioOptions = RadioOptions.EXTEND_BY;
-  DateTime!: typeof DateTime;
 
   extendByDeadlineKey = '';
   extendByDeadlineOptions: Map<string, number> = new Map([
@@ -78,7 +74,6 @@ export class IndividualExtensionDateModalComponent {
 
   constructor() {
     this.RadioOptions = RadioOptions;
-    this.DateTime = DateTime;
   }
 
   onConfirm(): void {
@@ -104,12 +99,20 @@ export class IndividualExtensionDateModalComponent {
       );
   }
 
-  onChangeDateTime(data: DateFormat | TimeFormat, field: DateTime): void {
-    if (field === DateTime.DATE) {
-      this.extendToDatePicker = data as DateFormat;
-    } else if (field === DateTime.TIME) {
-      this.extendToTimePicker = data as TimeFormat;
-    }
+  onChangeExtendToDateTime(dateTime: Date): void {
+    [this.extendToDatePicker, this.extendToTimePicker] =
+      this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+  }
+
+  get extendToDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(this.extendToDatePicker, this.extendToTimePicker);
+  }
+
+  get minDateTimeForExtendTo(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.getDateFormat(this.feedbackSessionEndingTimestamp),
+      getDefaultTimeFormat(),
+    );
   }
 
   getDateFormat(timestamp: number): DateFormat {

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -36,7 +36,7 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -344,190 +344,189 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -550,190 +549,189 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -885,167 +883,169 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -1108,190 +1108,192 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -1562,7 +1564,7 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -1870,190 +1872,189 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -2076,190 +2077,189 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -2411,167 +2411,169 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -2634,190 +2636,192 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -3088,7 +3092,7 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -3396,190 +3400,189 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -3602,190 +3605,189 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -3937,167 +3939,169 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -4160,190 +4164,192 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -4582,7 +4588,7 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -4903,190 +4909,189 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -5109,190 +5114,189 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -5444,167 +5448,169 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -5667,190 +5673,192 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -6125,7 +6133,7 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -6433,190 +6441,189 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -6639,190 +6646,189 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -6974,167 +6980,169 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -7197,190 +7205,192 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -7651,7 +7661,7 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -7959,190 +7969,189 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -8165,190 +8174,189 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-invalid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-invalid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -8500,167 +8508,169 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -8723,190 +8733,192 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine"
-                              disabled=""
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine"
+                                  disabled=""
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -9177,7 +9189,7 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
   ngbModal={[Function NgbModal]}
   progressBarService={[Function _ProgressBarService]}
   publishStatusName={[Function _PublishStatusNamePipe]}
-  publishUnpublishRetryAttempts="undefined"
+  publishUnpublishRetryAttempts={[Function Number]}
   recycleBinFeedbackSessionRowModels={[Function Array]}
   recycleBinFeedbackSessionRowModelsSortBy="0"
   recycleBinFeedbackSessionRowModelsSortOrder={[Function Number]}
@@ -9485,190 +9497,189 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
                     </div>
                     <div
                       class="row text-center align-items-center"
+                      id="submission-start-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-start-date"
+                        class="col-12"
+                        id="submission-start-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-valid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-start-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-valid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -9691,190 +9702,189 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
                     </div>
                     <div
                       class="row align-items-center"
+                      id="submission-end-date"
                     >
                       <div
-                        class="col-md-7 col-xs-center"
-                        id="submission-end-date"
+                        class="col-12"
+                        id="submission-end-time"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-valid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-5"
-                      >
-                        <tm-timepicker
-                          id="submission-end-time"
+                        <tm-datetimepicker
+                          class="d-flex align-items-center justify-content-center gap-2"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                          >
-                            <option
-                              disabled=""
-                              value="1: Object"
+                          <tm-datepicker>
+                            <div
+                              class="input-group"
                             >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
+                              <input
+                                aria-label="Date"
+                                class="form-control ng-untouched ng-pristine ng-valid"
+                                ngbdatepicker=""
+                                readonly=""
+                                type="text"
+                              />
+                              <button
+                                aria-label="Change date"
+                                class="btn btn-light input-group-text"
+                                type="button"
+                              >
+                                <i
+                                  class="fas fa-calendar-alt"
+                                />
+                              </button>
+                            </div>
+                          </tm-datepicker>
+                          <tm-timepicker>
+                            <select
+                              aria-label="Select time"
+                              class="form-control form-select ng-untouched ng-pristine ng-valid"
                             >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                              <option
+                                disabled=""
+                                value="1: Object"
+                              >
+                                 01:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="2: Object"
+                              >
+                                 02:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="3: Object"
+                              >
+                                 03:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="4: Object"
+                              >
+                                 04:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="5: Object"
+                              >
+                                 05:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="6: Object"
+                              >
+                                 06:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="7: Object"
+                              >
+                                 07:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="8: Object"
+                              >
+                                 08:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="9: Object"
+                              >
+                                 09:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="10: Object"
+                              >
+                                 10:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="11: Object"
+                              >
+                                 11:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="12: Object"
+                              >
+                                 12:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="13: Object"
+                              >
+                                 13:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="14: Object"
+                              >
+                                 14:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="15: Object"
+                              >
+                                 15:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="16: Object"
+                              >
+                                 16:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="17: Object"
+                              >
+                                 17:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="18: Object"
+                              >
+                                 18:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="19: Object"
+                              >
+                                 19:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="20: Object"
+                              >
+                                 20:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="21: Object"
+                              >
+                                 21:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="22: Object"
+                              >
+                                 22:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="23: Object"
+                              >
+                                 23:00H 
+                              </option>
+                              <option
+                                disabled=""
+                                value="0: Object"
+                              >
+                                23:59H
+                              </option>
+                            </select>
+                          </tm-timepicker>
+                        </tm-datetimepicker>
                       </div>
                     </div>
                   </div>
@@ -10026,166 +10036,168 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="session-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-valid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="session-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine ng-valid"
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine ng-valid"
+                                disabled=""
+                              >
+                                <option
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div
@@ -10248,189 +10260,191 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
                         </div>
                       </div>
                       <div
-                        class="col-md-6"
+                        class="col-md-10"
                         id="response-visibility-date"
                       >
-                        <tm-datepicker>
-                          <div
-                            class="input-group"
-                          >
-                            <input
-                              aria-label="Date"
-                              class="form-control ng-untouched ng-pristine ng-valid"
-                              ngbdatepicker=""
-                              readonly=""
-                              type="text"
-                            />
-                            <button
-                              aria-label="Change date"
-                              class="btn btn-light input-group-text"
-                              disabled=""
-                              type="button"
-                            >
-                              <i
-                                class="fas fa-calendar-alt"
-                              />
-                            </button>
-                          </div>
-                        </tm-datepicker>
-                      </div>
-                      <div
-                        class="col-md-4"
-                      >
-                        <tm-timepicker
+                        <div
                           id="response-visibility-time"
                         >
-                          <select
-                            aria-label="Select time"
-                            class="form-control form-select ng-untouched ng-pristine ng-valid"
-                            disabled=""
+                          <tm-datetimepicker
+                            class="d-flex align-items-center gap-2"
                           >
-                            <option
-                              disabled=""
-                              value="1: Object"
-                            >
-                               01:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="2: Object"
-                            >
-                               02:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="3: Object"
-                            >
-                               03:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="4: Object"
-                            >
-                               04:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="5: Object"
-                            >
-                               05:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="6: Object"
-                            >
-                               06:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="7: Object"
-                            >
-                               07:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="8: Object"
-                            >
-                               08:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="9: Object"
-                            >
-                               09:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="10: Object"
-                            >
-                               10:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="11: Object"
-                            >
-                               11:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="12: Object"
-                            >
-                               12:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="13: Object"
-                            >
-                               13:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="14: Object"
-                            >
-                               14:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="15: Object"
-                            >
-                               15:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="16: Object"
-                            >
-                               16:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="17: Object"
-                            >
-                               17:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="18: Object"
-                            >
-                               18:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="19: Object"
-                            >
-                               19:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="20: Object"
-                            >
-                               20:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="21: Object"
-                            >
-                               21:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="22: Object"
-                            >
-                               22:00H 
-                            </option>
-                            <option
-                              disabled=""
-                              value="23: Object"
-                            >
-                               23:00H 
-                            </option>
-                            <option
-                              value="0: Object"
-                            >
-                              23:59H
-                            </option>
-                          </select>
-                        </tm-timepicker>
+                            <tm-datepicker>
+                              <div
+                                class="input-group"
+                              >
+                                <input
+                                  aria-label="Date"
+                                  class="form-control ng-untouched ng-pristine ng-valid"
+                                  ngbdatepicker=""
+                                  readonly=""
+                                  type="text"
+                                />
+                                <button
+                                  aria-label="Change date"
+                                  class="btn btn-light input-group-text"
+                                  disabled=""
+                                  type="button"
+                                >
+                                  <i
+                                    class="fas fa-calendar-alt"
+                                  />
+                                </button>
+                              </div>
+                            </tm-datepicker>
+                            <tm-timepicker>
+                              <select
+                                aria-label="Select time"
+                                class="form-control form-select ng-untouched ng-pristine ng-valid"
+                                disabled=""
+                              >
+                                <option
+                                  disabled=""
+                                  value="1: Object"
+                                >
+                                   01:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="2: Object"
+                                >
+                                   02:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="3: Object"
+                                >
+                                   03:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="4: Object"
+                                >
+                                   04:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="5: Object"
+                                >
+                                   05:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="6: Object"
+                                >
+                                   06:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="7: Object"
+                                >
+                                   07:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="8: Object"
+                                >
+                                   08:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="9: Object"
+                                >
+                                   09:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="10: Object"
+                                >
+                                   10:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="11: Object"
+                                >
+                                   11:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="12: Object"
+                                >
+                                   12:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="13: Object"
+                                >
+                                   13:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="14: Object"
+                                >
+                                   14:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="15: Object"
+                                >
+                                   15:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="16: Object"
+                                >
+                                   16:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="17: Object"
+                                >
+                                   17:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="18: Object"
+                                >
+                                   18:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="19: Object"
+                                >
+                                   19:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="20: Object"
+                                >
+                                   20:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="21: Object"
+                                >
+                                   21:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="22: Object"
+                                >
+                                   22:00H 
+                                </option>
+                                <option
+                                  disabled=""
+                                  value="23: Object"
+                                >
+                                   23:00H 
+                                </option>
+                                <option
+                                  value="0: Object"
+                                >
+                                  23:59H
+                                </option>
+                              </select>
+                            </tm-timepicker>
+                          </tm-datetimepicker>
+                        </div>
                       </div>
                     </div>
                     <div

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/__snapshots__/instructor-student-activity-logs.component.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`InstructorStudentActivityLogsComponent > should snap when page is still
   course={[Function Object]}
   courseService={[Function _CourseService]}
   dateToday={[Function Object]}
+  datetimeService={[Function _DateTimeService]}
   earliestSearchDate={[Function Object]}
   feedbackSessions={[Function Map]}
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -70,6 +71,7 @@ exports[`InstructorStudentActivityLogsComponent > should snap when searching for
   course={[Function Object]}
   courseService={[Function _CourseService]}
   dateToday={[Function Object]}
+  datetimeService={[Function _DateTimeService]}
   earliestSearchDate={[Function Object]}
   feedbackSessions={[Function Map]}
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -221,157 +223,189 @@ exports[`InstructorStudentActivityLogsComponent > should snap when searching for
           </label>
           <div
             class="input-group"
+            id="logs-from-datepicker"
           >
             <div
-              class="input-group"
-              id="logs-from-datepicker"
-            >
-              <input
-                aria-label="Date to search from"
-                class="form-control ng-untouched ng-pristine ng-valid"
-                ngbdatepicker=""
-                readonly=""
-                type="text"
-              />
-              <button
-                aria-label="Change date"
-                class="btn btn-light"
-                type="button"
-              >
-                <i
-                  class="fas fa-calendar-alt"
-                />
-              </button>
-            </div>
-            <tm-timepicker
               id="logs-from-timepicker"
             >
-              <select
-                aria-label="Select time"
-                class="form-control form-select ng-untouched ng-pristine ng-valid"
+              <tm-datetimepicker
+                class="d-flex align-items-center gap-2"
               >
-                <option
-                  value="1: Object"
-                >
-                   01:00H 
-                </option>
-                <option
-                  value="2: Object"
-                >
-                   02:00H 
-                </option>
-                <option
-                  value="3: Object"
-                >
-                   03:00H 
-                </option>
-                <option
-                  value="4: Object"
-                >
-                   04:00H 
-                </option>
-                <option
-                  value="5: Object"
-                >
-                   05:00H 
-                </option>
-                <option
-                  value="6: Object"
-                >
-                   06:00H 
-                </option>
-                <option
-                  value="7: Object"
-                >
-                   07:00H 
-                </option>
-                <option
-                  value="8: Object"
-                >
-                   08:00H 
-                </option>
-                <option
-                  value="9: Object"
-                >
-                   09:00H 
-                </option>
-                <option
-                  value="10: Object"
-                >
-                   10:00H 
-                </option>
-                <option
-                  value="11: Object"
-                >
-                   11:00H 
-                </option>
-                <option
-                  value="12: Object"
-                >
-                   12:00H 
-                </option>
-                <option
-                  value="13: Object"
-                >
-                   13:00H 
-                </option>
-                <option
-                  value="14: Object"
-                >
-                   14:00H 
-                </option>
-                <option
-                  value="15: Object"
-                >
-                   15:00H 
-                </option>
-                <option
-                  value="16: Object"
-                >
-                   16:00H 
-                </option>
-                <option
-                  value="17: Object"
-                >
-                   17:00H 
-                </option>
-                <option
-                  value="18: Object"
-                >
-                   18:00H 
-                </option>
-                <option
-                  value="19: Object"
-                >
-                   19:00H 
-                </option>
-                <option
-                  value="20: Object"
-                >
-                   20:00H 
-                </option>
-                <option
-                  value="21: Object"
-                >
-                   21:00H 
-                </option>
-                <option
-                  value="22: Object"
-                >
-                   22:00H 
-                </option>
-                <option
-                  value="23: Object"
-                >
-                   23:00H 
-                </option>
-                <option
-                  value="0: Object"
-                >
-                  23:59H
-                </option>
-              </select>
-            </tm-timepicker>
+                <tm-datepicker>
+                  <div
+                    class="input-group"
+                  >
+                    <input
+                      aria-label="Date"
+                      class="form-control ng-untouched ng-pristine ng-valid"
+                      ngbdatepicker=""
+                      readonly=""
+                      type="text"
+                    />
+                    <button
+                      aria-label="Change date"
+                      class="btn btn-light input-group-text"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-calendar-alt"
+                      />
+                    </button>
+                  </div>
+                </tm-datepicker>
+                <tm-timepicker>
+                  <select
+                    aria-label="Select time"
+                    class="form-control form-select ng-untouched ng-pristine ng-valid"
+                  >
+                    <option
+                      disabled=""
+                      value="1: Object"
+                    >
+                       01:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="2: Object"
+                    >
+                       02:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="3: Object"
+                    >
+                       03:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="4: Object"
+                    >
+                       04:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="5: Object"
+                    >
+                       05:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="6: Object"
+                    >
+                       06:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="7: Object"
+                    >
+                       07:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="8: Object"
+                    >
+                       08:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="9: Object"
+                    >
+                       09:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="10: Object"
+                    >
+                       10:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="11: Object"
+                    >
+                       11:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="12: Object"
+                    >
+                       12:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="13: Object"
+                    >
+                       13:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="14: Object"
+                    >
+                       14:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="15: Object"
+                    >
+                       15:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="16: Object"
+                    >
+                       16:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="17: Object"
+                    >
+                       17:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="18: Object"
+                    >
+                       18:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="19: Object"
+                    >
+                       19:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="20: Object"
+                    >
+                       20:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="21: Object"
+                    >
+                       21:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="22: Object"
+                    >
+                       22:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="23: Object"
+                    >
+                       23:00H 
+                    </option>
+                    <option
+                      disabled=""
+                      value="0: Object"
+                    >
+                      23:59H
+                    </option>
+                  </select>
+                </tm-timepicker>
+              </tm-datetimepicker>
+            </div>
           </div>
         </div>
         <div
@@ -385,158 +419,165 @@ exports[`InstructorStudentActivityLogsComponent > should snap when searching for
           </label>
           <div
             class="input-group"
+            id="logs-to-datepicker"
           >
             <div
-              class="input-group"
-              id="logs-to-datepicker"
-            >
-              <input
-                aria-label="Date to search until"
-                class="form-control ng-untouched ng-pristine ng-valid"
-                ngbdatepicker=""
-                readonly=""
-                type="text"
-              />
-              <button
-                aria-label="Change date"
-                class="btn btn-light"
-                type="button"
-              >
-                <i
-                  class="fas fa-calendar-alt"
-                />
-              </button>
-            </div>
-            <tm-timepicker
-              aria-label="Search period until time"
               id="logs-to-timepicker"
             >
-              <select
-                aria-label="Select time"
-                class="form-control form-select ng-untouched ng-pristine ng-valid"
+              <tm-datetimepicker
+                class="d-flex align-items-center gap-2"
               >
-                <option
-                  value="1: Object"
-                >
-                   01:00H 
-                </option>
-                <option
-                  value="2: Object"
-                >
-                   02:00H 
-                </option>
-                <option
-                  value="3: Object"
-                >
-                   03:00H 
-                </option>
-                <option
-                  value="4: Object"
-                >
-                   04:00H 
-                </option>
-                <option
-                  value="5: Object"
-                >
-                   05:00H 
-                </option>
-                <option
-                  value="6: Object"
-                >
-                   06:00H 
-                </option>
-                <option
-                  value="7: Object"
-                >
-                   07:00H 
-                </option>
-                <option
-                  value="8: Object"
-                >
-                   08:00H 
-                </option>
-                <option
-                  value="9: Object"
-                >
-                   09:00H 
-                </option>
-                <option
-                  value="10: Object"
-                >
-                   10:00H 
-                </option>
-                <option
-                  value="11: Object"
-                >
-                   11:00H 
-                </option>
-                <option
-                  value="12: Object"
-                >
-                   12:00H 
-                </option>
-                <option
-                  value="13: Object"
-                >
-                   13:00H 
-                </option>
-                <option
-                  value="14: Object"
-                >
-                   14:00H 
-                </option>
-                <option
-                  value="15: Object"
-                >
-                   15:00H 
-                </option>
-                <option
-                  value="16: Object"
-                >
-                   16:00H 
-                </option>
-                <option
-                  value="17: Object"
-                >
-                   17:00H 
-                </option>
-                <option
-                  value="18: Object"
-                >
-                   18:00H 
-                </option>
-                <option
-                  value="19: Object"
-                >
-                   19:00H 
-                </option>
-                <option
-                  value="20: Object"
-                >
-                   20:00H 
-                </option>
-                <option
-                  value="21: Object"
-                >
-                   21:00H 
-                </option>
-                <option
-                  value="22: Object"
-                >
-                   22:00H 
-                </option>
-                <option
-                  value="23: Object"
-                >
-                   23:00H 
-                </option>
-                <option
-                  value="0: Object"
-                >
-                  23:59H
-                </option>
-              </select>
-            </tm-timepicker>
+                <tm-datepicker>
+                  <div
+                    class="input-group"
+                  >
+                    <input
+                      aria-label="Date"
+                      class="form-control ng-untouched ng-pristine ng-valid"
+                      ngbdatepicker=""
+                      readonly=""
+                      type="text"
+                    />
+                    <button
+                      aria-label="Change date"
+                      class="btn btn-light input-group-text"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-calendar-alt"
+                      />
+                    </button>
+                  </div>
+                </tm-datepicker>
+                <tm-timepicker>
+                  <select
+                    aria-label="Select time"
+                    class="form-control form-select ng-untouched ng-pristine ng-valid"
+                  >
+                    <option
+                      value="1: Object"
+                    >
+                       01:00H 
+                    </option>
+                    <option
+                      value="2: Object"
+                    >
+                       02:00H 
+                    </option>
+                    <option
+                      value="3: Object"
+                    >
+                       03:00H 
+                    </option>
+                    <option
+                      value="4: Object"
+                    >
+                       04:00H 
+                    </option>
+                    <option
+                      value="5: Object"
+                    >
+                       05:00H 
+                    </option>
+                    <option
+                      value="6: Object"
+                    >
+                       06:00H 
+                    </option>
+                    <option
+                      value="7: Object"
+                    >
+                       07:00H 
+                    </option>
+                    <option
+                      value="8: Object"
+                    >
+                       08:00H 
+                    </option>
+                    <option
+                      value="9: Object"
+                    >
+                       09:00H 
+                    </option>
+                    <option
+                      value="10: Object"
+                    >
+                       10:00H 
+                    </option>
+                    <option
+                      value="11: Object"
+                    >
+                       11:00H 
+                    </option>
+                    <option
+                      value="12: Object"
+                    >
+                       12:00H 
+                    </option>
+                    <option
+                      value="13: Object"
+                    >
+                       13:00H 
+                    </option>
+                    <option
+                      value="14: Object"
+                    >
+                       14:00H 
+                    </option>
+                    <option
+                      value="15: Object"
+                    >
+                       15:00H 
+                    </option>
+                    <option
+                      value="16: Object"
+                    >
+                       16:00H 
+                    </option>
+                    <option
+                      value="17: Object"
+                    >
+                       17:00H 
+                    </option>
+                    <option
+                      value="18: Object"
+                    >
+                       18:00H 
+                    </option>
+                    <option
+                      value="19: Object"
+                    >
+                       19:00H 
+                    </option>
+                    <option
+                      value="20: Object"
+                    >
+                       20:00H 
+                    </option>
+                    <option
+                      value="21: Object"
+                    >
+                       21:00H 
+                    </option>
+                    <option
+                      value="22: Object"
+                    >
+                       22:00H 
+                    </option>
+                    <option
+                      value="23: Object"
+                    >
+                       23:00H 
+                    </option>
+                    <option
+                      value="0: Object"
+                    >
+                      23:59H
+                    </option>
+                  </select>
+                </tm-timepicker>
+              </tm-datetimepicker>
+            </div>
           </div>
         </div>
         <div
@@ -612,6 +653,7 @@ exports[`InstructorStudentActivityLogsComponent > should snap with default field
   course={[Function Object]}
   courseService={[Function _CourseService]}
   dateToday={[Function Object]}
+  datetimeService={[Function _DateTimeService]}
   earliestSearchDate={[Function Object]}
   feedbackSessions={[Function Map]}
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -672,6 +714,7 @@ exports[`InstructorStudentActivityLogsComponent > should snap with results of a 
   course={[Function Object]}
   courseService={[Function _CourseService]}
   dateToday={[Function Object]}
+  datetimeService={[Function _DateTimeService]}
   earliestSearchDate={[Function Object]}
   feedbackSessions={[Function Map]}
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -818,157 +861,165 @@ exports[`InstructorStudentActivityLogsComponent > should snap with results of a 
           </label>
           <div
             class="input-group"
+            id="logs-from-datepicker"
           >
             <div
-              class="input-group"
-              id="logs-from-datepicker"
-            >
-              <input
-                aria-label="Date to search from"
-                class="form-control ng-untouched ng-pristine ng-valid"
-                ngbdatepicker=""
-                readonly=""
-                type="text"
-              />
-              <button
-                aria-label="Change date"
-                class="btn btn-light"
-                type="button"
-              >
-                <i
-                  class="fas fa-calendar-alt"
-                />
-              </button>
-            </div>
-            <tm-timepicker
               id="logs-from-timepicker"
             >
-              <select
-                aria-label="Select time"
-                class="form-control form-select ng-untouched ng-pristine ng-valid"
+              <tm-datetimepicker
+                class="d-flex align-items-center gap-2"
               >
-                <option
-                  value="1: Object"
-                >
-                   01:00H 
-                </option>
-                <option
-                  value="2: Object"
-                >
-                   02:00H 
-                </option>
-                <option
-                  value="3: Object"
-                >
-                   03:00H 
-                </option>
-                <option
-                  value="4: Object"
-                >
-                   04:00H 
-                </option>
-                <option
-                  value="5: Object"
-                >
-                   05:00H 
-                </option>
-                <option
-                  value="6: Object"
-                >
-                   06:00H 
-                </option>
-                <option
-                  value="7: Object"
-                >
-                   07:00H 
-                </option>
-                <option
-                  value="8: Object"
-                >
-                   08:00H 
-                </option>
-                <option
-                  value="9: Object"
-                >
-                   09:00H 
-                </option>
-                <option
-                  value="10: Object"
-                >
-                   10:00H 
-                </option>
-                <option
-                  value="11: Object"
-                >
-                   11:00H 
-                </option>
-                <option
-                  value="12: Object"
-                >
-                   12:00H 
-                </option>
-                <option
-                  value="13: Object"
-                >
-                   13:00H 
-                </option>
-                <option
-                  value="14: Object"
-                >
-                   14:00H 
-                </option>
-                <option
-                  value="15: Object"
-                >
-                   15:00H 
-                </option>
-                <option
-                  value="16: Object"
-                >
-                   16:00H 
-                </option>
-                <option
-                  value="17: Object"
-                >
-                   17:00H 
-                </option>
-                <option
-                  value="18: Object"
-                >
-                   18:00H 
-                </option>
-                <option
-                  value="19: Object"
-                >
-                   19:00H 
-                </option>
-                <option
-                  value="20: Object"
-                >
-                   20:00H 
-                </option>
-                <option
-                  value="21: Object"
-                >
-                   21:00H 
-                </option>
-                <option
-                  value="22: Object"
-                >
-                   22:00H 
-                </option>
-                <option
-                  value="23: Object"
-                >
-                   23:00H 
-                </option>
-                <option
-                  value="0: Object"
-                >
-                  23:59H
-                </option>
-              </select>
-            </tm-timepicker>
+                <tm-datepicker>
+                  <div
+                    class="input-group"
+                  >
+                    <input
+                      aria-label="Date"
+                      class="form-control ng-untouched ng-pristine ng-valid"
+                      ngbdatepicker=""
+                      readonly=""
+                      type="text"
+                    />
+                    <button
+                      aria-label="Change date"
+                      class="btn btn-light input-group-text"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-calendar-alt"
+                      />
+                    </button>
+                  </div>
+                </tm-datepicker>
+                <tm-timepicker>
+                  <select
+                    aria-label="Select time"
+                    class="form-control form-select ng-untouched ng-pristine ng-valid"
+                  >
+                    <option
+                      value="1: Object"
+                    >
+                       01:00H 
+                    </option>
+                    <option
+                      value="2: Object"
+                    >
+                       02:00H 
+                    </option>
+                    <option
+                      value="3: Object"
+                    >
+                       03:00H 
+                    </option>
+                    <option
+                      value="4: Object"
+                    >
+                       04:00H 
+                    </option>
+                    <option
+                      value="5: Object"
+                    >
+                       05:00H 
+                    </option>
+                    <option
+                      value="6: Object"
+                    >
+                       06:00H 
+                    </option>
+                    <option
+                      value="7: Object"
+                    >
+                       07:00H 
+                    </option>
+                    <option
+                      value="8: Object"
+                    >
+                       08:00H 
+                    </option>
+                    <option
+                      value="9: Object"
+                    >
+                       09:00H 
+                    </option>
+                    <option
+                      value="10: Object"
+                    >
+                       10:00H 
+                    </option>
+                    <option
+                      value="11: Object"
+                    >
+                       11:00H 
+                    </option>
+                    <option
+                      value="12: Object"
+                    >
+                       12:00H 
+                    </option>
+                    <option
+                      value="13: Object"
+                    >
+                       13:00H 
+                    </option>
+                    <option
+                      value="14: Object"
+                    >
+                       14:00H 
+                    </option>
+                    <option
+                      value="15: Object"
+                    >
+                       15:00H 
+                    </option>
+                    <option
+                      value="16: Object"
+                    >
+                       16:00H 
+                    </option>
+                    <option
+                      value="17: Object"
+                    >
+                       17:00H 
+                    </option>
+                    <option
+                      value="18: Object"
+                    >
+                       18:00H 
+                    </option>
+                    <option
+                      value="19: Object"
+                    >
+                       19:00H 
+                    </option>
+                    <option
+                      value="20: Object"
+                    >
+                       20:00H 
+                    </option>
+                    <option
+                      value="21: Object"
+                    >
+                       21:00H 
+                    </option>
+                    <option
+                      value="22: Object"
+                    >
+                       22:00H 
+                    </option>
+                    <option
+                      value="23: Object"
+                    >
+                       23:00H 
+                    </option>
+                    <option
+                      value="0: Object"
+                    >
+                      23:59H
+                    </option>
+                  </select>
+                </tm-timepicker>
+              </tm-datetimepicker>
+            </div>
           </div>
         </div>
         <div
@@ -982,158 +1033,165 @@ exports[`InstructorStudentActivityLogsComponent > should snap with results of a 
           </label>
           <div
             class="input-group"
+            id="logs-to-datepicker"
           >
             <div
-              class="input-group"
-              id="logs-to-datepicker"
-            >
-              <input
-                aria-label="Date to search until"
-                class="form-control ng-untouched ng-pristine ng-valid"
-                ngbdatepicker=""
-                readonly=""
-                type="text"
-              />
-              <button
-                aria-label="Change date"
-                class="btn btn-light"
-                type="button"
-              >
-                <i
-                  class="fas fa-calendar-alt"
-                />
-              </button>
-            </div>
-            <tm-timepicker
-              aria-label="Search period until time"
               id="logs-to-timepicker"
             >
-              <select
-                aria-label="Select time"
-                class="form-control form-select ng-untouched ng-pristine ng-valid"
+              <tm-datetimepicker
+                class="d-flex align-items-center gap-2"
               >
-                <option
-                  value="1: Object"
-                >
-                   01:00H 
-                </option>
-                <option
-                  value="2: Object"
-                >
-                   02:00H 
-                </option>
-                <option
-                  value="3: Object"
-                >
-                   03:00H 
-                </option>
-                <option
-                  value="4: Object"
-                >
-                   04:00H 
-                </option>
-                <option
-                  value="5: Object"
-                >
-                   05:00H 
-                </option>
-                <option
-                  value="6: Object"
-                >
-                   06:00H 
-                </option>
-                <option
-                  value="7: Object"
-                >
-                   07:00H 
-                </option>
-                <option
-                  value="8: Object"
-                >
-                   08:00H 
-                </option>
-                <option
-                  value="9: Object"
-                >
-                   09:00H 
-                </option>
-                <option
-                  value="10: Object"
-                >
-                   10:00H 
-                </option>
-                <option
-                  value="11: Object"
-                >
-                   11:00H 
-                </option>
-                <option
-                  value="12: Object"
-                >
-                   12:00H 
-                </option>
-                <option
-                  value="13: Object"
-                >
-                   13:00H 
-                </option>
-                <option
-                  value="14: Object"
-                >
-                   14:00H 
-                </option>
-                <option
-                  value="15: Object"
-                >
-                   15:00H 
-                </option>
-                <option
-                  value="16: Object"
-                >
-                   16:00H 
-                </option>
-                <option
-                  value="17: Object"
-                >
-                   17:00H 
-                </option>
-                <option
-                  value="18: Object"
-                >
-                   18:00H 
-                </option>
-                <option
-                  value="19: Object"
-                >
-                   19:00H 
-                </option>
-                <option
-                  value="20: Object"
-                >
-                   20:00H 
-                </option>
-                <option
-                  value="21: Object"
-                >
-                   21:00H 
-                </option>
-                <option
-                  value="22: Object"
-                >
-                   22:00H 
-                </option>
-                <option
-                  value="23: Object"
-                >
-                   23:00H 
-                </option>
-                <option
-                  value="0: Object"
-                >
-                  23:59H
-                </option>
-              </select>
-            </tm-timepicker>
+                <tm-datepicker>
+                  <div
+                    class="input-group"
+                  >
+                    <input
+                      aria-label="Date"
+                      class="form-control ng-untouched ng-pristine ng-valid"
+                      ngbdatepicker=""
+                      readonly=""
+                      type="text"
+                    />
+                    <button
+                      aria-label="Change date"
+                      class="btn btn-light input-group-text"
+                      type="button"
+                    >
+                      <i
+                        class="fas fa-calendar-alt"
+                      />
+                    </button>
+                  </div>
+                </tm-datepicker>
+                <tm-timepicker>
+                  <select
+                    aria-label="Select time"
+                    class="form-control form-select ng-untouched ng-pristine ng-valid"
+                  >
+                    <option
+                      value="1: Object"
+                    >
+                       01:00H 
+                    </option>
+                    <option
+                      value="2: Object"
+                    >
+                       02:00H 
+                    </option>
+                    <option
+                      value="3: Object"
+                    >
+                       03:00H 
+                    </option>
+                    <option
+                      value="4: Object"
+                    >
+                       04:00H 
+                    </option>
+                    <option
+                      value="5: Object"
+                    >
+                       05:00H 
+                    </option>
+                    <option
+                      value="6: Object"
+                    >
+                       06:00H 
+                    </option>
+                    <option
+                      value="7: Object"
+                    >
+                       07:00H 
+                    </option>
+                    <option
+                      value="8: Object"
+                    >
+                       08:00H 
+                    </option>
+                    <option
+                      value="9: Object"
+                    >
+                       09:00H 
+                    </option>
+                    <option
+                      value="10: Object"
+                    >
+                       10:00H 
+                    </option>
+                    <option
+                      value="11: Object"
+                    >
+                       11:00H 
+                    </option>
+                    <option
+                      value="12: Object"
+                    >
+                       12:00H 
+                    </option>
+                    <option
+                      value="13: Object"
+                    >
+                       13:00H 
+                    </option>
+                    <option
+                      value="14: Object"
+                    >
+                       14:00H 
+                    </option>
+                    <option
+                      value="15: Object"
+                    >
+                       15:00H 
+                    </option>
+                    <option
+                      value="16: Object"
+                    >
+                       16:00H 
+                    </option>
+                    <option
+                      value="17: Object"
+                    >
+                       17:00H 
+                    </option>
+                    <option
+                      value="18: Object"
+                    >
+                       18:00H 
+                    </option>
+                    <option
+                      value="19: Object"
+                    >
+                       19:00H 
+                    </option>
+                    <option
+                      value="20: Object"
+                    >
+                       20:00H 
+                    </option>
+                    <option
+                      value="21: Object"
+                    >
+                       21:00H 
+                    </option>
+                    <option
+                      value="22: Object"
+                    >
+                       22:00H 
+                    </option>
+                    <option
+                      value="23: Object"
+                    >
+                       23:00H 
+                    </option>
+                    <option
+                      value="0: Object"
+                    >
+                      23:59H
+                    </option>
+                  </select>
+                </tm-timepicker>
+              </tm-datetimepicker>
+            </div>
           </div>
         </div>
         <div

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.html
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.html
@@ -55,50 +55,30 @@
     <div class="row form-group">
       <div class="col-6">
         <label for="logs-from-datepicker" class="fw-bold">Search period from</label>
-        <div class="input-group">
-          <div id="logs-from-datepicker" class="input-group">
-            <input
-              type="text"
-              class="form-control"
-              ngbDatepicker
-              readonly
-              [minDate]="earliestSearchDate"
-              [maxDate]="formModel.logsDateTo"
-              [(ngModel)]="formModel.logsDateFrom"
-              #logsFromDp="ngbDatepicker"
-              aria-label="Date to search from"
-            />
-            <button class="btn btn-light" aria-label="Change date" (click)="logsFromDp.toggle()" type="button">
-              <i class="fas fa-calendar-alt"></i>
-            </button>
+        <div id="logs-from-datepicker" class="input-group">
+          <div id="logs-from-timepicker">
+            <tm-datetimepicker
+              class="d-flex align-items-center gap-2"
+              [dateTime]="logsDateTimeFrom"
+              [minDateTime]="earliestSearchDateTime"
+              [maxDateTime]="logsDateTimeTo"
+              (dateTimeChange)="triggerDateTimeModelChange('logsDateFrom', 'logsTimeFrom', $event)"
+            ></tm-datetimepicker>
           </div>
-          <tm-timepicker id="logs-from-timepicker" [(time)]="formModel.logsTimeFrom"></tm-timepicker>
         </div>
       </div>
       <div class="col-6">
         <label for="logs-to-datepicker" class="fw-bold">Search period until</label>
-        <div class="input-group">
-          <div id="logs-to-datepicker" class="input-group">
-            <input
-              type="text"
-              class="form-control"
-              ngbDatepicker
-              readonly
-              [minDate]="formModel.logsDateFrom"
-              [maxDate]="dateToday"
-              [(ngModel)]="formModel.logsDateTo"
-              #logsToDp="ngbDatepicker"
-              aria-label="Date to search until"
-            />
-            <button class="btn btn-light" aria-label="Change date" (click)="logsToDp.toggle()" type="button">
-              <i class="fas fa-calendar-alt"></i>
-            </button>
+        <div id="logs-to-datepicker" class="input-group">
+          <div id="logs-to-timepicker">
+            <tm-datetimepicker
+              class="d-flex align-items-center gap-2"
+              [dateTime]="logsDateTimeTo"
+              [minDateTime]="logsDateTimeFrom"
+              [maxDateTime]="dateTodayDateTime"
+              (dateTimeChange)="triggerDateTimeModelChange('logsDateTo', 'logsTimeTo', $event)"
+            ></tm-datetimepicker>
           </div>
-          <tm-timepicker
-            id="logs-to-timepicker"
-            [(time)]="formModel.logsTimeTo"
-            aria-label="Search period until time"
-          ></tm-timepicker>
         </div>
       </div>
       <div class="col-12">

--- a/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-activity-logs/instructor-student-activity-logs.component.ts
@@ -2,9 +2,10 @@ import { NgClass, KeyValuePipe } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { NgbDateParserFormatter, NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
+import { NgbDateParserFormatter } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { finalize } from 'rxjs/operators';
 import { CourseService } from '../../../services/course.service';
+import { DateTimeService } from '../../../services/datetime.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { LogService } from '../../../services/log.service';
 import { StatusMessageService } from '../../../services/status-message.service';
@@ -32,6 +33,7 @@ import {
 import { castAsInputElement } from '../../../types/event-target-caster';
 import { SortBy } from '../../../types/sort-properties';
 import { DatePickerFormatter } from '../../components/datepicker/datepicker-formatter';
+import { DatetimepickerComponent } from '../../components/datetimepicker/datetimepicker.component';
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
 import { PanelChevronComponent } from '../../components/panel-chevron/panel-chevron.component';
 import {
@@ -39,7 +41,6 @@ import {
   SortableTableCellData,
   SortableTableComponent,
 } from '../../components/sortable-table/sortable-table.component';
-import { TimepickerComponent } from '../../components/timepicker/timepicker.component';
 import { ErrorMessageOutput } from '../../error-message-output';
 
 /**
@@ -92,8 +93,7 @@ interface FeedbackSessionLogModel {
   imports: [
     LoadingSpinnerDirective,
     FormsModule,
-    NgbInputDatepicker,
-    TimepickerComponent,
+    DatetimepickerComponent,
     NgClass,
     PanelChevronComponent,
     SortableTableComponent,
@@ -108,6 +108,7 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
   private logsService = inject(LogService);
   private timezoneService = inject(TimezoneService);
   private statusMessageService = inject(StatusMessageService);
+  private datetimeService = inject(DateTimeService);
 
   readonly castAsInputElement = castAsInputElement;
 
@@ -152,6 +153,37 @@ export class InstructorStudentActivityLogsComponent implements OnInit {
 
   constructor() {
     this.SortBy = SortBy;
+  }
+
+  get logsDateTimeFrom(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.formModel.logsDateFrom,
+      this.formModel.logsTimeFrom,
+    );
+  }
+
+  get logsDateTimeTo(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(
+      this.formModel.logsDateTo,
+      this.formModel.logsTimeTo,
+    );
+  }
+
+  get earliestSearchDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(this.earliestSearchDate, getDefaultTimeFormat());
+  }
+
+  get dateTodayDateTime(): Date {
+    return this.datetimeService.convertDateFormatAndTimeFormatToDate(this.dateToday, getLatestTimeFormat());
+  }
+
+  triggerDateTimeModelChange(dateField: string, timeField: string, dateTime: Date): void {
+    const [date, time] = this.datetimeService.convertDateToDateFormatAndTimeFormat(dateTime);
+    this.formModel = {
+      ...this.formModel,
+      [dateField]: date,
+      [timeField]: time,
+    };
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
Fixes #13870

**Outline of Solution**

Added a reusable `tm-datetimepicker` component that combines the existing datepicker and timepicker while keeping `Date` as the public input/output API.

Replaced paired date/time picker usages in feedback session edit forms, admin notification edit form, individual extension modal, and instructor student activity logs.

Existing Selenium/test anchors are preserved on caller-owned wrappers so page objects can still locate descendant inputs/buttons/selects.

Handled the individual extension modal's deadline initialization when the modal component is assigned inputs dynamically.

Note: most of this PR's line count is from updated snapshot files. Excluding snapshots, the implementation diff is much smaller.

**Verification**

- `npm run lint`
- `npm run coverage`
- `npm run build`
- GitHub Actions: Component Tests, Accessibility Tests, E2E Tests, API Type Definitions Check, Build Developer Guide, and Snyk all pass.