### PR TITLE
[#14020] Refactor EmailGenerator to accept user objects instead of user emails

### DIFF
--- a/src/it/java/teammates/it/logic/api/EmailGeneratorTestIT.java
+++ b/src/it/java/teammates/it/logic/api/EmailGeneratorTestIT.java
@@ -3,6 +3,8 @@ package teammates.it.logic.api;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.List;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -76,7 +78,8 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("invalid email address");
 
-        EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent("non-existing-student");
+        EmailWrapper email = emailGenerator
+                .generateSessionLinksRecoveryEmailForNonExistentStudent("non-existing-student");
         String subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, "non-existing-student", subject,
@@ -86,7 +89,8 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithDatabaseAccess {
 
         Student student1InCourse1 = dataBundle.students.get("student1InCourse1");
 
-        email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(student1InCourse1.getEmail());
+        email = emailGenerator.generateSessionLinksRecoveryEmailForExistingStudent(
+                student1InCourse1.getEmail(), List.of(student1InCourse1));
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
         verifyEmail(email, student1InCourse1.getEmail(), subject,
@@ -96,7 +100,8 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithDatabaseAccess {
 
         Student student1InCourse3 = dataBundle.students.get("student1InCourse3");
 
-        email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(student1InCourse3.getEmail());
+        email = emailGenerator.generateSessionLinksRecoveryEmailForExistingStudent(
+                student1InCourse3.getEmail(), List.of(student1InCourse3));
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 
@@ -107,7 +112,8 @@ public class EmailGeneratorTestIT extends BaseTestCaseWithDatabaseAccess {
 
         Student student1InCourse4 = dataBundle.students.get("student1InCourse4");
 
-        email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(student1InCourse4.getEmail());
+        email = emailGenerator.generateSessionLinksRecoveryEmailForExistingStudent(
+                student1InCourse4.getEmail(), List.of(student1InCourse4));
 
         subject = EmailType.SESSION_LINKS_RECOVERY.getSubject();
 

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -352,6 +352,7 @@ public final class EmailGenerator {
      * Generates the email to be sent to a non-existent student when they request for session links recovery.
      */
     public EmailWrapper generateSessionLinksRecoveryEmailForNonExistentStudent(String recoveryEmailAddress) {
+        Objects.requireNonNull(recoveryEmailAddress);
         String recoveryUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSIONS_LINK_RECOVERY_PAGE).toAbsoluteString();
         String emailBody = Templates.populateTemplate(
                 EmailTemplates.SESSION_LINKS_RECOVERY_EMAIL_NOT_FOUND,
@@ -373,6 +374,7 @@ public final class EmailGenerator {
      */
     public EmailWrapper generateSessionLinksRecoveryEmailForExistingStudent(
             String recoveryEmailAddress, List<Student> studentsForEmail) {
+        Objects.requireNonNull(recoveryEmailAddress);
         if (studentsForEmail.isEmpty()) {
             throw new IllegalArgumentException("studentsForEmail cannot be empty");
         }

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -20,7 +21,6 @@ import teammates.common.util.SanitizationHelper;
 import teammates.common.util.Templates;
 import teammates.common.util.Templates.EmailTemplates;
 import teammates.common.util.TimeHelper;
-import teammates.logic.core.CoursesLogic;
 import teammates.logic.core.DeadlineExtensionsLogic;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.logic.core.UsersLogic;
@@ -62,7 +62,6 @@ public final class EmailGenerator {
 
     private static final EmailGenerator instance = new EmailGenerator();
 
-    private final CoursesLogic coursesLogic = CoursesLogic.inst();
     private final DeadlineExtensionsLogic deLogic = DeadlineExtensionsLogic.inst();
     private final FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
     private final UsersLogic usersLogic = UsersLogic.inst();
@@ -241,27 +240,40 @@ public final class EmailGenerator {
 
     /**
      * Generates the email containing the summary of the feedback sessions
-     * email for the given {@code courseId} for {@code userEmail}.
-     * @param courseId - ID of the course
-     * @param userEmail - Email of student to send feedback session summary to
+     * email for the given {@code user}.
+     *
+     * @param user - User to send feedback session summary to
      * @param emailType - The email type which corresponds to the reason behind why the links are being resent
      */
-    public EmailWrapper generateFeedbackSessionSummaryOfCourse(
-            String courseId, String userEmail, EmailType emailType) {
-        assert emailType == EmailType.STUDENT_EMAIL_CHANGED
-                || emailType == EmailType.STUDENT_COURSE_LINKS_REGENERATED
-                || emailType == EmailType.INSTRUCTOR_COURSE_LINKS_REGENERATED;
+    public EmailWrapper generateFeedbackSessionSummaryOfCourse(User user, EmailType emailType) {
+        Objects.requireNonNull(user);
+        if (emailType != EmailType.STUDENT_EMAIL_CHANGED
+                && emailType != EmailType.STUDENT_COURSE_LINKS_REGENERATED
+                && emailType != EmailType.INSTRUCTOR_COURSE_LINKS_REGENERATED) {
+            throw new IllegalArgumentException("Unsupported email type: " + emailType);
+        }
 
-        Course course = coursesLogic.getCourse(courseId);
-        boolean isInstructor = emailType == EmailType.INSTRUCTOR_COURSE_LINKS_REGENERATED;
-        Student student = usersLogic.getStudentForEmail(courseId, userEmail);
-        Instructor instructor = null;
-        if (isInstructor) {
-            instructor = usersLogic.getInstructorForEmail(courseId, userEmail);
+        String userEmail = user.getEmail();
+        Course course = user.getCourse();
+
+        String joinUrl = Config.getFrontEndAppUrl(user.getRegistrationUrl()).toAbsoluteString();
+        boolean isYetToJoinCourse = user.getAccount() == null;
+        String userKey = user.getRegKey();
+        String userName = user.getName();
+
+        String joinFragmentTemplate;
+        if (user instanceof Instructor) {
+            joinFragmentTemplate = EmailTemplates.FRAGMENT_INSTRUCTOR_COURSE_REJOIN_AFTER_REGKEY_RESET;
+        } else if (user instanceof Student) {
+            joinFragmentTemplate = emailType == EmailType.STUDENT_EMAIL_CHANGED
+                    ? EmailTemplates.FRAGMENT_STUDENT_COURSE_JOIN
+                    : EmailTemplates.FRAGMENT_STUDENT_COURSE_REJOIN_AFTER_REGKEY_RESET;
+        } else {
+            throw new IllegalArgumentException("Unsupported user type: " + user.getClass().getSimpleName());
         }
 
         List<FeedbackSession> sessions = new ArrayList<>();
-        List<FeedbackSession> fsInCourse = fsLogic.getFeedbackSessionsForCourse(courseId);
+        List<FeedbackSession> fsInCourse = fsLogic.getFeedbackSessionsForCourse(course.getId());
 
         for (FeedbackSession fs : fsInCourse) {
             if (fs.isOpenedEmailSent() || fs.isPublishedEmailSent()) {
@@ -270,15 +282,6 @@ public final class EmailGenerator {
         }
 
         StringBuilder linksFragmentValue = new StringBuilder(1000);
-        String joinUrl = Config.getFrontEndAppUrl(
-                isInstructor ? instructor.getRegistrationUrl() : student.getRegistrationUrl()).toAbsoluteString();
-        boolean isYetToJoinCourse = isInstructor ? isYetToJoinCourse(instructor) : isYetToJoinCourse(student);
-        String joinFragmentTemplate = isInstructor
-                ? EmailTemplates.FRAGMENT_INSTRUCTOR_COURSE_REJOIN_AFTER_REGKEY_RESET
-                : emailType == EmailType.STUDENT_EMAIL_CHANGED
-                        ? EmailTemplates.FRAGMENT_STUDENT_COURSE_JOIN
-                        : EmailTemplates.FRAGMENT_STUDENT_COURSE_REJOIN_AFTER_REGKEY_RESET;
-
         String joinFragmentValue = isYetToJoinCourse
                 ? Templates.populateTemplate(joinFragmentTemplate,
                         "${joinUrl}", joinUrl,
@@ -291,13 +294,11 @@ public final class EmailGenerator {
             String submitUrlHtml = "(Feedback session is not yet opened)";
             String reportUrlHtml = "(Feedback session is not yet published)";
 
-            String userKey = isInstructor ? instructor.getRegKey() : student.getRegKey();
-
             if (fs.isOpened() || fs.isClosed()) {
                 String submitUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
                         .withFeedbackSessionId(fs.getId().toString())
                         .withRegistrationKey(userKey)
-                        .withEntityType(isInstructor ? Const.EntityType.INSTRUCTOR : "")
+                        .withEntityType(user instanceof Instructor ? Const.EntityType.INSTRUCTOR : "")
                         .toAbsoluteString();
                 submitUrlHtml = "<a href=\"" + submitUrl + "\">" + submitUrl + "</a>";
             }
@@ -306,7 +307,7 @@ public final class EmailGenerator {
                 String reportUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
                         .withFeedbackSessionId(fs.getId().toString())
                         .withRegistrationKey(userKey)
-                        .withEntityType(isInstructor ? Const.EntityType.INSTRUCTOR : "")
+                        .withEntityType(user instanceof Instructor ? Const.EntityType.INSTRUCTOR : "")
                         .toAbsoluteString();
                 reportUrlHtml = "<a href=\"" + reportUrl + "\">" + reportUrl + "</a>";
             }
@@ -322,16 +323,15 @@ public final class EmailGenerator {
                     "${reportUrl}", reportUrlHtml));
         }
 
-        if (linksFragmentValue.length() == 0) {
+        if (linksFragmentValue.isEmpty()) {
             linksFragmentValue.append("No links found.");
         }
 
-        String additionalContactInformation = getAdditionalContactInformationFragment(course, isInstructor);
+        String additionalContactInformation = getAdditionalContactInformationFragment(course, user instanceof Instructor);
         String resendLinksTemplate = emailType == EmailType.STUDENT_EMAIL_CHANGED
                 ? Templates.EmailTemplates.USER_FEEDBACK_SESSION_RESEND_ALL_LINKS
                 : Templates.EmailTemplates.USER_REGKEY_REGENERATION_RESEND_ALL_COURSE_LINKS;
 
-        String userName = isInstructor ? instructor.getName() : student.getName();
         String emailBody = Templates.populateTemplate(resendLinksTemplate,
                 "${userName}", SanitizationHelper.sanitizeForHtml(userName),
                 "${userEmail}", userEmail,
@@ -349,22 +349,9 @@ public final class EmailGenerator {
     }
 
     /**
-     * Generates for the student an recovery email listing the links to submit/view responses for all feedback sessions
-     * under {@code recoveryEmailAddress} in the past 180 days. If no student with {@code recoveryEmailAddress} is
-     * found, generate an email stating that there is no such student in the system. If no feedback sessions are found,
-     * generate an email stating no feedback sessions found.
+     * Generates the email to be sent to a non-existent student when they request for session links recovery.
      */
-    public EmailWrapper generateSessionLinksRecoveryEmailForStudent(String recoveryEmailAddress) {
-        List<Student> studentsForEmail = usersLogic.getAllStudentsForEmail(recoveryEmailAddress);
-
-        if (studentsForEmail.isEmpty()) {
-            return generateSessionLinksRecoveryEmailForNonExistentStudent(recoveryEmailAddress);
-        } else {
-            return generateSessionLinksRecoveryEmailForExistingStudent(recoveryEmailAddress, studentsForEmail);
-        }
-    }
-
-    private EmailWrapper generateSessionLinksRecoveryEmailForNonExistentStudent(String recoveryEmailAddress) {
+    public EmailWrapper generateSessionLinksRecoveryEmailForNonExistentStudent(String recoveryEmailAddress) {
         String recoveryUrl = Config.getFrontEndAppUrl(Const.WebPageURIs.SESSIONS_LINK_RECOVERY_PAGE).toAbsoluteString();
         String emailBody = Templates.populateTemplate(
                 EmailTemplates.SESSION_LINKS_RECOVERY_EMAIL_NOT_FOUND,
@@ -379,9 +366,16 @@ public final class EmailGenerator {
         return email;
     }
 
-    private EmailWrapper generateSessionLinksRecoveryEmailForExistingStudent(String recoveryEmailAddress,
-            List<Student> studentsForEmail) {
-        assert !studentsForEmail.isEmpty();
+    /**
+     * Generates the email to be sent to an existing student when they request for session links recovery.
+     *
+     * <p>Lists the links to submit/view responses for all feedback sessions under the student's email in the past 180 days.
+     */
+    public EmailWrapper generateSessionLinksRecoveryEmailForExistingStudent(
+            String recoveryEmailAddress, List<Student> studentsForEmail) {
+        if (studentsForEmail.isEmpty()) {
+            throw new IllegalArgumentException("studentsForEmail cannot be empty");
+        }
         int firstStudentIdx = 0;
         Map<Course, StringBuilder> linkFragmentsMap = generateLinkFragmentsMap(studentsForEmail);
         String emailBody;
@@ -422,11 +416,11 @@ public final class EmailGenerator {
         return email;
     }
 
-    private Map<Course, StringBuilder> generateLinkFragmentsMap(List<Student> studentsForEmail) {
+    private Map<Course, StringBuilder> generateLinkFragmentsMap(List<Student> students) {
         Instant searchStartTime = TimeHelper.getInstantDaysOffsetBeforeNow(SESSION_LINK_RECOVERY_DURATION_IN_DAYS);
         Map<Course, StringBuilder> linkFragmentsMap = new HashMap<>();
 
-        for (var student : studentsForEmail) {
+        for (var student : students) {
             RequestTracer.checkRemainingTime();
             Course course = student.getCourse();
             String courseId = course.getId();
@@ -504,38 +498,24 @@ public final class EmailGenerator {
         boolean isEmailNeededForInstructors =
                 !deadlineExtensions.isEmpty() && fsLogic.isFeedbackSessionForUserTypeToAnswer(session, true);
 
-        List<Student> students = new ArrayList<>();
-        if (isEmailNeededForStudents) {
-            for (DeadlineExtension de : deadlineExtensions) {
-                Student student = usersLogic.getStudentForEmail(course.getId(), de.getUser().getEmail());
-                if (student != null) {
-                    students.add(student);
-                }
-            }
-        }
-
-        List<Instructor> instructors = new ArrayList<>();
-        if (isEmailNeededForInstructors) {
-            for (DeadlineExtension de : deadlineExtensions) {
-                Instructor instructor =
-                        usersLogic.getInstructorForEmail(course.getId(), de.getUser().getEmail());
-                if (instructor != null) {
-                    instructors.add(instructor);
-                }
-            }
-        }
+        List<User> usersWithExtensions = deadlineExtensions.stream()
+                .map(DeadlineExtension::getUser)
+                .toList();
 
         String template = EmailTemplates.USER_FEEDBACK_SESSION.replace("${status}", FEEDBACK_STATUS_SESSION_CLOSING_SOON);
         EmailType type = EmailType.FEEDBACK_CLOSING_SOON;
         String feedbackAction = FEEDBACK_ACTION_SUBMIT_EDIT_OR_VIEW;
         List<EmailWrapper> emails = new ArrayList<>();
-        for (Student student : students) {
-            emails.addAll(generateFeedbackSessionEmailBases(course, session, Collections.singletonList(student),
-                    Collections.emptyList(), Collections.emptyList(), template, type, feedbackAction));
-        }
-        for (Instructor instructor : instructors) {
-            emails.addAll(generateFeedbackSessionEmailBases(course, session, Collections.emptyList(),
-                    Collections.singletonList(instructor), Collections.emptyList(), template, type, feedbackAction));
+        for (User user : usersWithExtensions) {
+            if (isEmailNeededForStudents && user instanceof Student student) {
+                emails.addAll(generateFeedbackSessionEmailBases(course, session, Collections.singletonList(student),
+                        Collections.emptyList(), Collections.emptyList(), template, type, feedbackAction));
+            }
+            if (isEmailNeededForInstructors && user instanceof Instructor instructor) {
+                emails.addAll(generateFeedbackSessionEmailBases(course, session, Collections.emptyList(),
+                        Collections.singletonList(instructor), Collections.emptyList(), template, type,
+                        feedbackAction));
+            }
         }
         return emails;
     }
@@ -803,14 +783,6 @@ public final class EmailGenerator {
         email.setSubjectFromType(course.getName(), session.getName());
         email.setContent(emailBody);
         return email;
-    }
-
-    private boolean isYetToJoinCourse(Student student) {
-        return student.getAccount() == null || student.getAccount().getGoogleId().isEmpty();
-    }
-
-    private boolean isYetToJoinCourse(Instructor instructor) {
-        return instructor.getAccount() == null || instructor.getAccount().getGoogleId().isEmpty();
     }
 
     /**

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -127,6 +127,7 @@ public class Instructor extends User {
         return getClass().hashCode();
     }
 
+    @Override
     public String getRegistrationUrl() {
         return Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(getRegKey())

--- a/src/main/java/teammates/storage/entity/Student.java
+++ b/src/main/java/teammates/storage/entity/Student.java
@@ -129,6 +129,7 @@ public class Student extends User {
         return errors;
     }
 
+    @Override
     public String getRegistrationUrl() {
         return Config.getFrontEndAppUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(getRegKey())

--- a/src/main/java/teammates/storage/entity/User.java
+++ b/src/main/java/teammates/storage/entity/User.java
@@ -200,4 +200,6 @@ public abstract class User extends BaseEntity {
     public boolean isRegistered() {
         return this.account != null || this.accountId != null;
     }
+
+    public abstract String getRegistrationUrl();
 }

--- a/src/main/java/teammates/storage/entity/User.java
+++ b/src/main/java/teammates/storage/entity/User.java
@@ -201,5 +201,8 @@ public abstract class User extends BaseEntity {
         return this.account != null || this.accountId != null;
     }
 
+    /**
+     * Gets the registration URL for the user.
+     */
     public abstract String getRegistrationUrl();
 }

--- a/src/main/java/teammates/ui/webapi/RegenerateUserKeyAction.java
+++ b/src/main/java/teammates/ui/webapi/RegenerateUserKeyAction.java
@@ -61,8 +61,7 @@ public class RegenerateUserKeyAction extends AdminOnlyAction {
         EmailType emailType = user.getUserType() == UserType.STUDENT
                 ? EmailType.STUDENT_COURSE_LINKS_REGENERATED
                 : EmailType.INSTRUCTOR_COURSE_LINKS_REGENERATED;
-        EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
-                user.getCourseId(), user.getEmail(), emailType);
+        EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(user, emailType);
         EmailSendingStatus status = emailSender.sendEmail(email);
         return status.isSuccess();
     }

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -7,6 +7,7 @@ import java.util.List;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.StringHelper;
+import teammates.storage.entity.Student;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.output.SessionLinksRecoveryResponseData;
 
@@ -29,7 +30,11 @@ public class SessionLinksRecoveryAction extends PublicAction {
                     + "Please try again.");
         }
 
-        EmailWrapper email = emailGenerator.generateSessionLinksRecoveryEmailForStudent(recoveryEmailAddress);
+        List<Student> studentsForEmail = logic.getAllStudentsForEmail(recoveryEmailAddress);
+        EmailWrapper email = studentsForEmail.isEmpty()
+                ? emailGenerator.generateSessionLinksRecoveryEmailForNonExistentStudent(recoveryEmailAddress)
+                : emailGenerator.generateSessionLinksRecoveryEmailForExistingStudent(
+                        recoveryEmailAddress, studentsForEmail);
         taskQueuer.scheduleEmailsForPrioritySending(List.of(email));
 
         return new JsonResult(new SessionLinksRecoveryResponseData(

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -71,8 +71,9 @@ public class UpdateStudentAction extends Action {
             throw new EntityNotFoundException(STUDENT_NOT_FOUND_FOR_EDIT);
         }
 
+        Student updatedStudent;
         try {
-            logic.updateStudent(studentId, updateRequest);
+            updatedStudent = logic.updateStudent(studentId, updateRequest);
         } catch (EnrollException e) {
             throw new InvalidOperationException(e);
         } catch (InvalidParametersException e) {
@@ -84,8 +85,7 @@ public class UpdateStudentAction extends Action {
         }
 
         if (updateRequest.getIsSessionSummarySendEmail()) {
-            String courseId = existingStudent.getCourseId();
-            boolean emailSent = sendEmail(courseId, updateRequest.getEmail());
+            boolean emailSent = sendEmail(updatedStudent);
             String statusMessage = emailSent ? SUCCESSFUL_UPDATE_WITH_EMAIL
                     : SUCCESSFUL_UPDATE_BUT_EMAIL_FAILED;
             return new JsonResult(statusMessage);
@@ -99,9 +99,9 @@ public class UpdateStudentAction extends Action {
      *
      * @return The true if email was sent successfully or false otherwise.
      */
-    private boolean sendEmail(String courseId, String studentEmail) {
+    private boolean sendEmail(Student student) {
         EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
-                courseId, studentEmail, EmailType.STUDENT_EMAIL_CHANGED);
+                student, EmailType.STUDENT_EMAIL_CHANGED);
         EmailSendingStatus status = emailSender.sendEmail(email);
         return status.isSuccess();
     }

--- a/src/test/java/teammates/ui/webapi/SessionLinksRecoveryActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SessionLinksRecoveryActionTest.java
@@ -69,7 +69,7 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         stubEmailWrapper.setRecipient("non-existent@email.com");
         when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(true);
         when(mockLogic.getAllStudentsForEmail("non-existent@email.com")).thenReturn(List.of());
-        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent("non-existent@email.com"))
+        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForNonExistentStudent("non-existent@email.com"))
                 .thenReturn(stubEmailWrapper);
 
         SessionLinksRecoveryAction action = getAction(params);
@@ -89,7 +89,9 @@ public class SessionLinksRecoveryActionTest extends BaseActionTest<SessionLinksR
         };
 
         when(mockRecaptchaVerifier.isVerificationSuccessful(params[3])).thenReturn(true);
-        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForStudent(stubStudent.getEmail()))
+        when(mockLogic.getAllStudentsForEmail(stubStudent.getEmail())).thenReturn(List.of(stubStudent));
+        when(mockEmailGenerator.generateSessionLinksRecoveryEmailForExistingStudent(
+                stubStudent.getEmail(), List.of(stubStudent)))
                 .thenReturn(stubEmailWrapper);
 
         SessionLinksRecoveryAction action = getAction(params);

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionTest.java
@@ -82,8 +82,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockEmailGenerator.generateFeedbackSessionSummaryOfCourse(
-                course.getId(),
-                updatedStudent.getEmail(),
+                updatedStudent,
                 EmailType.STUDENT_EMAIL_CHANGED
         )).thenReturn(mockEmail);
         mockEmailSender.setShouldFail(false);
@@ -98,8 +97,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         verify(mockLogic, times(1)).updateStudent(eq(student.getId()), any());
 
         verify(mockEmailGenerator, times(1)).generateFeedbackSessionSummaryOfCourse(
-                course.getId(),
-                updatedStudent.getEmail(),
+                updatedStudent,
                 EmailType.STUDENT_EMAIL_CHANGED
         );
         verifyNumberOfEmailsSent(1);
@@ -119,8 +117,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
 
         EmailWrapper mockEmail = mock(EmailWrapper.class);
         when(mockEmailGenerator.generateFeedbackSessionSummaryOfCourse(
-                course.getId(),
-                updatedStudent.getEmail(),
+                updatedStudent,
                 EmailType.STUDENT_EMAIL_CHANGED
         )).thenReturn(mockEmail);
         mockEmailSender.setShouldFail(true);
@@ -135,8 +132,7 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         verify(mockLogic, times(1)).updateStudent(eq(student.getId()), any());
 
         verify(mockEmailGenerator, times(1)).generateFeedbackSessionSummaryOfCourse(
-                course.getId(),
-                updatedStudent.getEmail(),
+                updatedStudent,
                 EmailType.STUDENT_EMAIL_CHANGED
         );
 

--- a/static-analysis/teammates-pmd.xml
+++ b/static-analysis/teammates-pmd.xml
@@ -61,7 +61,6 @@
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
     <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
-    <rule ref="category/java/codestyle.xml/PrematureDeclaration"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryCast"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14020

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Updated 3 methods in EmailGenerator. 

1. generateFeedbackSessionSummaryOfCourse

Previously accepted courseId and userEmail. Now accepts a user object instead.

2. generateSessionLinksRecoveryEmailForStudent

Previously, it fetched a list of students for email address. If student list was empty, it generated the appropriate email. Otherwise it generated the email with a list of links. The fetching of students and branching logic has been moved into `SessionLinksRecoveryAction` instead.

3. generateFeedbackSessionClosingWithExtensionEmails

Instead of fetching user by userId, we get the user directly from the DeadlineExtension object instead. The logic here has also been simplified to avoid separated student/instructor branches.


Others:

PMD rule PrematureDeclaration has been disabled. This rule has been applied a little too aggressively in our codebase, especially in the action layer. For example, there are many cases where the code in execute method should ideally be:

// Parse parameters
// validate parameters
// call logic

but have instead become

// parse some parameters
// validate parameters
// parse other parameters
// call logic

which hurts readability.