### PR TITLE
[#13721] Simplify GetNotificationsAction

### DIFF
--- a/src/it/java/teammates/it/storage/api/NotificationDbIT.java
+++ b/src/it/java/teammates/it/storage/api/NotificationDbIT.java
@@ -118,7 +118,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: get active notifications with target user GENERAL");
         List<Notification> actualNotifications =
-                notificationsDb.getActiveNotificationsByTargetUsers(List.of(NotificationTargetUser.GENERAL));
+                notificationsDb.getNotificationsByTargetUsers(List.of(NotificationTargetUser.GENERAL), true);
         List<Notification> expectedNotifications = List.of(n4, n1);
         assertEquals(expectedNotifications.size(), actualNotifications.size());
         Iterator<Notification> it1 = expectedNotifications.iterator();
@@ -127,8 +127,8 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
         });
 
         ______TS("success: get active notifications with target users INSTRUCTOR and GENERAL");
-        actualNotifications = notificationsDb.getActiveNotificationsByTargetUsers(
-                List.of(NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL));
+        actualNotifications = notificationsDb.getNotificationsByTargetUsers(
+                List.of(NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL), true);
         expectedNotifications = List.of(n4, n2, n1);
         assertEquals(expectedNotifications.size(), actualNotifications.size());
         Iterator<Notification> it2 = expectedNotifications.iterator();
@@ -137,8 +137,8 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
         });
 
         ______TS("success: get active notifications with target user INSTRUCTOR only");
-        actualNotifications = notificationsDb.getActiveNotificationsByTargetUsers(
-                List.of(NotificationTargetUser.INSTRUCTOR));
+        actualNotifications = notificationsDb.getNotificationsByTargetUsers(
+                List.of(NotificationTargetUser.INSTRUCTOR), true);
         expectedNotifications = List.of(n2);
         assertEquals(expectedNotifications.size(), actualNotifications.size());
         Iterator<Notification> it3 = expectedNotifications.iterator();

--- a/src/it/java/teammates/it/storage/api/NotificationDbIT.java
+++ b/src/it/java/teammates/it/storage/api/NotificationDbIT.java
@@ -137,9 +137,9 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
             notificationsDb.createNotification(n);
         }
 
-        ______TS("success: get active notification with target user GENERAL");
+        ______TS("success: get active notifications with target user GENERAL");
         List<Notification> actualNotifications =
-                notificationsDb.getActiveNotificationsByTargetUser(NotificationTargetUser.GENERAL);
+                notificationsDb.getActiveNotificationsByTargetUsers(List.of(NotificationTargetUser.GENERAL));
         List<Notification> expectedNotifications = List.of(n4, n1);
         assertEquals(expectedNotifications.size(), actualNotifications.size());
         Iterator<Notification> it1 = expectedNotifications.iterator();
@@ -147,13 +147,24 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
             verifyEquals(it1.next(), actual);
         });
 
-        ______TS("success: get active notification with target user INSTRUCTOR");
-        actualNotifications = notificationsDb.getActiveNotificationsByTargetUser(NotificationTargetUser.INSTRUCTOR);
+        ______TS("success: get active notifications with target users INSTRUCTOR and GENERAL");
+        actualNotifications = notificationsDb.getActiveNotificationsByTargetUsers(
+                List.of(NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL));
         expectedNotifications = List.of(n4, n2, n1);
         assertEquals(expectedNotifications.size(), actualNotifications.size());
         Iterator<Notification> it2 = expectedNotifications.iterator();
         actualNotifications.forEach(actual -> {
             verifyEquals(it2.next(), actual);
+        });
+
+        ______TS("success: get active notifications with target user INSTRUCTOR only");
+        actualNotifications = notificationsDb.getActiveNotificationsByTargetUsers(
+                List.of(NotificationTargetUser.INSTRUCTOR));
+        expectedNotifications = List.of(n2);
+        assertEquals(expectedNotifications.size(), actualNotifications.size());
+        Iterator<Notification> it3 = expectedNotifications.iterator();
+        actualNotifications.forEach(actual -> {
+            verifyEquals(it3.next(), actual);
         });
     }
 

--- a/src/it/java/teammates/it/storage/api/NotificationDbIT.java
+++ b/src/it/java/teammates/it/storage/api/NotificationDbIT.java
@@ -13,7 +13,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
-import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.it.test.BaseTestCaseWithDatabaseAccess;
 import teammates.storage.api.NotificationsDb;
 import teammates.storage.entity.Notification;
@@ -26,7 +25,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
     private final NotificationsDb notificationsDb = NotificationsDb.inst();
 
     @Test
-    public void testCreateNotification() throws EntityAlreadyExistsException {
+    public void testCreateNotification() {
         ______TS("success: create notification that does not exist");
         Notification newNotification = generateTypicalNotification();
 
@@ -38,7 +37,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testGetNotification() throws EntityAlreadyExistsException {
+    public void testGetNotification() {
         ______TS("success: get a notification that already exists");
         Notification newNotification = generateTypicalNotification();
 
@@ -55,7 +54,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testDeleteNotification() throws EntityAlreadyExistsException {
+    public void testDeleteNotification() {
         ______TS("success: delete a notification that already exists");
         Notification notification = generateTypicalNotification();
 
@@ -68,27 +67,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testGetAllNotifications() throws EntityAlreadyExistsException {
-        ______TS("success: no notification present in the database");
-        List<Notification> allNotifications = notificationsDb.getAllNotifications();
-        assertEquals(0, allNotifications.size());
-
-        ______TS("success: multiple notifications present in the database");
-        Notification n1 = generateTypicalNotification();
-        Notification n2 = generateTypicalNotification();
-
-        notificationsDb.createNotification(n1);
-        notificationsDb.createNotification(n2);
-
-        allNotifications = notificationsDb.getAllNotifications();
-
-        assertEquals(2, allNotifications.size());
-        verifyEquals(n1, allNotifications.get(0));
-        verifyEquals(n2, allNotifications.get(1));
-    }
-
-    @Test
-    public void testGetActiveNotificationsByTargetUser() throws EntityAlreadyExistsException {
+    public void testGetActiveNotificationsByTargetUser() {
         Notification n1 = new Notification(
                 Instant.parse("2011-01-04T00:00:00Z"),
                 Instant.parse("2099-01-01T00:00:00Z"),

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -175,7 +175,6 @@ public final class Const {
 
         public static final String NOTIFICATION_ID = "notificationid";
         public static final String NOTIFICATION_TARGET_USER = "usertype";
-        public static final String NOTIFICATION_IS_FETCHING_ALL = "isfetchingall";
     }
 
     /**

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -175,6 +175,7 @@ public final class Const {
 
         public static final String NOTIFICATION_ID = "notificationid";
         public static final String NOTIFICATION_TARGET_USER = "usertype";
+        public static final String NOTIFICATION_IS_FETCHING_ACTIVE = "isfetchingactive";
     }
 
     /**

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -13,10 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
-import java.util.stream.Collectors;
 
-import teammates.common.datatransfer.NotificationStyle;
-import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
 import teammates.common.datatransfer.participanttypes.ViewerType;
@@ -60,25 +57,7 @@ public final class FieldValidator {
     public static final String NOTIFICATION_NAME = "notification";
     public static final String NOTIFICATION_VISIBLE_TIME_FIELD_NAME = "time when the notification will be visible";
     public static final String NOTIFICATION_EXPIRY_TIME_FIELD_NAME = "time when the notification will expire";
-    public static final String NOTIFICATION_STYLE_FIELD_NAME = "notification style";
-    public static final String NOTIFICATION_TARGET_USER_FIELD_NAME = "notification target user";
     public static final int NOTIFICATION_TITLE_MAX_LENGTH = 80;
-
-    public static final List<String> NOTIFICATION_STYLE_ACCEPTED_VALUES =
-            Collections.unmodifiableList(
-                    Arrays.stream(
-                            NotificationStyle.values())
-                            .map(NotificationStyle::toString)
-                            .collect(Collectors.toList())
-            );
-
-    public static final List<String> NOTIFICATION_TARGET_USER_ACCEPTED_VALUES =
-            Collections.unmodifiableList(
-                    Arrays.stream(
-                            NotificationTargetUser.values())
-                            .map(NotificationTargetUser::toString)
-                            .collect(Collectors.toList())
-            );
 
     // others
     public static final String STUDENT_ROLE_COMMENTS_FIELD_NAME = "comments about a student enrolled in a course";
@@ -218,12 +197,6 @@ public final class FieldValidator {
 
     public static final String ROLE_ERROR_MESSAGE =
             "\"%s\" is not an accepted " + ROLE_FIELD_NAME + " to TEAMMATES. ";
-
-    public static final String NOTIFICATION_STYLE_ERROR_MESSAGE =
-            "\"%s\" is not an accepted " + NOTIFICATION_STYLE_FIELD_NAME + " to TEAMMATES. ";
-
-    public static final String NOTIFICATION_TARGET_USER_ERROR_MESSAGE =
-            "\"%s\" is not an accepted " + NOTIFICATION_TARGET_USER_FIELD_NAME + " to TEAMMATES. ";
 
     public static final String SESSION_VISIBLE_TIME_FIELD_NAME = "time when the session will be visible";
     public static final String RESULTS_VISIBLE_TIME_FIELD_NAME = "time when the results will be visible";
@@ -581,39 +554,6 @@ public final class FieldValidator {
             return getPopulatedEmptyStringErrorMessage(EMPTY_STRING_ERROR_INFO, NOTIFICATION_MESSAGE_FIELD_NAME, 0);
         }
 
-        return "";
-    }
-
-    /**
-     * Checks if {@code style} is one of the recognized notification style {@link #NOTIFICATION_STYLE_ACCEPTED_VALUES}.
-     *
-     * @return An explanation of why the {@code style} is not acceptable.
-     *         Returns an empty string if the {@code style} is acceptable.
-     */
-    public static String getInvalidityInfoForNotificationStyle(String style) {
-        assert style != null;
-        try {
-            NotificationStyle.valueOf(style);
-        } catch (IllegalArgumentException e) {
-            return String.format(NOTIFICATION_STYLE_ERROR_MESSAGE, style);
-        }
-        return "";
-    }
-
-    /**
-     * Checks if {@code targetUser} is one of the
-     * recognized notification target user groups {@link #NOTIFICATION_TARGET_USER_ACCEPTED_VALUES}.
-     *
-     * @return An explanation of why the {@code targetUser} is not acceptable.
-     *         Returns an empty string if the {@code targetUser} is acceptable.
-     */
-    public static String getInvalidityInfoForNotificationTargetUser(String targetUser) {
-        assert targetUser != null;
-        try {
-            NotificationTargetUser.valueOf(targetUser);
-        } catch (IllegalArgumentException e) {
-            return String.format(NOTIFICATION_TARGET_USER_ERROR_MESSAGE, targetUser);
-        }
         return "";
     }
 

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1122,10 +1122,11 @@ public class Logic {
     }
 
     /**
-     * Returns all notifications for the specified {@code targetUsers}.
+     * Returns notifications for the specified {@code targetUsers}.
      */
-    public List<Notification> getNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
-        return notificationsLogic.getNotificationsByTargetUsers(targetUsers);
+    public List<Notification> getNotificationsByTargetUsers(
+            List<NotificationTargetUser> targetUsers, boolean isActive) {
+        return notificationsLogic.getNotificationsByTargetUsers(targetUsers, isActive);
     }
 
     /**
@@ -1165,13 +1166,6 @@ public class Logic {
         assert instructorToEdit != null;
 
         usersLogic.updateToEnsureValidityOfInstructorsForTheCourse(courseId, instructorToEdit);
-    }
-
-    /**
-     * Returns active notifications for the specified {@code targetUsers}.
-     */
-    public List<Notification> getActiveNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
-        return notificationsLogic.getActiveNotificationsByTargetUsers(targetUsers);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1121,8 +1121,11 @@ public class Logic {
         usersLogic.deleteInstructorCascade(userId);
     }
 
-    public List<Notification> getAllNotifications() {
-        return notificationsLogic.getAllNotifications();
+    /**
+     * Returns all notifications for the specified {@code targetUsers}.
+     */
+    public List<Notification> getNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
+        return notificationsLogic.getNotificationsByTargetUsers(targetUsers);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1122,11 +1122,15 @@ public class Logic {
     }
 
     /**
-     * Returns notifications for the specified {@code targetUsers}.
+     * Gets a list of notifications.
+     *
+     * @return a list of notifications with the specified {@code targetUsers}.
+     *         If {@code isActiveOnly} is true, only active notifications are returned.
+     *         Otherwise, all notifications for the specified {@code targetUsers} are returned.
      */
     public List<Notification> getNotificationsByTargetUsers(
-            List<NotificationTargetUser> targetUsers, boolean isActive) {
-        return notificationsLogic.getNotificationsByTargetUsers(targetUsers, isActive);
+            List<NotificationTargetUser> targetUsers, boolean isActiveOnly) {
+        return notificationsLogic.getNotificationsByTargetUsers(targetUsers, isActiveOnly);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1165,19 +1165,10 @@ public class Logic {
     }
 
     /**
-     * Returns active notification for general users and the specified
-     * {@code targetUser}.
+     * Returns active notifications for the specified {@code targetUsers}.
      */
-    public List<Notification> getActiveNotificationsByTargetUser(NotificationTargetUser targetUser) {
-        return notificationsLogic.getActiveNotificationsByTargetUser(targetUser);
-    }
-
-    /**
-     * Returns active unread notifications for the specified {@code targetUsers} and {@code accountId}.
-     */
-    public List<Notification> getUnreadActiveNotificationsByTargetUser(
-            List<NotificationTargetUser> targetUsers, UUID accountId, Instant now) {
-        return notificationsLogic.getUnreadActiveNotificationsByTargetUser(targetUsers, accountId, now);
+    public List<Notification> getActiveNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
+        return notificationsLogic.getActiveNotificationsByTargetUsers(targetUsers);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -124,19 +124,10 @@ public final class NotificationsLogic {
      *
      * @return a list of notifications with the specified {@code targetUsers}.
      */
-    public List<Notification> getNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
+    public List<Notification> getNotificationsByTargetUsers(
+            List<NotificationTargetUser> targetUsers, boolean isActive) {
         Objects.requireNonNull(targetUsers);
-        return notificationsDb.getNotificationsByTargetUsers(targetUsers);
-    }
-
-    /**
-     * Gets a list of notifications.
-     *
-     * @return a list of notifications with the specified {@code targetUsers}.
-     */
-    public List<Notification> getActiveNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
-        Objects.requireNonNull(targetUsers);
-        return notificationsDb.getActiveNotificationsByTargetUsers(targetUsers);
+        return notificationsDb.getNotificationsByTargetUsers(targetUsers, isActive);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -120,10 +120,13 @@ public final class NotificationsLogic {
     }
 
     /**
-     * Gets all notifications.
+     * Gets a list of notifications.
+     *
+     * @return a list of notifications with the specified {@code targetUsers}.
      */
-    public List<Notification> getAllNotifications() {
-        return notificationsDb.getAllNotifications();
+    public List<Notification> getNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
+        Objects.requireNonNull(targetUsers);
+        return notificationsDb.getNotificationsByTargetUsers(targetUsers);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -4,6 +4,7 @@ import static teammates.common.util.Const.ERROR_UPDATE_NON_EXISTENT;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import teammates.common.datatransfer.NotificationStyle;
@@ -128,28 +129,18 @@ public final class NotificationsLogic {
     /**
      * Gets a list of notifications.
      *
-     * @return a list of notifications with the specified {@code targetUser}.
+     * @return a list of notifications with the specified {@code targetUsers}.
      */
-    public List<Notification> getActiveNotificationsByTargetUser(NotificationTargetUser targetUser) {
-        assert targetUser != null;
-        return notificationsDb.getActiveNotificationsByTargetUser(targetUser);
-    }
-
-    /**
-     * Returns active unread notifications for the specified {@code targetUsers} and {@code accountId}.
-     */
-    public List<Notification> getUnreadActiveNotificationsByTargetUser(
-            List<NotificationTargetUser> targetUsers, UUID accountId, Instant now) {
-        assert targetUsers != null;
-        assert accountId != null;
-        return notificationsDb.getUnreadActiveNotificationsByTargetUser(targetUsers, accountId, now);
+    public List<Notification> getActiveNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
+        Objects.requireNonNull(targetUsers);
+        return notificationsDb.getActiveNotificationsByTargetUsers(targetUsers);
     }
 
     /**
      * Gets a list of notifications that have been read by the account with {@code accountId}.
      */
     public List<ReadNotification> getReadNotificationsByAccountId(UUID accountId) {
-        assert accountId != null;
+        Objects.requireNonNull(accountId);
         return notificationsDb.getReadNotificationsByAccountId(accountId);
     }
 

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -122,7 +122,7 @@ public final class NotificationsLogic {
     /**
      * Gets a list of notifications.
      *
-     * @return a list of notifications with the specified {@code targetUsers}.
+     * @return a list of notifications with the specified {@code targetUsers} and active status.
      */
     public List<Notification> getNotificationsByTargetUsers(
             List<NotificationTargetUser> targetUsers, boolean isActive) {

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -122,12 +122,14 @@ public final class NotificationsLogic {
     /**
      * Gets a list of notifications.
      *
-     * @return a list of notifications with the specified {@code targetUsers} and active status.
+     * @return a list of notifications with the specified {@code targetUsers}.
+     *         If {@code isActiveOnly} is true, only active notifications are returned.
+     *         Otherwise, all notifications for the specified {@code targetUsers} are returned.
      */
     public List<Notification> getNotificationsByTargetUsers(
-            List<NotificationTargetUser> targetUsers, boolean isActive) {
+            List<NotificationTargetUser> targetUsers, boolean isActiveOnly) {
         Objects.requireNonNull(targetUsers);
-        return notificationsDb.getNotificationsByTargetUsers(targetUsers, isActive);
+        return notificationsDb.getNotificationsByTargetUsers(targetUsers, isActiveOnly);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -74,50 +74,19 @@ public final class NotificationsDb {
     }
 
     /**
-     * Gets notifications by {@code targetUser}.
+     * Gets notifications by {@code targetUsers}.
      *
-     * @return a list of notifications for the specified targetUser.
+     * @return a list of notifications for the specified targetUsers.
      */
-    public List<Notification> getActiveNotificationsByTargetUser(NotificationTargetUser targetUser) {
+    public List<Notification> getActiveNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
         Root<Notification> root = cq.from(Notification.class);
-        cq.select(root)
-                .where(cb.and(
-                        cb.or(cb.equal(root.get("targetUser"), targetUser),
-                                cb.equal(root.get("targetUser"), NotificationTargetUser.GENERAL)),
-                        cb.lessThanOrEqualTo(root.get("startTime"), Instant.now()),
-                        cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now())))
-                .orderBy(cb.asc(root.get("startTime")));
-        TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
-        return query.getResultList();
-    }
-
-    /**
-     * Gets active notifications by {@code targetUser} that have not been read by the account
-     * with the given {@code accountId}.
-     *
-     * @return a list of unread active notifications for the specified targetUser and account.
-     */
-    public List<Notification> getUnreadActiveNotificationsByTargetUser(
-            List<NotificationTargetUser> targetUsers, UUID accountId, Instant now) {
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
-        Root<Notification> root = cq.from(Notification.class);
-
-        Subquery<Integer> subquery = cq.subquery(Integer.class);
-        Root<ReadNotification> readRoot = subquery.from(ReadNotification.class);
-        subquery.select(cb.literal(1))
-                .where(cb.and(
-                        cb.equal(readRoot.get("notification").get("id"), root.get("id")),
-                        cb.equal(readRoot.get("account").get("id"), accountId)));
-
         cq.select(root)
                 .where(cb.and(
                         root.get("targetUser").in(targetUsers),
-                        cb.lessThanOrEqualTo(root.get("startTime"), now),
-                        cb.greaterThanOrEqualTo(root.get("endTime"), now),
-                        cb.not(cb.exists(subquery))))
+                        cb.lessThanOrEqualTo(root.get("startTime"), Instant.now()),
+                        cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now())))
                 .orderBy(cb.asc(root.get("startTime")));
         TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
         return query.getResultList();

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -65,32 +65,25 @@ public final class NotificationsDb {
      *
      * @return a list of notifications for the specified targetUsers.
      */
-    public List<Notification> getNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
+    public List<Notification> getNotificationsByTargetUsers(
+            List<NotificationTargetUser> targetUsers, boolean isActive) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
         Root<Notification> root = cq.from(Notification.class);
-        cq.select(root)
-                .where(root.get("targetUser").in(targetUsers))
-                .orderBy(cb.asc(root.get("startTime")));
-        TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
-        return query.getResultList();
-    }
 
-    /**
-     * Gets notifications by {@code targetUsers}.
-     *
-     * @return a list of notifications for the specified targetUsers.
-     */
-    public List<Notification> getActiveNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
-        Root<Notification> root = cq.from(Notification.class);
-        cq.select(root)
-                .where(cb.and(
-                        root.get("targetUser").in(targetUsers),
-                        cb.lessThanOrEqualTo(root.get("startTime"), Instant.now()),
-                        cb.greaterThanOrEqualTo(root.get("endTime"), Instant.now())))
-                .orderBy(cb.asc(root.get("startTime")));
+        if (isActive) {
+            Instant now = Instant.now();
+            cq.select(root)
+                    .where(cb.and(
+                            root.get("targetUser").in(targetUsers),
+                            cb.lessThanOrEqualTo(root.get("startTime"), now),
+                            cb.greaterThanOrEqualTo(root.get("endTime"), now)));
+        } else {
+            cq.select(root)
+                    .where(root.get("targetUser").in(targetUsers));
+        }
+
+        cq.orderBy(cb.asc(root.get("startTime")));
         TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
         return query.getResultList();
     }

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -61,9 +61,12 @@ public final class NotificationsDb {
     }
 
     /**
-     * Gets all notifications by {@code targetUsers}.
+     * Gets all notifications by {@code targetUsers} for the specified active status.
      *
-     * @return a list of notifications for the specified targetUsers.
+     * <p>An active notification is a notification that is currently being displayed to users,
+     * i.e. the current time is between the notification's start and end time.
+     *
+     * @return a list of notifications for the specified targetUsers for the specified active status.
      */
     public List<Notification> getNotificationsByTargetUsers(
             List<NotificationTargetUser> targetUsers, boolean isActive) {

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -61,20 +61,22 @@ public final class NotificationsDb {
     }
 
     /**
-     * Gets all notifications by {@code targetUsers} for the specified active status.
+     * Gets all notifications by {@code targetUsers}.
      *
      * <p>An active notification is a notification that is currently being displayed to users,
      * i.e. the current time is between the notification's start and end time.
      *
-     * @return a list of notifications for the specified targetUsers for the specified active status.
+     * @return a list of notifications for the specified targetUsers.
+     *         If isActiveOnly is true, only active notifications are returned.
+     *         Otherwise, all notifications for the specified targetUsers are returned.
      */
     public List<Notification> getNotificationsByTargetUsers(
-            List<NotificationTargetUser> targetUsers, boolean isActive) {
+            List<NotificationTargetUser> targetUsers, boolean isActiveOnly) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
         Root<Notification> root = cq.from(Notification.class);
 
-        if (isActive) {
+        if (isActiveOnly) {
             Instant now = Instant.now();
             cq.select(root)
                     .where(cb.and(

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -8,7 +8,6 @@ import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Root;
-import jakarta.persistence.criteria.Subquery;
 
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.util.HibernateUtil;
@@ -62,15 +61,19 @@ public final class NotificationsDb {
     }
 
     /**
-     * Gets all notifications.
+     * Gets all notifications by {@code targetUsers}.
+     *
+     * @return a list of notifications for the specified targetUsers.
      */
-    public List<Notification> getAllNotifications() {
+    public List<Notification> getNotificationsByTargetUsers(List<NotificationTargetUser> targetUsers) {
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Notification> cq = cb.createQuery(Notification.class);
         Root<Notification> root = cq.from(Notification.class);
-        CriteriaQuery<Notification> all = cq.select(root);
-        TypedQuery<Notification> allQuery = HibernateUtil.createQuery(all);
-        return allQuery.getResultList();
+        cq.select(root)
+                .where(root.get("targetUser").in(targetUsers))
+                .orderBy(cb.asc(root.get("startTime")));
+        TypedQuery<Notification> query = HibernateUtil.createQuery(cq);
+        return query.getResultList();
     }
 
     /**

--- a/src/main/java/teammates/storage/entity/Notification.java
+++ b/src/main/java/teammates/storage/entity/Notification.java
@@ -83,8 +83,6 @@ public class Notification extends BaseEntity {
         addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("notification visible time", startTime), errors);
         addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("notification expiry time", endTime), errors);
         addNonEmptyError(FieldValidator.getInvalidityInfoForTimeForNotificationStartAndEnd(startTime, endTime), errors);
-        addNonEmptyError(FieldValidator.getInvalidityInfoForNotificationStyle(style.name()), errors);
-        addNonEmptyError(FieldValidator.getInvalidityInfoForNotificationTargetUser(targetUser.name()), errors);
         addNonEmptyError(FieldValidator.getInvalidityInfoForNotificationTitle(title), errors);
         addNonEmptyError(FieldValidator.getInvalidityInfoForNotificationBody(message), errors);
 

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -155,6 +155,9 @@ public abstract class Action {
         return value;
     }
 
+    /**
+     * Returns all values for the specified parameter expected to be present in the HTTP request.
+     */
     String[] getNonNullRequestParamValues(String paramName) {
         String[] values = req.getParameterValues(paramName);
         if (values == null || values.length == 0) {

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -49,13 +49,7 @@ public class GetNotificationsAction extends Action {
         boolean isFetchingActive = getBooleanRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE);
         List<NotificationTargetUser> targetUsers = getTargetUsersFromRequest();
 
-        if (targetUsers.isEmpty()) {
-            throw new InvalidHttpParameterException(
-                    String.format("The [%s] HTTP parameter is null.", Const.ParamsNames.NOTIFICATION_TARGET_USER));
-        }
-
         List<Notification> notifications = logic.getNotificationsByTargetUsers(targetUsers, isFetchingActive);
-
         return new JsonResult(new NotificationsData(notifications));
     }
 

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -54,9 +54,7 @@ public class GetNotificationsAction extends Action {
                     String.format("The [%s] HTTP parameter is null.", Const.ParamsNames.NOTIFICATION_TARGET_USER));
         }
 
-        List<Notification> notifications = isFetchingActive
-                ? logic.getActiveNotificationsByTargetUsers(targetUsers)
-                : logic.getNotificationsByTargetUsers(targetUsers);
+        List<Notification> notifications = logic.getNotificationsByTargetUsers(targetUsers, isFetchingActive);
 
         return new JsonResult(new NotificationsData(notifications));
     }

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -1,24 +1,20 @@
 package teammates.ui.webapi;
 
-import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
-import teammates.storage.entity.Account;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.NotificationsData;
 
 /**
  * Action: Gets a list of notifications.
  */
 public class GetNotificationsAction extends Action {
-
-    private static final String INVALID_TARGET_USER = "Target user can only be STUDENT or INSTRUCTOR.";
 
     @Override
     AuthType getMinAuthLevel() {
@@ -30,18 +26,15 @@ public class GetNotificationsAction extends Action {
         if (authContext.isAdmin()) {
             return;
         }
-        String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
-        String targetUserErrorMessage = FieldValidator.getInvalidityInfoForNotificationTargetUser(targetUserString);
-        if (!targetUserErrorMessage.isEmpty()) {
-            throw new InvalidHttpParameterException(targetUserErrorMessage);
-        }
-        NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
-        if (targetUser == NotificationTargetUser.STUDENT) {
-            gateKeeper.verifyStudentInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
-        }
 
-        if (targetUser == NotificationTargetUser.INSTRUCTOR) {
-            gateKeeper.verifyInstructorInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
+        for (NotificationTargetUser targetUser : getTargetUsersFromRequest()) {
+            if (targetUser == NotificationTargetUser.STUDENT) {
+                gateKeeper.verifyStudentInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
+            }
+
+            if (targetUser == NotificationTargetUser.INSTRUCTOR) {
+                gateKeeper.verifyInstructorInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
+            }
         }
     }
 
@@ -56,37 +49,28 @@ public class GetNotificationsAction extends Action {
             return new JsonResult(new NotificationsData(notifications));
         }
 
-        // retrieve active notification for specified target user
+        // retrieve active notification for specified target users
+        List<NotificationTargetUser> targetUsers = getTargetUsersFromRequest();
+        notifications = logic.getActiveNotificationsByTargetUsers(targetUsers);
+
+        return new JsonResult(new NotificationsData(notifications));
+    }
+
+    private List<NotificationTargetUser> getTargetUsersFromRequest() {
+        return Arrays.stream(getNonNullRequestParamValues(Const.ParamsNames.NOTIFICATION_TARGET_USER))
+                .map(this::parseTargetUser)
+                .toList();
+    }
+
+    private NotificationTargetUser parseTargetUser(String targetUserString) {
+        if (targetUserString == null) {
+            throw new InvalidHttpParameterException(
+                    String.format("The [%s] HTTP parameter is null.", Const.ParamsNames.NOTIFICATION_TARGET_USER));
+        }
         String targetUserErrorMessage = FieldValidator.getInvalidityInfoForNotificationTargetUser(targetUserString);
         if (!targetUserErrorMessage.isEmpty()) {
             throw new InvalidHttpParameterException(targetUserErrorMessage);
         }
-        NotificationTargetUser targetUser = NotificationTargetUser.valueOf(targetUserString);
-        if (targetUser == NotificationTargetUser.GENERAL) {
-            throw new InvalidHttpParameterException(INVALID_TARGET_USER);
-        }
-        notifications = logic.getActiveNotificationsByTargetUser(targetUser);
-
-        boolean isFetchingAll = false;
-        if (getRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL) != null) {
-            isFetchingAll = getBooleanRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL);
-        }
-
-        if (isFetchingAll) {
-            return new JsonResult(new NotificationsData(notifications));
-        }
-
-        Account account = logic.getAccountForGoogleId(getCurrentUserGoogleId());
-        if (account == null) {
-            // This should not happen as the user is authenticated
-            throw new UnexpectedServerException("Account not found");
-        }
-        notifications = logic.getUnreadActiveNotificationsByTargetUser(
-                List.of(targetUser, NotificationTargetUser.GENERAL), account.getId(), Instant.now());
-
-        if (authContext.isAdmin()) {
-            return new JsonResult(new NotificationsData(notifications));
-        }
-        return new JsonResult(new NotificationsData(notifications));
+        return NotificationTargetUser.valueOf(targetUserString);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.util.Const;
-import teammates.common.util.FieldValidator;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -62,14 +61,11 @@ public class GetNotificationsAction extends Action {
     }
 
     private NotificationTargetUser parseTargetUser(String targetUserString) {
-        if (targetUserString == null) {
+        try {
+            return NotificationTargetUser.valueOf(targetUserString);
+        } catch (IllegalArgumentException e) {
             throw new InvalidHttpParameterException(
-                    String.format("The [%s] HTTP parameter is null.", Const.ParamsNames.NOTIFICATION_TARGET_USER));
+                    String.format("Invalid notification target user: %s", targetUserString), e);
         }
-        String targetUserErrorMessage = FieldValidator.getInvalidityInfoForNotificationTargetUser(targetUserString);
-        if (!targetUserErrorMessage.isEmpty()) {
-            throw new InvalidHttpParameterException(targetUserErrorMessage);
-        }
-        return NotificationTargetUser.valueOf(targetUserString);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -27,6 +27,10 @@ public class GetNotificationsAction extends Action {
             return;
         }
 
+        if (!getBooleanRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE)) {
+            throw new UnauthorizedAccessException("Only admins can fetch non-active notifications.");
+        }
+
         List<NotificationTargetUser> targetUsers = getTargetUsersFromRequest();
 
         for (NotificationTargetUser targetUser : targetUsers) {

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -35,11 +35,11 @@ public class GetNotificationsAction extends Action {
 
         for (NotificationTargetUser targetUser : targetUsers) {
             if (targetUser == NotificationTargetUser.STUDENT) {
-                gateKeeper.verifyStudentInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
+                gateKeeper.verifyStudentInAnyCourse(getCurrentAccount());
             }
 
             if (targetUser == NotificationTargetUser.INSTRUCTOR) {
-                gateKeeper.verifyInstructorInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
+                gateKeeper.verifyInstructorInAnyCourse(getCurrentAccount());
             }
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -27,7 +27,9 @@ public class GetNotificationsAction extends Action {
             return;
         }
 
-        for (NotificationTargetUser targetUser : getTargetUsersFromRequest()) {
+        List<NotificationTargetUser> targetUsers = getTargetUsersFromRequest();
+
+        for (NotificationTargetUser targetUser : targetUsers) {
             if (targetUser == NotificationTargetUser.STUDENT) {
                 gateKeeper.verifyStudentInAnyCourse(logic.getAccountForGoogleId(getCurrentUserGoogleId()));
             }
@@ -40,24 +42,25 @@ public class GetNotificationsAction extends Action {
 
     @Override
     public JsonResult execute() {
-        String targetUserString = getRequestParamValue(Const.ParamsNames.NOTIFICATION_TARGET_USER);
-        List<Notification> notifications;
+        boolean isFetchingActive = getBooleanRequestParamValue(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE);
+        List<NotificationTargetUser> targetUsers = getTargetUsersFromRequest();
 
-        if (targetUserString == null && authContext.isAdmin()) {
-            // if request is from admin and targetUser is not specified, retrieve all notifications
-            notifications = logic.getAllNotifications();
-            return new JsonResult(new NotificationsData(notifications));
+        if (targetUsers.isEmpty()) {
+            throw new InvalidHttpParameterException(
+                    String.format("The [%s] HTTP parameter is null.", Const.ParamsNames.NOTIFICATION_TARGET_USER));
         }
 
-        // retrieve active notification for specified target users
-        List<NotificationTargetUser> targetUsers = getTargetUsersFromRequest();
-        notifications = logic.getActiveNotificationsByTargetUsers(targetUsers);
+        List<Notification> notifications = isFetchingActive
+                ? logic.getActiveNotificationsByTargetUsers(targetUsers)
+                : logic.getNotificationsByTargetUsers(targetUsers);
 
         return new JsonResult(new NotificationsData(notifications));
     }
 
     private List<NotificationTargetUser> getTargetUsersFromRequest() {
-        return Arrays.stream(getNonNullRequestParamValues(Const.ParamsNames.NOTIFICATION_TARGET_USER))
+        String[] targetUserStrings = getNonNullRequestParamValues(Const.ParamsNames.NOTIFICATION_TARGET_USER);
+
+        return Arrays.stream(targetUserStrings)
                 .map(this::parseTargetUser)
                 .toList();
     }

--- a/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetReadNotificationsAction.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import teammates.storage.entity.Account;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.ReadNotificationsData;
 
 /**
@@ -24,11 +23,7 @@ public class GetReadNotificationsAction extends Action {
 
     @Override
     public ActionResult execute() {
-        Account account = logic.getAccountForGoogleId(getCurrentUserGoogleId());
-        if (account == null) {
-            // This should not happen as the user is authenticated
-            throw new UnexpectedServerException("Account not found");
-        }
+        Account account = getCurrentAccount();
         List<UUID> readNotifications =
                 logic.getReadNotificationsByAccountId(account.getId()).stream()
                         .map(n -> n.getNotification().getId())

--- a/src/test/java/teammates/common/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/common/util/FieldValidatorTest.java
@@ -789,30 +789,6 @@ public class FieldValidatorTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetInvalidityInfoForNotificationStyle_valid_returnEmptyString() {
-        assertEquals("", FieldValidator.getInvalidityInfoForNotificationStyle("SUCCESS"));
-    }
-
-    @Test
-    public void testGetInvalidityInfoForNotificationStyle_inValid_returnErrorString() {
-        String invalidStyle = "invalid style";
-        assertEquals("\"" + invalidStyle + "\" is not an accepted notification style to TEAMMATES. ",
-                FieldValidator.getInvalidityInfoForNotificationStyle(invalidStyle));
-    }
-
-    @Test
-    public void testGetInvalidityInfoForNotificationTargetUser_valid_returnEmptyString() {
-        assertEquals("", FieldValidator.getInvalidityInfoForNotificationTargetUser("GENERAL"));
-    }
-
-    @Test
-    public void testGetInvalidityInfoForNotificationTargetUser_inValid_returnErrorString() {
-        String invalidUser = "invalid user";
-        assertEquals("\"" + invalidUser + "\" is not an accepted notification target user to TEAMMATES. ",
-                FieldValidator.getInvalidityInfoForNotificationTargetUser(invalidUser));
-    }
-
-    @Test
     public void testRegexName() {
         ______TS("success: typical name");
         String name = "Benny Charlés";

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -94,6 +94,16 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     }
 
     @Test
+    void testAccessControl_nonAdminFetchingNonActiveNotification_shouldFail() {
+        loginAsInstructor(GOOGLE_ID);
+        String[] requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(false),
+        };
+        verifyCannotAccess(requestParams);
+    }
+
+    @Test
     void testAccessControl_adminAccessAllNotification_shouldSucceed() {
         loginAsAdmin();
         String[] requestParams = new String[] {

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -129,7 +129,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         List<NotificationTargetUser> targetUsers = List.of(
                 NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL);
-        when(mockLogic.getActiveNotificationsByTargetUsers(targetUsers))
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers, true))
                 .thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
@@ -146,7 +146,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         // should fetch correct number of notifications
         assertEquals(expectedNumberOfNotifications, notifications.size());
-        verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers, true);
     }
 
     @Test
@@ -162,7 +162,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         List<NotificationTargetUser> targetUsers = List.of(
                 NotificationTargetUser.STUDENT, NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL);
-        when(mockLogic.getNotificationsByTargetUsers(targetUsers)).thenReturn(testNotifications);
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers, false)).thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
@@ -178,7 +178,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         List<NotificationData> notificationOutput = output.getNotifications();
 
         assertEquals(expectedNumberOfNotifications, notificationOutput.size());
-        verify(mockLogic).getNotificationsByTargetUsers(targetUsers);
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers, false);
 
         NotificationData expected = new NotificationData(testNotifications.get(0));
         NotificationData firstNotification = notificationOutput.get(0);
@@ -237,7 +237,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         }
 
         List<NotificationTargetUser> targetUsers = List.of(NotificationTargetUser.INSTRUCTOR);
-        when(mockLogic.getActiveNotificationsByTargetUsers(targetUsers))
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers, true))
                 .thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
@@ -255,7 +255,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         for (int i = 0; i < testNotifications.size(); i++) {
             verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
         }
-        verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers, true);
     }
 
     @Test
@@ -269,7 +269,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         }
 
         List<NotificationTargetUser> targetUsers = List.of(NotificationTargetUser.INSTRUCTOR);
-        when(mockLogic.getNotificationsByTargetUsers(targetUsers))
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers, false))
                 .thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
@@ -287,7 +287,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         for (int i = 0; i < testNotifications.size(); i++) {
             verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
         }
-        verify(mockLogic).getNotificationsByTargetUsers(targetUsers);
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers, false);
     }
 
     @Test
@@ -301,7 +301,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         }
 
         List<NotificationTargetUser> targetUsers = List.of(NotificationTargetUser.GENERAL);
-        when(mockLogic.getActiveNotificationsByTargetUsers(targetUsers))
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers, true))
                 .thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
@@ -319,7 +319,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         for (int i = 0; i < testNotifications.size(); i++) {
             verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
         }
-        verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers, true);
     }
 
     private void verifyNotificationEquals(NotificationData expected, NotificationData actual) {

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -1,8 +1,7 @@
 package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -45,7 +44,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsInstructor(GOOGLE_ID);
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
         };
         verifyCannotAccess(requestParams);
     }
@@ -55,7 +54,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsInstructor(GOOGLE_ID);
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
         };
         verifyCanAccess(requestParams);
     }
@@ -65,7 +64,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsStudent(GOOGLE_ID);
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
         };
         verifyCannotAccess(requestParams);
     }
@@ -75,7 +74,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsStudent(GOOGLE_ID);
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
         };
 
         verifyCanAccess(requestParams);
@@ -86,7 +85,6 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsInstructor(GOOGLE_ID);
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, "unknown",
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
         };
         verifyHttpParameterFailureAcl(requestParams);
     }
@@ -94,15 +92,12 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     @Test
     void testAccessControl_adminAccessAllNotification_shouldSucceed() {
         loginAsAdmin();
-        String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_TARGET_USER, null,
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
-        };
+        String[] requestParams = new String[] {};
         verifyCanAccess(requestParams);
     }
 
     @Test
-    void testExecute_withValidUserTypeForNonAdmin_shouldReturnData() {
+    void testExecute_withValidTargetUsersForNonAdmin_shouldReturnData() {
         List<Notification> testNotifications = new ArrayList<>();
 
         loginAsInstructor(GOOGLE_ID);
@@ -113,12 +108,14 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
             testNotifications.add(getTypicalNotificationWithId());
         }
 
-        when(mockLogic.getActiveNotificationsByTargetUser(NotificationTargetUser.INSTRUCTOR))
+        List<NotificationTargetUser> targetUsers = List.of(
+                NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL);
+        when(mockLogic.getActiveNotificationsByTargetUsers(targetUsers))
                 .thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
         };
 
         GetNotificationsAction action = getAction(requestParams);
@@ -129,12 +126,12 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         // should fetch correct number of notifications
         assertEquals(expectedNumberOfNotifications, notifications.size());
+        verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
     }
 
     @Test
     public void testExecute_withoutUserTypeForAdmin_shouldReturnAllNotifications() {
         final int expectedNumberOfNotifications = 5;
-        Notification testNotification = getTypicalNotificationWithId();
 
         loginAsAdmin();
 
@@ -144,13 +141,8 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         }
 
         when(mockLogic.getAllNotifications()).thenReturn(testNotifications);
-        when(mockLogic.getActiveNotificationsByTargetUser(testNotification.getTargetUser()))
-                .thenReturn(testNotifications);
 
-        String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_TARGET_USER, null,
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
-        };
+        String[] requestParams = new String[] {};
 
         GetNotificationsAction action = getAction(requestParams);
         JsonResult jsonResult = getJsonResult(action);
@@ -170,73 +162,31 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     public void testExecute_withoutUserTypeForNonAdmin_shouldFail() {
         loginAsInstructor(GOOGLE_ID);
 
-        String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(true),
-        };
-
-        GetNotificationsAction action = getAction(requestParams);
-        assertThrows(AssertionError.class, action::execute);
+        verifyHttpParameterFailure();
     }
 
     @Test
     public void testExecute_invalidUserType_shouldFail() {
         loginAsInstructor(GOOGLE_ID);
 
-        // when usertype is GENERAL
-        verifyHttpParameterFailure(Const.ParamsNames.NOTIFICATION_TARGET_USER,
-                NotificationTargetUser.GENERAL.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL,
-                String.valueOf(true));
-
         // when usertype is a random string
         verifyHttpParameterFailure(Const.ParamsNames.NOTIFICATION_TARGET_USER,
-                "invalid string",
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL,
-                String.valueOf(true));
+                "invalid string");
     }
 
     @Test
-    public void testExecute_withFalseIsFetchingAll_returnUnreadNotifications() {
+    public void testExecute_withSingleTargetUser_shouldNotImplicitlyAddGeneralTargetUser() {
         loginAsInstructor(GOOGLE_ID);
 
-        List<Notification> testUnreadNotifications = new ArrayList<>();
+        List<Notification> testNotifications = new ArrayList<>();
 
         for (int i = 0; i < UNREAD_NOTIFICATION_COUNT; i++) {
-            testUnreadNotifications.add(getTypicalNotificationWithId());
+            testNotifications.add(getTypicalNotificationWithId());
         }
 
-        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any(), any()))
-                .thenReturn(testUnreadNotifications);
-
-        String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, String.valueOf(false),
-        };
-
-        GetNotificationsAction action = getAction(requestParams);
-        JsonResult jsonResult = getJsonResult(action);
-
-        NotificationsData output = (NotificationsData) jsonResult.getOutput();
-        List<NotificationData> notifications = output.getNotifications();
-
-        assertEquals(testUnreadNotifications.size(), notifications.size());
-        for (int i = 0; i < testUnreadNotifications.size(); i++) {
-            verifyNotificationEquals(new NotificationData(testUnreadNotifications.get(i)), notifications.get(i));
-        }
-    }
-
-    @Test
-    public void testExecute_withoutIsFetchingAll_shouldUpdateShownAndReturnUnreadNotifications() {
-        List<Notification> testUnreadNotifications = new ArrayList<>();
-
-        loginAsInstructor(GOOGLE_ID);
-
-        for (int i = 0; i < UNREAD_NOTIFICATION_COUNT; i++) {
-            testUnreadNotifications.add(getTypicalNotificationWithId());
-        }
-
-        when(mockLogic.getUnreadActiveNotificationsByTargetUser(any(), any(), any()))
-                .thenReturn(testUnreadNotifications);
+        List<NotificationTargetUser> targetUsers = List.of(NotificationTargetUser.INSTRUCTOR);
+        when(mockLogic.getActiveNotificationsByTargetUsers(targetUsers))
+                .thenReturn(testNotifications);
 
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
@@ -248,22 +198,42 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
         List<NotificationData> notifications = output.getNotifications();
 
-        assertEquals(testUnreadNotifications.size(), notifications.size());
-        for (int i = 0; i < testUnreadNotifications.size(); i++) {
-            verifyNotificationEquals(new NotificationData(testUnreadNotifications.get(i)), notifications.get(i));
+        assertEquals(testNotifications.size(), notifications.size());
+        for (int i = 0; i < testNotifications.size(); i++) {
+            verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
         }
+        verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
     }
 
     @Test
-    public void testExecute_withInvalidIsFetchingAll_shouldFail() {
+    public void testExecute_withGeneralTargetUser_shouldReturnGeneralNotifications() {
+        List<Notification> testNotifications = new ArrayList<>();
+
         loginAsInstructor(GOOGLE_ID);
 
+        for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
+            testNotifications.add(getTypicalNotificationWithId());
+        }
+
+        List<NotificationTargetUser> targetUsers = List.of(NotificationTargetUser.GENERAL);
+        when(mockLogic.getActiveNotificationsByTargetUsers(targetUsers))
+                .thenReturn(testNotifications);
+
         String[] requestParams = new String[] {
-                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
-                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ALL, "random-value",
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
         };
 
-        verifyHttpParameterFailure(requestParams);
+        GetNotificationsAction action = getAction(requestParams);
+        JsonResult jsonResult = getJsonResult(action);
+
+        NotificationsData output = (NotificationsData) jsonResult.getOutput();
+        List<NotificationData> notifications = output.getNotifications();
+
+        assertEquals(testNotifications.size(), notifications.size());
+        for (int i = 0; i < testNotifications.size(); i++) {
+            verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
+        }
+        verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
     }
 
     private void verifyNotificationEquals(NotificationData expected, NotificationData actual) {

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -89,6 +89,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsInstructor(GOOGLE_ID);
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, "unknown",
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
         verifyHttpParameterFailureAcl(requestParams);
     }

--- a/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetNotificationsActionTest.java
@@ -45,6 +45,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
         verifyCannotAccess(requestParams);
     }
@@ -55,6 +56,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
         verifyCanAccess(requestParams);
     }
@@ -65,6 +67,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
         verifyCannotAccess(requestParams);
     }
@@ -75,6 +78,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
 
         verifyCanAccess(requestParams);
@@ -92,7 +96,12 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     @Test
     void testAccessControl_adminAccessAllNotification_shouldSucceed() {
         loginAsAdmin();
-        String[] requestParams = new String[] {};
+        String[] requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(false),
+        };
         verifyCanAccess(requestParams);
     }
 
@@ -116,6 +125,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
 
         GetNotificationsAction action = getAction(requestParams);
@@ -130,7 +140,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     }
 
     @Test
-    public void testExecute_withoutUserTypeForAdmin_shouldReturnAllNotifications() {
+    public void testExecute_withAllUserTypesForAdmin_shouldReturnAllNotifications() {
         final int expectedNumberOfNotifications = 5;
 
         loginAsAdmin();
@@ -140,9 +150,16 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
             testNotifications.add(getTypicalNotificationWithId());
         }
 
-        when(mockLogic.getAllNotifications()).thenReturn(testNotifications);
+        List<NotificationTargetUser> targetUsers = List.of(
+                NotificationTargetUser.STUDENT, NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL);
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers)).thenReturn(testNotifications);
 
-        String[] requestParams = new String[] {};
+        String[] requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.STUDENT.toString(),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(false),
+        };
 
         GetNotificationsAction action = getAction(requestParams);
         JsonResult jsonResult = getJsonResult(action);
@@ -150,8 +167,8 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         NotificationsData output = (NotificationsData) jsonResult.getOutput();
         List<NotificationData> notificationOutput = output.getNotifications();
 
-        assertEquals(expectedNumberOfNotifications, mockLogic.getAllNotifications().size());
         assertEquals(expectedNumberOfNotifications, notificationOutput.size());
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers);
 
         NotificationData expected = new NotificationData(testNotifications.get(0));
         NotificationData firstNotification = notificationOutput.get(0);
@@ -162,7 +179,22 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
     public void testExecute_withoutUserTypeForNonAdmin_shouldFail() {
         loginAsInstructor(GOOGLE_ID);
 
-        verifyHttpParameterFailure();
+        verifyHttpParameterFailure(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(false));
+    }
+
+    @Test
+    public void testExecute_withoutUserTypeForAdmin_shouldFail() {
+        loginAsAdmin();
+
+        verifyHttpParameterFailure(Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(false));
+    }
+
+    @Test
+    public void testExecute_withoutIsFetchingActive_shouldFail() {
+        loginAsInstructor(GOOGLE_ID);
+
+        verifyHttpParameterFailure(
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString());
     }
 
     @Test
@@ -170,8 +202,18 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
         loginAsInstructor(GOOGLE_ID);
 
         // when usertype is a random string
-        verifyHttpParameterFailure(Const.ParamsNames.NOTIFICATION_TARGET_USER,
-                "invalid string");
+        verifyHttpParameterFailure(
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, "invalid string",
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true));
+    }
+
+    @Test
+    public void testExecute_withInvalidIsFetchingActive_shouldFail() {
+        loginAsInstructor(GOOGLE_ID);
+
+        verifyHttpParameterFailure(
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, "not-a-boolean");
     }
 
     @Test
@@ -190,6 +232,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
 
         GetNotificationsAction action = getAction(requestParams);
@@ -203,6 +246,38 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
             verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
         }
         verify(mockLogic).getActiveNotificationsByTargetUsers(targetUsers);
+    }
+
+    @Test
+    public void testExecute_withIsFetchingActiveFalseAndTargetUsers_shouldReturnAllNotificationsForTargetUsers() {
+        loginAsInstructor(GOOGLE_ID);
+
+        List<Notification> testNotifications = new ArrayList<>();
+
+        for (int i = 0; i < UNREAD_NOTIFICATION_COUNT; i++) {
+            testNotifications.add(getTypicalNotificationWithId());
+        }
+
+        List<NotificationTargetUser> targetUsers = List.of(NotificationTargetUser.INSTRUCTOR);
+        when(mockLogic.getNotificationsByTargetUsers(targetUsers))
+                .thenReturn(testNotifications);
+
+        String[] requestParams = new String[] {
+                Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.INSTRUCTOR.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(false),
+        };
+
+        GetNotificationsAction action = getAction(requestParams);
+        JsonResult jsonResult = getJsonResult(action);
+
+        NotificationsData output = (NotificationsData) jsonResult.getOutput();
+        List<NotificationData> notifications = output.getNotifications();
+
+        assertEquals(testNotifications.size(), notifications.size());
+        for (int i = 0; i < testNotifications.size(); i++) {
+            verifyNotificationEquals(new NotificationData(testNotifications.get(i)), notifications.get(i));
+        }
+        verify(mockLogic).getNotificationsByTargetUsers(targetUsers);
     }
 
     @Test
@@ -221,6 +296,7 @@ public class GetNotificationsActionTest extends BaseActionTest<GetNotificationsA
 
         String[] requestParams = new String[] {
                 Const.ParamsNames.NOTIFICATION_TARGET_USER, NotificationTargetUser.GENERAL.toString(),
+                Const.ParamsNames.NOTIFICATION_IS_FETCHING_ACTIVE, String.valueOf(true),
         };
 
         GetNotificationsAction action = getAction(requestParams);

--- a/src/test/java/teammates/ui/webapi/GetReadNotificationsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetReadNotificationsActionTest.java
@@ -34,10 +34,11 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
 
     @Test
     protected void testExecute_getReadNotificationsAsInstructor_shouldSucceed() {
-        Account account = getTypicalAccount();
+        loginAsInstructor("instructor-google-id");
+        GetReadNotificationsAction action = getAction();
+        Account account = action.getCurrentAccount();
         List<ReadNotification> testReadNotifications = new ArrayList<>();
 
-        loginAsInstructor(account.getGoogleId());
         for (int i = 0; i < READ_NOTIFICATION_COUNT; i++) {
             ReadNotification readNotification = new ReadNotification();
             account.addReadNotification(readNotification);
@@ -45,10 +46,8 @@ public class GetReadNotificationsActionTest extends BaseActionTest<GetReadNotifi
             testReadNotifications.add(readNotification);
         }
 
-        when(mockLogic.getAccountForGoogleId(account.getGoogleId())).thenReturn(account);
         when(mockLogic.getReadNotificationsByAccountId(account.getId())).thenReturn(testReadNotifications);
 
-        GetReadNotificationsAction action = getAction();
         JsonResult jsonResult = getJsonResult(action);
 
         ReadNotificationsData output = (ReadNotificationsData) jsonResult.getOutput();

--- a/src/web/app/components/notification-banner/notification-banner.component.spec.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.spec.ts
@@ -57,7 +57,7 @@ describe('NotificationBannerComponent', () => {
   });
 
   it('should load data correctly', () => {
-    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotifications').mockReturnValue(
       of({
         notifications: [testNotificationOne, testNotificationTwo],
       }),
@@ -68,13 +68,16 @@ describe('NotificationBannerComponent', () => {
       }),
     );
     component.ngOnInit();
-    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL]);
+    expect(getNotificationSpy).toHaveBeenCalledWith({
+      targetUsers: [NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL],
+      isFetchingActive: true,
+    });
     expect(getReadNotificationSpy).toHaveBeenCalledTimes(1);
     expect(component.notifications).toEqual([testNotificationTwo]);
   });
 
   it('should not duplicate general target user when loading general notifications', () => {
-    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotifications').mockReturnValue(
       of({
         notifications: [testNotificationOne],
       }),
@@ -86,7 +89,10 @@ describe('NotificationBannerComponent', () => {
     );
     component.notificationTargetUser = NotificationTargetUser.GENERAL;
     component.fetchNotifications();
-    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.GENERAL]);
+    expect(getNotificationSpy).toHaveBeenCalledWith({
+      targetUsers: [NotificationTargetUser.GENERAL],
+      isFetchingActive: true,
+    });
   });
 
   it('should close after clicking X', () => {

--- a/src/web/app/components/notification-banner/notification-banner.component.spec.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.spec.ts
@@ -57,14 +57,36 @@ describe('NotificationBannerComponent', () => {
   });
 
   it('should load data correctly', () => {
-    const spy = vi.spyOn(notificationService, 'getUnreadNotificationsForTargetUser').mockReturnValue(
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
       of({
         notifications: [testNotificationOne, testNotificationTwo],
       }),
     );
+    const getReadNotificationSpy = vi.spyOn(notificationService, 'getReadNotifications').mockReturnValue(
+      of({
+        readNotifications: [testNotificationOne.notificationId],
+      }),
+    );
     component.ngOnInit();
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(component.notifications).toEqual([testNotificationOne, testNotificationTwo]);
+    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL]);
+    expect(getReadNotificationSpy).toHaveBeenCalledTimes(1);
+    expect(component.notifications).toEqual([testNotificationTwo]);
+  });
+
+  it('should not duplicate general target user when loading general notifications', () => {
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
+      of({
+        notifications: [testNotificationOne],
+      }),
+    );
+    vi.spyOn(notificationService, 'getReadNotifications').mockReturnValue(
+      of({
+        readNotifications: [],
+      }),
+    );
+    component.notificationTargetUser = NotificationTargetUser.GENERAL;
+    component.fetchNotifications();
+    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.GENERAL]);
   });
 
   it('should close after clicking X', () => {

--- a/src/web/app/components/notification-banner/notification-banner.component.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.ts
@@ -1,9 +1,10 @@
 import { NgClass } from '@angular/common';
 import { Component, Input, OnChanges, OnInit, ChangeDetectorRef, inject } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
+import { forkJoin } from 'rxjs';
 import { NotificationService } from '../../../services/notification.service';
 import { StatusMessageService } from '../../../services/status-message.service';
-import { Notification, Notifications, NotificationTargetUser } from '../../../types/api-output';
+import { Notification, Notifications, NotificationTargetUser, ReadNotifications } from '../../../types/api-output';
 import { ErrorMessageOutput } from '../../error-message-output';
 import { NotificationStyleClassPipe } from '../teammates-common/notification-style-class.pipe';
 
@@ -44,15 +45,31 @@ export class NotificationBannerComponent implements OnInit, OnChanges {
   }
 
   fetchNotifications(): void {
-    this.notificationService
-      .getUnreadNotificationsForTargetUser(this.notificationTargetUser)
-      .subscribe((response: Notifications) => {
-        this.notifications = response.notifications;
+    forkJoin({
+      readNotifications: this.notificationService.getReadNotifications(),
+      notifications: this.notificationService.getNotificationsForTargetUsers(this.getTargetUsers()),
+    }).subscribe(
+      ({
+        readNotifications,
+        notifications,
+      }: {
+        readNotifications: ReadNotifications;
+        notifications: Notifications;
+      }) => {
+        const readNotificationsSet = new Set(readNotifications.readNotifications);
+        this.notifications = notifications.notifications.filter(
+          (notification: Notification) => !readNotificationsSet.has(notification.notificationId),
+        );
         if (this.notifications.length > 0) {
           this.cdr.detectChanges();
           this.isShown = true;
         }
-      });
+      },
+    );
+  }
+
+  private getTargetUsers(): NotificationTargetUser[] {
+    return Array.from(new Set([this.notificationTargetUser, NotificationTargetUser.GENERAL]));
   }
 
   markNotificationAsRead(notification: Notification): void {

--- a/src/web/app/components/notification-banner/notification-banner.component.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.ts
@@ -47,7 +47,10 @@ export class NotificationBannerComponent implements OnInit, OnChanges {
   fetchNotifications(): void {
     forkJoin({
       readNotifications: this.notificationService.getReadNotifications(),
-      notifications: this.notificationService.getNotificationsForTargetUsers(this.getTargetUsers()),
+      notifications: this.notificationService.getNotifications({
+        targetUsers: this.getTargetUsers(),
+        isFetchingActive: true,
+      }),
     }).subscribe(
       ({
         readNotifications,

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
@@ -79,7 +79,7 @@ describe('UserNotificationsListComponent', () => {
 
   it('should load notifications from APIs correctly', () => {
     // two notifications, only first one has been read
-    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotifications').mockReturnValue(
       of({
         notifications: [testNotificationOne, testNotificationTwo],
       }),
@@ -91,7 +91,10 @@ describe('UserNotificationsListComponent', () => {
     );
     component.userType = NotificationTargetUser.STUDENT;
     component.loadNotifications();
-    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL]);
+    expect(getNotificationSpy).toHaveBeenCalledWith({
+      targetUsers: [NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL],
+      isFetchingActive: true,
+    });
     expect(getReadNotificationSpy).toHaveBeenCalledTimes(1);
     expect(component.notificationTabs).toEqual(
       getNotificationTabs([testNotificationOne, testNotificationTwo], [testNotificationOne.notificationId]),
@@ -99,7 +102,7 @@ describe('UserNotificationsListComponent', () => {
   });
 
   it('should not duplicate general target user when loading general notifications', () => {
-    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotifications').mockReturnValue(
       of({
         notifications: [testNotificationOne],
       }),
@@ -111,7 +114,10 @@ describe('UserNotificationsListComponent', () => {
     );
     component.userType = NotificationTargetUser.GENERAL;
     component.loadNotifications();
-    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.GENERAL]);
+    expect(getNotificationSpy).toHaveBeenCalledWith({
+      targetUsers: [NotificationTargetUser.GENERAL],
+      isFetchingActive: true,
+    });
   });
 
   it('should mark notification as read when button is clicked', () => {

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
@@ -79,7 +79,7 @@ describe('UserNotificationsListComponent', () => {
 
   it('should load notifications from APIs correctly', () => {
     // two notifications, only first one has been read
-    const getNotificationSpy = vi.spyOn(notificationService, 'getAllNotificationsForTargetUser').mockReturnValue(
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
       of({
         notifications: [testNotificationOne, testNotificationTwo],
       }),
@@ -89,12 +89,29 @@ describe('UserNotificationsListComponent', () => {
         readNotifications: [testNotificationOne.notificationId],
       }),
     );
+    component.userType = NotificationTargetUser.STUDENT;
     component.loadNotifications();
-    expect(getNotificationSpy).toHaveBeenCalledTimes(1);
+    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL]);
     expect(getReadNotificationSpy).toHaveBeenCalledTimes(1);
     expect(component.notificationTabs).toEqual(
       getNotificationTabs([testNotificationOne, testNotificationTwo], [testNotificationOne.notificationId]),
     );
+  });
+
+  it('should not duplicate general target user when loading general notifications', () => {
+    const getNotificationSpy = vi.spyOn(notificationService, 'getNotificationsForTargetUsers').mockReturnValue(
+      of({
+        notifications: [testNotificationOne],
+      }),
+    );
+    vi.spyOn(notificationService, 'getReadNotifications').mockReturnValue(
+      of({
+        readNotifications: [],
+      }),
+    );
+    component.userType = NotificationTargetUser.GENERAL;
+    component.loadNotifications();
+    expect(getNotificationSpy).toHaveBeenCalledWith([NotificationTargetUser.GENERAL]);
   });
 
   it('should mark notification as read when button is clicked', () => {

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -77,7 +77,7 @@ export class UserNotificationsListComponent implements OnInit {
 
     forkJoin({
       readNotifications: this.notificationService.getReadNotifications(),
-      notifications: this.notificationService.getAllNotificationsForTargetUser(this.userType),
+      notifications: this.notificationService.getNotificationsForTargetUsers(this.getTargetUsers()),
     })
       .pipe(
         finalize(() => {
@@ -103,6 +103,10 @@ export class UserNotificationsListComponent implements OnInit {
           this.statusMessageService.showErrorToast(resp.error.message);
         },
       });
+  }
+
+  private getTargetUsers(): NotificationTargetUser[] {
+    return Array.from(new Set([this.userType, NotificationTargetUser.GENERAL]));
   }
 
   private createNotificationTab(notification: Notification, readNotifications: Set<string>): NotificationTab {

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -77,7 +77,10 @@ export class UserNotificationsListComponent implements OnInit {
 
     forkJoin({
       readNotifications: this.notificationService.getReadNotifications(),
-      notifications: this.notificationService.getNotificationsForTargetUsers(this.getTargetUsers()),
+      notifications: this.notificationService.getNotifications({
+        targetUsers: this.getTargetUsers(),
+        isFetchingActive: true,
+      }),
     })
       .pipe(
         finalize(() => {

--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.spec.ts
@@ -139,7 +139,7 @@ describe('AdminNotificationsPageComponent', () => {
   });
 
   it('should load correct notification for a given API output', () => {
-    vi.spyOn(notificationService, 'getNotifications').mockReturnValue(
+    const getNotificationsSpy = vi.spyOn(notificationService, 'getNotifications').mockReturnValue(
       of({
         notifications: [testNotificationOne],
       }),
@@ -147,6 +147,10 @@ describe('AdminNotificationsPageComponent', () => {
 
     component.loadNotifications();
 
+    expect(getNotificationsSpy).toHaveBeenCalledWith({
+      targetUsers: [NotificationTargetUser.STUDENT, NotificationTargetUser.INSTRUCTOR, NotificationTargetUser.GENERAL],
+      isFetchingActive: false,
+    });
     expect(component.notificationsTableRowModels.length).toEqual(1);
     expect(component.notificationsTableRowModels[0].notification.notificationId).toEqual(
       testNotificationOne.notificationId,

--- a/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/admin-notifications-page.component.ts
@@ -130,7 +130,14 @@ export class AdminNotificationsPageComponent implements OnInit {
   loadNotifications(): void {
     this.isNotificationLoading = true;
     this.notificationService
-      .getNotifications()
+      .getNotifications({
+        targetUsers: [
+          NotificationTargetUser.STUDENT,
+          NotificationTargetUser.INSTRUCTOR,
+          NotificationTargetUser.GENERAL,
+        ],
+        isFetchingActive: false,
+      })
       .pipe(
         finalize(() => {
           this.isNotificationLoading = false;

--- a/src/web/services/notification.service.spec.ts
+++ b/src/web/services/notification.service.spec.ts
@@ -41,6 +41,14 @@ describe('NotificationService', () => {
     expect(spyHttpRequestService.get).toHaveBeenCalledWith(ResourceEndpoints.NOTIFICATIONS);
   });
 
+  it('should execute GET when retrieving notifications for target users', () => {
+    const paramsMap: Record<string, string[]> = {
+      usertype: [NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL],
+    };
+    service.getNotificationsForTargetUsers([NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL]);
+    expect(spyHttpRequestService.get).toHaveBeenCalledWith(ResourceEndpoints.NOTIFICATIONS, paramsMap);
+  });
+
   it('should execute POST when creating notifications', () => {
     const paramsMap: Record<string, string> = {};
     service.createNotification(requestBody);

--- a/src/web/services/notification.service.spec.ts
+++ b/src/web/services/notification.service.spec.ts
@@ -37,15 +37,14 @@ describe('NotificationService', () => {
   });
 
   it('should execute GET when retrieving notifications', () => {
-    service.getNotifications();
-    expect(spyHttpRequestService.get).toHaveBeenCalledWith(ResourceEndpoints.NOTIFICATIONS);
-  });
-
-  it('should execute GET when retrieving notifications for target users', () => {
-    const paramsMap: Record<string, string[]> = {
+    const paramsMap: Record<string, string | string[]> = {
       usertype: [NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL],
+      isfetchingactive: 'true',
     };
-    service.getNotificationsForTargetUsers([NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL]);
+    service.getNotifications({
+      targetUsers: [NotificationTargetUser.STUDENT, NotificationTargetUser.GENERAL],
+      isFetchingActive: true,
+    });
     expect(spyHttpRequestService.get).toHaveBeenCalledWith(ResourceEndpoints.NOTIFICATIONS, paramsMap);
   });
 

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -2,18 +2,17 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpRequestService } from './http-request.service';
 import { ResourceEndpoints } from '../types/api-const';
-import {
-  MessageOutput,
-  Notification,
-  Notifications,
-  NotificationTargetUser,
-  ReadNotifications,
-} from '../types/api-output';
+import { MessageOutput, Notification, Notifications, ReadNotifications } from '../types/api-output';
 import {
   MarkNotificationAsReadRequest,
   NotificationCreateRequest,
   NotificationUpdateRequest,
 } from '../types/api-request';
+
+export interface GetNotificationsParams {
+  targetUsers: string[];
+  isFetchingActive: boolean;
+}
 
 /**
  * Handles notification related logic injection
@@ -34,8 +33,12 @@ export class NotificationService {
   /**
    * Retrieves all notifications by calling API.
    */
-  getNotifications(): Observable<Notifications> {
-    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS);
+  getNotifications(params: GetNotificationsParams): Observable<Notifications> {
+    const paramMap: Record<string, string | string[]> = {
+      usertype: params.targetUsers,
+      isfetchingactive: String(params.isFetchingActive),
+    };
+    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS, paramMap);
   }
 
   /**
@@ -63,16 +66,6 @@ export class NotificationService {
    */
   markNotificationAsRead(request: MarkNotificationAsReadRequest): Observable<ReadNotifications> {
     return this.httpRequestService.post(ResourceEndpoints.NOTIFICATION_READ, {}, request);
-  }
-
-  /**
-   * Retrieves all active notifications for specific target user types.
-   */
-  getNotificationsForTargetUsers(userTypes: NotificationTargetUser[]): Observable<Notifications> {
-    const paramMap: Record<string, string[]> = {
-      usertype: userTypes,
-    };
-    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS, paramMap);
   }
 
   /**

--- a/src/web/services/notification.service.ts
+++ b/src/web/services/notification.service.ts
@@ -66,23 +66,11 @@ export class NotificationService {
   }
 
   /**
-   * Retrieves unread notifications for a specific target user type.
+   * Retrieves all active notifications for specific target user types.
    */
-  getUnreadNotificationsForTargetUser(userType: NotificationTargetUser): Observable<Notifications> {
-    const paramMap: Record<string, string> = {
-      usertype: userType,
-      isfetchingall: 'false',
-    };
-    return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS, paramMap);
-  }
-
-  /**
-   * Retrieves all notifications for a specific target user type.
-   */
-  getAllNotificationsForTargetUser(userType: NotificationTargetUser): Observable<Notifications> {
-    const paramMap: Record<string, string> = {
-      usertype: userType,
-      isfetchingall: 'true',
+  getNotificationsForTargetUsers(userTypes: NotificationTargetUser[]): Observable<Notifications> {
+    const paramMap: Record<string, string[]> = {
+      usertype: userTypes,
     };
     return this.httpRequestService.get(ResourceEndpoints.NOTIFICATIONS, paramMap);
   }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

**1. Simplification of API contract**

Previously, the parameters of `GetNotificationsAction` were implicitly defined based on the user's role (admin, instructor or student). 

This PR changes the parameters to be explicitly defined. `GetNotificationsAction` now accepts a list of `userTypes` and a boolean param `isFetchingActive` which now must be explicitly sent by the frontend callers. 

**2. Access Control Rules**

Admin can access all notifications.

Only Instructors can specify Instructor userType. Only Student can specify Student userType. Anyone can specify general userType. 

Only admins can fetch inactive notifications.

**3. Separation of concerns**

`GetNotificationsAction` now returns only notifications without filtering by read status. Instead, read status is fetched by calling existing `GetReadNotificationsAction` and relevant notifications are filtered on the FE instead.

**4. Logic is moved out of the Action Layer**

**5. Parsing of targetUser has been simplified.**

In field validator, `getInvalidityInfoForNotificationTargetUser` and `getInvalidityInfoForNotificationStyle` have been removed. The remaining usages of these are in `getInvalidityInfo` of `Notification.java`. However, the values can never be invalid at this point (because they are already enums).

In `GetNotificationsAction`, this enum is parsed directly, similar to how it's done in other similar actions.