### PR TITLE
[#14022] Rework GetFeedbackSessionSubmittedGiverSetAction to include non givers

### DIFF
--- a/src/it/java/teammates/it/logic/core/FeedbackSessionsLogicIT.java
+++ b/src/it/java/teammates/it/logic/core/FeedbackSessionsLogicIT.java
@@ -17,6 +17,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.HibernateUtil;
@@ -53,15 +54,16 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithDatabaseAccess {
     @Test
     public void testGiverSetThatAnsweredFeedbackQuestion_hasGivers_findsGivers() throws EntityDoesNotExistException {
         FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
-        Set<String> expectedGivers = new HashSet<>();
+        Set<UUID> expectedStudentGivers = new HashSet<>();
 
-        expectedGivers.add(typicalDataBundle.students.get("student1InCourse1").getEmail());
-        expectedGivers.add(typicalDataBundle.students.get("student2InCourse1").getEmail());
-        expectedGivers.add(typicalDataBundle.students.get("student3InCourse1").getEmail());
+        expectedStudentGivers.add(typicalDataBundle.students.get("student1InCourse1").getId());
+        expectedStudentGivers.add(typicalDataBundle.students.get("student2InCourse1").getId());
+        expectedStudentGivers.add(typicalDataBundle.students.get("student3InCourse1").getId());
 
-        Set<String> givers = fsLogic.getGiverSetThatAnsweredFeedbackSession(fs.getId());
-        assertEquals(expectedGivers.size(), givers.size());
-        assertEquals(expectedGivers, givers);
+        SubmittedGiverSetBundle givers = fsLogic.getSubmittedGiverSetThatAnsweredFeedbackSession(fs.getId());
+        assertEquals(expectedStudentGivers, new HashSet<>(givers.studentGiverIds()));
+        assertTrue(givers.instructorGiverIds().isEmpty());
+        assertTrue(givers.teamGiverIds().isEmpty());
     }
 
     @Test

--- a/src/it/java/teammates/it/logic/core/FeedbackSessionsLogicIT.java
+++ b/src/it/java/teammates/it/logic/core/FeedbackSessionsLogicIT.java
@@ -77,14 +77,12 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithDatabaseAccess {
         SubmittedGiverSetBundle givers = fsLogic.getSubmittedGiverSet(fs.getId());
         assertEquals(expectedStudentGivers, new HashSet<>(givers.studentGiverIds()));
         assertTrue(givers.instructorGiverIds().isEmpty());
-        assertTrue(givers.teamGiverIds().isEmpty());
         assertEquals(expectedStudentNonGivers, new HashSet<>(givers.studentNonGiverIds()));
         assertEquals(expectedInstructorNonGivers, new HashSet<>(givers.instructorNonGiverIds()));
-        assertTrue(givers.teamNonGiverIds().isEmpty());
     }
 
     @Test
-    public void testGetSubmittedGiverSet_studentQuestionsOnly_excludesInstructorAndTeamNonGivers()
+    public void testGetSubmittedGiverSet_studentQuestionsOnly_excludesInstructorNonGivers()
             throws EntityDoesNotExistException {
         FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session2InTypicalCourse");
 
@@ -100,10 +98,8 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         assertEquals(expectedStudentGivers, new HashSet<>(givers.studentGiverIds()));
         assertTrue(givers.instructorGiverIds().isEmpty());
-        assertTrue(givers.teamGiverIds().isEmpty());
         assertEquals(expectedStudentNonGivers, new HashSet<>(givers.studentNonGiverIds()));
         assertTrue(givers.instructorNonGiverIds().isEmpty());
-        assertTrue(givers.teamNonGiverIds().isEmpty());
     }
 
     @Test

--- a/src/it/java/teammates/it/logic/core/FeedbackSessionsLogicIT.java
+++ b/src/it/java/teammates/it/logic/core/FeedbackSessionsLogicIT.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -28,6 +29,7 @@ import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
+import teammates.storage.entity.Student;
 import teammates.ui.output.ResponseVisibleSetting;
 import teammates.ui.output.SessionVisibleSetting;
 import teammates.ui.request.FeedbackSessionUpdateRequest;
@@ -52,18 +54,56 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testGiverSetThatAnsweredFeedbackQuestion_hasGivers_findsGivers() throws EntityDoesNotExistException {
+    public void testGetSubmittedGiverSet_hasGivers_findsGivers() throws EntityDoesNotExistException {
         FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
         Set<UUID> expectedStudentGivers = new HashSet<>();
+        Set<UUID> expectedStudentNonGivers;
+        Set<UUID> expectedInstructorNonGivers = typicalDataBundle.instructors.values()
+                .stream()
+                .filter(instructor -> instructor.getCourseId().equals(fs.getCourseId()))
+                .map(Instructor::getId)
+                .collect(Collectors.toSet());
 
         expectedStudentGivers.add(typicalDataBundle.students.get("student1InCourse1").getId());
         expectedStudentGivers.add(typicalDataBundle.students.get("student2InCourse1").getId());
         expectedStudentGivers.add(typicalDataBundle.students.get("student3InCourse1").getId());
+        expectedStudentNonGivers = typicalDataBundle.students.values()
+                .stream()
+                .filter(student -> student.getCourseId().equals(fs.getCourseId()))
+                .map(Student::getId)
+                .filter(studentId -> !expectedStudentGivers.contains(studentId))
+                .collect(Collectors.toSet());
 
-        SubmittedGiverSetBundle givers = fsLogic.getSubmittedGiverSetThatAnsweredFeedbackSession(fs.getId());
+        SubmittedGiverSetBundle givers = fsLogic.getSubmittedGiverSet(fs.getId());
         assertEquals(expectedStudentGivers, new HashSet<>(givers.studentGiverIds()));
         assertTrue(givers.instructorGiverIds().isEmpty());
         assertTrue(givers.teamGiverIds().isEmpty());
+        assertEquals(expectedStudentNonGivers, new HashSet<>(givers.studentNonGiverIds()));
+        assertEquals(expectedInstructorNonGivers, new HashSet<>(givers.instructorNonGiverIds()));
+        assertTrue(givers.teamNonGiverIds().isEmpty());
+    }
+
+    @Test
+    public void testGetSubmittedGiverSet_studentQuestionsOnly_excludesInstructorAndTeamNonGivers()
+            throws EntityDoesNotExistException {
+        FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session2InTypicalCourse");
+
+        Set<UUID> expectedStudentGivers = Set.of(typicalDataBundle.students.get("student1InCourse1").getId());
+        Set<UUID> expectedStudentNonGivers = typicalDataBundle.students.values()
+                .stream()
+                .filter(student -> student.getCourseId().equals(fs.getCourseId()))
+                .map(Student::getId)
+                .filter(studentId -> !expectedStudentGivers.contains(studentId))
+                .collect(Collectors.toSet());
+
+        SubmittedGiverSetBundle givers = fsLogic.getSubmittedGiverSet(fs.getId());
+
+        assertEquals(expectedStudentGivers, new HashSet<>(givers.studentGiverIds()));
+        assertTrue(givers.instructorGiverIds().isEmpty());
+        assertTrue(givers.teamGiverIds().isEmpty());
+        assertEquals(expectedStudentNonGivers, new HashSet<>(givers.studentNonGiverIds()));
+        assertTrue(givers.instructorNonGiverIds().isEmpty());
+        assertTrue(givers.teamNonGiverIds().isEmpty());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
@@ -88,12 +88,10 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
                 .map(Instructor::getId)
                 .collect(Collectors.toSet());
         assertEquals(Collections.emptySet(), output.getInstructorGivers());
-        assertEquals(Collections.emptySet(), output.getTeamGivers());
         assertEquals(expectedStudentNonGivers, Sets.newHashSet(output.getStudentNonGivers()));
         assertEquals(expectedInstructorNonGivers, Sets.newHashSet(output.getInstructorNonGivers()));
-        assertEquals(Collections.emptySet(), output.getTeamNonGivers());
 
-        ______TS("Session with student questions only should not produce instructor/team non-givers");
+        ______TS("Session with student questions only should not produce instructor non-givers");
         FeedbackSession fsb = typicalBundle.feedbackSessions.get("session2InTypicalCourse");
         String[] session2Params = new String[] {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fsb.getId().toString(),
@@ -116,7 +114,6 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
         assertEquals(expectedSession2StudentNonGivers,
                 Sets.newHashSet(session2Output.getStudentNonGivers()));
         assertEquals(Collections.emptySet(), session2Output.getInstructorNonGivers());
-        assertEquals(Collections.emptySet(), session2Output.getTeamNonGivers());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
@@ -3,6 +3,9 @@ package teammates.it.ui.webapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -14,6 +17,7 @@ import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
+import teammates.storage.entity.Student;
 import teammates.ui.output.FeedbackSessionSubmittedGiverSet;
 import teammates.ui.webapi.GetFeedbackSessionSubmittedGiverSetAction;
 import teammates.ui.webapi.JsonResult;
@@ -63,13 +67,56 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
         JsonResult result = getJsonResult(pageAction);
 
         FeedbackSessionSubmittedGiverSet output = (FeedbackSessionSubmittedGiverSet) result.getOutput();
+        Set<UUID> expectedStudentGivers = Sets.newHashSet(
+                typicalBundle.students.get("student1InCourse1").getId(),
+                typicalBundle.students.get("student2InCourse1").getId(),
+                typicalBundle.students.get("student3InCourse1").getId());
+        Set<UUID> expectedStudentNonGivers = typicalBundle.students.values()
+                .stream()
+                .filter(student -> student.getCourseId().equals(fsa.getCourseId()))
+                .map(Student::getId)
+                .filter(studentId -> !expectedStudentGivers.contains(studentId))
+                .collect(Collectors.toSet());
         assertEquals(Sets.newHashSet(
                 typicalBundle.students.get("student1InCourse1").getId(),
                 typicalBundle.students.get("student2InCourse1").getId(),
                 typicalBundle.students.get("student3InCourse1").getId()),
                 Sets.newHashSet(output.getStudentGivers()));
+        Set<UUID> expectedInstructorNonGivers = typicalBundle.instructors.values()
+                .stream()
+                .filter(instructor -> instructor.getCourseId().equals(fsa.getCourseId()))
+                .map(Instructor::getId)
+                .collect(Collectors.toSet());
         assertEquals(Collections.emptySet(), output.getInstructorGivers());
         assertEquals(Collections.emptySet(), output.getTeamGivers());
+        assertEquals(expectedStudentNonGivers, Sets.newHashSet(output.getStudentNonGivers()));
+        assertEquals(expectedInstructorNonGivers, Sets.newHashSet(output.getInstructorNonGivers()));
+        assertEquals(Collections.emptySet(), output.getTeamNonGivers());
+
+        ______TS("Session with student questions only should not produce instructor/team non-givers");
+        FeedbackSession fsb = typicalBundle.feedbackSessions.get("session2InTypicalCourse");
+        String[] session2Params = new String[] {
+                Const.ParamsNames.FEEDBACK_SESSION_ID, fsb.getId().toString(),
+        };
+
+        GetFeedbackSessionSubmittedGiverSetAction session2Action = getAction(session2Params);
+        JsonResult session2Result = getJsonResult(session2Action);
+        FeedbackSessionSubmittedGiverSet session2Output = (FeedbackSessionSubmittedGiverSet) session2Result.getOutput();
+
+        Set<UUID> expectedSession2StudentGivers = Sets.newHashSet(typicalBundle.students.get("student1InCourse1").getId());
+        Set<UUID> expectedSession2StudentNonGivers = typicalBundle.students.values()
+                .stream()
+                .filter(student -> student.getCourseId().equals(fsb.getCourseId()))
+                .map(Student::getId)
+                .filter(studentId -> !expectedSession2StudentGivers.contains(studentId))
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedSession2StudentGivers,
+                Sets.newHashSet(session2Output.getStudentGivers()));
+        assertEquals(expectedSession2StudentNonGivers,
+                Sets.newHashSet(session2Output.getStudentNonGivers()));
+        assertEquals(Collections.emptySet(), session2Output.getInstructorNonGivers());
+        assertEquals(Collections.emptySet(), session2Output.getTeamNonGivers());
     }
 
     @Test

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
@@ -2,6 +2,8 @@ package teammates.it.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -61,8 +63,13 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
         JsonResult result = getJsonResult(pageAction);
 
         FeedbackSessionSubmittedGiverSet output = (FeedbackSessionSubmittedGiverSet) result.getOutput();
-        assertEquals(Sets.newHashSet("student1@teammates.tmt", "student2@teammates.tmt",
-                "student3@teammates.tmt"), output.getGiverIdentifiers());
+        assertEquals(Sets.newHashSet(
+                typicalBundle.students.get("student1InCourse1").getId(),
+                typicalBundle.students.get("student2InCourse1").getId(),
+                typicalBundle.students.get("student3InCourse1").getId()),
+                Sets.newHashSet(output.getStudentGivers()));
+        assertEquals(Collections.emptySet(), output.getInstructorGivers());
+        assertEquals(Collections.emptySet(), output.getTeamGivers());
     }
 
     @Test

--- a/src/main/java/teammates/common/datatransfer/SubmittedGiverSetBundle.java
+++ b/src/main/java/teammates/common/datatransfer/SubmittedGiverSetBundle.java
@@ -1,0 +1,17 @@
+package teammates.common.datatransfer;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Represents submitted givers partitioned by giver type.
+ *
+ * @param studentGiverIds    set of student giver ids
+ * @param instructorGiverIds set of instructor giver ids
+ * @param teamGiverIds       set of team giver ids
+ */
+public record SubmittedGiverSetBundle(
+        Set<UUID> studentGiverIds,
+        Set<UUID> instructorGiverIds,
+        Set<UUID> teamGiverIds) {
+}

--- a/src/main/java/teammates/common/datatransfer/SubmittedGiverSetBundle.java
+++ b/src/main/java/teammates/common/datatransfer/SubmittedGiverSetBundle.java
@@ -6,12 +6,30 @@ import java.util.UUID;
 /**
  * Represents submitted givers partitioned by giver type.
  *
- * @param studentGiverIds    set of student giver ids
- * @param instructorGiverIds set of instructor giver ids
- * @param teamGiverIds       set of team giver ids
+ * @param studentGiverIds       set of student giver ids
+ * @param instructorGiverIds    set of instructor giver ids
+ * @param teamGiverIds          set of team giver ids
+ * @param studentNonGiverIds    set of students with at least one answerable
+ *                              question but no submission
+ * @param instructorNonGiverIds set of instructors with at least one answerable
+ *                              question but no submission
+ * @param teamNonGiverIds       set of teams with at least one answerable
+ *                              question but no submission
  */
 public record SubmittedGiverSetBundle(
         Set<UUID> studentGiverIds,
         Set<UUID> instructorGiverIds,
-        Set<UUID> teamGiverIds) {
+        Set<UUID> teamGiverIds,
+        Set<UUID> studentNonGiverIds,
+        Set<UUID> instructorNonGiverIds,
+        Set<UUID> teamNonGiverIds) {
+
+    public SubmittedGiverSetBundle {
+        studentGiverIds = Set.copyOf(studentGiverIds);
+        instructorGiverIds = Set.copyOf(instructorGiverIds);
+        teamGiverIds = Set.copyOf(teamGiverIds);
+        studentNonGiverIds = Set.copyOf(studentNonGiverIds);
+        instructorNonGiverIds = Set.copyOf(instructorNonGiverIds);
+        teamNonGiverIds = Set.copyOf(teamNonGiverIds);
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/SubmittedGiverSetBundle.java
+++ b/src/main/java/teammates/common/datatransfer/SubmittedGiverSetBundle.java
@@ -4,32 +4,25 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * Represents submitted givers partitioned by giver type.
+ * Represents submitted and non-submitted givers by user type.
  *
- * @param studentGiverIds       set of student giver ids
+ * @param studentGiverIds       set of student giver ids; includes students in a responding team
  * @param instructorGiverIds    set of instructor giver ids
- * @param teamGiverIds          set of team giver ids
  * @param studentNonGiverIds    set of students with at least one answerable
  *                              question but no submission
  * @param instructorNonGiverIds set of instructors with at least one answerable
- *                              question but no submission
- * @param teamNonGiverIds       set of teams with at least one answerable
  *                              question but no submission
  */
 public record SubmittedGiverSetBundle(
         Set<UUID> studentGiverIds,
         Set<UUID> instructorGiverIds,
-        Set<UUID> teamGiverIds,
         Set<UUID> studentNonGiverIds,
-        Set<UUID> instructorNonGiverIds,
-        Set<UUID> teamNonGiverIds) {
+        Set<UUID> instructorNonGiverIds) {
 
     public SubmittedGiverSetBundle {
         studentGiverIds = Set.copyOf(studentGiverIds);
         instructorGiverIds = Set.copyOf(instructorGiverIds);
-        teamGiverIds = Set.copyOf(teamGiverIds);
         studentNonGiverIds = Set.copyOf(studentNonGiverIds);
         instructorNonGiverIds = Set.copyOf(instructorNonGiverIds);
-        teamNonGiverIds = Set.copyOf(teamNonGiverIds);
     }
 }

--- a/src/main/java/teammates/common/datatransfer/participanttypes/QuestionGiverType.java
+++ b/src/main/java/teammates/common/datatransfer/participanttypes/QuestionGiverType.java
@@ -34,4 +34,6 @@ public enum QuestionGiverType {
      * Teams of the same section.
      */
     TEAMS_IN_SAME_SECTION
+
+    // TODO: remove TEAMS_IN_SAME_SECTION and STUDENTS_IN_SAME_SECTION as these are not valid giver types
 }

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -17,6 +17,7 @@ import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.SessionResultsBundle;
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.datatransfer.UpdateExtensionsResult;
 import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 import teammates.common.exception.EnrollException;
@@ -537,13 +538,13 @@ public class Logic {
     }
 
     /**
-     * Gets a set of giver identifiers that has at least one response under a feedback session.
+     * Gets submitted givers partitioned by giver type under a feedback session.
      *
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
-    public Set<String> getGiverSetThatAnsweredFeedbackSession(
+    public SubmittedGiverSetBundle getSubmittedGiverSetThatAnsweredFeedbackSession(
             UUID feedbackSessionId) throws EntityDoesNotExistException {
-        return feedbackSessionsLogic.getGiverSetThatAnsweredFeedbackSession(feedbackSessionId);
+        return feedbackSessionsLogic.getSubmittedGiverSetThatAnsweredFeedbackSession(feedbackSessionId);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -542,9 +542,9 @@ public class Logic {
      *
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
-    public SubmittedGiverSetBundle getSubmittedGiverSetThatAnsweredFeedbackSession(
+    public SubmittedGiverSetBundle getSubmittedGiverSet(
             UUID feedbackSessionId) throws EntityDoesNotExistException {
-        return feedbackSessionsLogic.getSubmittedGiverSetThatAnsweredFeedbackSession(feedbackSessionId);
+        return feedbackSessionsLogic.getSubmittedGiverSet(feedbackSessionId);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -3,9 +3,9 @@ package teammates.logic.core;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -27,6 +27,8 @@ import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.ResponseGiver;
+import teammates.storage.entity.Student;
+import teammates.storage.entity.Team;
 import teammates.ui.request.FeedbackSessionUpdateRequest;
 
 /**
@@ -156,7 +158,7 @@ public final class FeedbackSessionsLogic {
      *
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
-    public SubmittedGiverSetBundle getSubmittedGiverSetThatAnsweredFeedbackSession(
+    public SubmittedGiverSetBundle getSubmittedGiverSet(
             UUID feedbackSessionId) throws EntityDoesNotExistException {
         FeedbackSession feedbackSession = fsDb.getFeedbackSession(feedbackSessionId);
         if (feedbackSession == null) {
@@ -164,14 +166,31 @@ public final class FeedbackSessionsLogic {
                 String.format("Feedback session with id %s not found.", feedbackSessionId));
         }
 
-        return getSubmittedGiverSetThatAnsweredFeedbackSession(feedbackSession);
+        return getSubmittedGiverSet(feedbackSession);
     }
 
-    private SubmittedGiverSetBundle getSubmittedGiverSetThatAnsweredFeedbackSession(FeedbackSession feedbackSession) {
-        Set<UUID> studentGiverIds = new TreeSet<>(Comparator.comparing(UUID::toString));
-        Set<UUID> instructorGiverIds = new TreeSet<>(Comparator.comparing(UUID::toString));
-        Set<UUID> teamGiverIds = new TreeSet<>(Comparator.comparing(UUID::toString));
+    private SubmittedGiverSetBundle getSubmittedGiverSet(FeedbackSession feedbackSession) {
+        Set<FeedbackQuestion> questions = feedbackSession.getFeedbackQuestions();
+        boolean hasQuestionsForStudents = fqLogic.hasFeedbackQuestionsForGiverType(questions, QuestionGiverType.STUDENTS);
+        boolean hasQuestionsForInstructors = fqLogic.hasFeedbackQuestionsForInstructors(questions, false);
+        boolean hasQuestionsForTeams = fqLogic.hasFeedbackQuestionsForGiverType(questions, QuestionGiverType.TEAMS);
 
+        List<Student> students = usersLogic.getStudentsForCourse(feedbackSession.getCourseId());
+        List<Instructor> instructors = usersLogic.getInstructorsForCourse(feedbackSession.getCourseId());
+        List<Team> teams = students.stream()
+                .map(Student::getTeam)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        Set<UUID> studentGiverIds = new TreeSet<>();
+        Set<UUID> instructorGiverIds = new TreeSet<>();
+        Set<UUID> teamGiverIds = new TreeSet<>();
+        Set<UUID> studentNonGiverIds = new TreeSet<>();
+        Set<UUID> instructorNonGiverIds = new TreeSet<>();
+        Set<UUID> teamNonGiverIds = new TreeSet<>();
+
+        // Populate giver sets
         for (FeedbackQuestion question : feedbackSession.getFeedbackQuestions()) {
             for (FeedbackResponse response : question.getFeedbackResponses()) {
                 ResponseGiver responseGiver = response.getGiver();
@@ -188,7 +207,33 @@ public final class FeedbackSessionsLogic {
             }
         }
 
-        return new SubmittedGiverSetBundle(studentGiverIds, instructorGiverIds, teamGiverIds);
+        // Populate non-giver sets
+        if (hasQuestionsForStudents) {
+            Set<UUID> allStudentIds = students.stream()
+                    .map(Student::getId)
+                    .collect(Collectors.toSet());
+            studentNonGiverIds.addAll(allStudentIds);
+            studentNonGiverIds.removeAll(studentGiverIds);
+        }
+
+        if (hasQuestionsForInstructors) {
+            Set<UUID> allInstructorIds = instructors.stream()
+                    .map(Instructor::getId)
+                    .collect(Collectors.toSet());
+            instructorNonGiverIds.addAll(allInstructorIds);
+            instructorNonGiverIds.removeAll(instructorGiverIds);
+        }
+
+        if (hasQuestionsForTeams) {
+            Set<UUID> allTeamIds = teams.stream()
+                    .map(Team::getId)
+                    .collect(Collectors.toSet());
+            teamNonGiverIds.addAll(allTeamIds);
+            teamNonGiverIds.removeAll(teamGiverIds);
+        }
+
+        return new SubmittedGiverSetBundle(studentGiverIds, instructorGiverIds, teamGiverIds,
+                studentNonGiverIds, instructorNonGiverIds, teamNonGiverIds);
     }
 
     /**
@@ -580,7 +625,7 @@ public final class FeedbackSessionsLogic {
      * Gets the actual number of submissions for a feedback session.
      */
     public int getActualTotalSubmission(FeedbackSession fs) {
-        SubmittedGiverSetBundle submittedGiverSetBundle = getSubmittedGiverSetThatAnsweredFeedbackSession(fs);
+        SubmittedGiverSetBundle submittedGiverSetBundle = getSubmittedGiverSet(fs);
         return submittedGiverSetBundle.studentGiverIds().size()
                 + submittedGiverSetBundle.instructorGiverIds().size()
                 + submittedGiverSetBundle.teamGiverIds().size();

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -3,12 +3,15 @@ package teammates.logic.core;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -149,11 +152,11 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * Gets a set of giver identifiers that has at least one response under a feedback session.
+     * Gets submitted givers partitioned by giver type under a feedback session.
      *
      * @throws EntityDoesNotExistException if the feedback session cannot be found
      */
-    public Set<String> getGiverSetThatAnsweredFeedbackSession(
+    public SubmittedGiverSetBundle getSubmittedGiverSetThatAnsweredFeedbackSession(
             UUID feedbackSessionId) throws EntityDoesNotExistException {
         FeedbackSession feedbackSession = fsDb.getFeedbackSession(feedbackSessionId);
         if (feedbackSession == null) {
@@ -161,15 +164,31 @@ public final class FeedbackSessionsLogic {
                 String.format("Feedback session with id %s not found.", feedbackSessionId));
         }
 
-        return getGiverSetThatAnsweredFeedbackSession(feedbackSession);
+        return getSubmittedGiverSetThatAnsweredFeedbackSession(feedbackSession);
     }
 
-    private Set<String> getGiverSetThatAnsweredFeedbackSession(FeedbackSession feedbackSession) {
-        return feedbackSession.getFeedbackQuestions().stream()
-                .flatMap(question -> question.getFeedbackResponses().stream())
-                .map(FeedbackResponse::getGiver)
-                .map(ResponseGiver::getIdentifier)
-                .collect(Collectors.toUnmodifiableSet());
+    private SubmittedGiverSetBundle getSubmittedGiverSetThatAnsweredFeedbackSession(FeedbackSession feedbackSession) {
+        Set<UUID> studentGiverIds = new TreeSet<>(Comparator.comparing(UUID::toString));
+        Set<UUID> instructorGiverIds = new TreeSet<>(Comparator.comparing(UUID::toString));
+        Set<UUID> teamGiverIds = new TreeSet<>(Comparator.comparing(UUID::toString));
+
+        for (FeedbackQuestion question : feedbackSession.getFeedbackQuestions()) {
+            for (FeedbackResponse response : question.getFeedbackResponses()) {
+                ResponseGiver responseGiver = response.getGiver();
+
+                if (responseGiver.isGiverStudent()) {
+                    studentGiverIds.add(responseGiver.getGiverUserId());
+                } else if (responseGiver.isGiverInstructor()) {
+                    instructorGiverIds.add(responseGiver.getGiverUserId());
+                } else if (responseGiver.isGiverTeam()) {
+                    teamGiverIds.add(responseGiver.getGiverTeamId());
+                } else {
+                    log.warning("Unknown giver type for response: " + response.getId());
+                }
+            }
+        }
+
+        return new SubmittedGiverSetBundle(studentGiverIds, instructorGiverIds, teamGiverIds);
     }
 
     /**
@@ -561,7 +580,10 @@ public final class FeedbackSessionsLogic {
      * Gets the actual number of submissions for a feedback session.
      */
     public int getActualTotalSubmission(FeedbackSession fs) {
-        return getGiverSetThatAnsweredFeedbackSession(fs).size();
+        SubmittedGiverSetBundle submittedGiverSetBundle = getSubmittedGiverSetThatAnsweredFeedbackSession(fs);
+        return submittedGiverSetBundle.studentGiverIds().size()
+                + submittedGiverSetBundle.instructorGiverIds().size()
+                + submittedGiverSetBundle.teamGiverIds().size();
     }
 
     private void validateFeedbackSession(FeedbackSession feedbackSession)

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -5,7 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -28,7 +28,6 @@ import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.Student;
-import teammates.storage.entity.Team;
 import teammates.ui.request.FeedbackSessionUpdateRequest;
 
 /**
@@ -171,24 +170,24 @@ public final class FeedbackSessionsLogic {
 
     private SubmittedGiverSetBundle getSubmittedGiverSet(FeedbackSession feedbackSession) {
         Set<FeedbackQuestion> questions = feedbackSession.getFeedbackQuestions();
-        boolean hasQuestionsForStudents = fqLogic.hasFeedbackQuestionsForGiverType(questions, QuestionGiverType.STUDENTS);
+        boolean hasQuestionsForStudents = fqLogic.hasFeedbackQuestionsForStudents(questions);
+        boolean hasQuestionsForIndividualStudents = fqLogic.hasFeedbackQuestionsForGiverType(
+                questions, QuestionGiverType.STUDENTS);
+        boolean shouldCountTeamResponsesAsStudentSubmissions = hasQuestionsForStudents
+                && !hasQuestionsForIndividualStudents;
         boolean hasQuestionsForInstructors = fqLogic.hasFeedbackQuestionsForInstructors(questions, false);
-        boolean hasQuestionsForTeams = fqLogic.hasFeedbackQuestionsForGiverType(questions, QuestionGiverType.TEAMS);
 
         List<Student> students = usersLogic.getStudentsForCourse(feedbackSession.getCourseId());
         List<Instructor> instructors = usersLogic.getInstructorsForCourse(feedbackSession.getCourseId());
-        List<Team> teams = students.stream()
-                .map(Student::getTeam)
-                .filter(Objects::nonNull)
-                .distinct()
-                .toList();
+        Map<UUID, Set<UUID>> studentIdsByTeamId = students.stream()
+                .filter(student -> student.getTeam() != null)
+                .collect(Collectors.groupingBy(student -> student.getTeam().getId(),
+                        Collectors.mapping(Student::getId, Collectors.toCollection(HashSet::new))));
 
         Set<UUID> studentGiverIds = new TreeSet<>();
         Set<UUID> instructorGiverIds = new TreeSet<>();
-        Set<UUID> teamGiverIds = new TreeSet<>();
         Set<UUID> studentNonGiverIds = new TreeSet<>();
         Set<UUID> instructorNonGiverIds = new TreeSet<>();
-        Set<UUID> teamNonGiverIds = new TreeSet<>();
 
         // Populate giver sets
         for (FeedbackQuestion question : feedbackSession.getFeedbackQuestions()) {
@@ -200,7 +199,10 @@ public final class FeedbackSessionsLogic {
                 } else if (responseGiver.isGiverInstructor()) {
                     instructorGiverIds.add(responseGiver.getGiverUserId());
                 } else if (responseGiver.isGiverTeam()) {
-                    teamGiverIds.add(responseGiver.getGiverTeamId());
+                    // For team-only sessions, one team response marks all team members as submitted.
+                    if (shouldCountTeamResponsesAsStudentSubmissions) {
+                        addStudentGiversForTeamResponse(response, studentIdsByTeamId, studentGiverIds);
+                    }
                 } else {
                     log.warning("Unknown giver type for response: " + response.getId());
                 }
@@ -224,16 +226,19 @@ public final class FeedbackSessionsLogic {
             instructorNonGiverIds.removeAll(instructorGiverIds);
         }
 
-        if (hasQuestionsForTeams) {
-            Set<UUID> allTeamIds = teams.stream()
-                    .map(Team::getId)
-                    .collect(Collectors.toSet());
-            teamNonGiverIds.addAll(allTeamIds);
-            teamNonGiverIds.removeAll(teamGiverIds);
+        return new SubmittedGiverSetBundle(studentGiverIds, instructorGiverIds, studentNonGiverIds, instructorNonGiverIds);
+    }
+
+    private void addStudentGiversForTeamResponse(FeedbackResponse response, Map<UUID, Set<UUID>> studentIdsByTeamId,
+            Set<UUID> studentGiverIds) {
+        UUID giverTeamId = response.getGiver().getGiverTeamId();
+        Set<UUID> memberStudentIds = studentIdsByTeamId.get(giverTeamId);
+        if (memberStudentIds == null || memberStudentIds.isEmpty()) {
+            log.warning("No students found for team giver response: " + response.getId());
+            return;
         }
 
-        return new SubmittedGiverSetBundle(studentGiverIds, instructorGiverIds, teamGiverIds,
-                studentNonGiverIds, instructorNonGiverIds, teamNonGiverIds);
+        studentGiverIds.addAll(memberStudentIds);
     }
 
     /**
@@ -627,8 +632,7 @@ public final class FeedbackSessionsLogic {
     public int getActualTotalSubmission(FeedbackSession fs) {
         SubmittedGiverSetBundle submittedGiverSetBundle = getSubmittedGiverSet(fs);
         return submittedGiverSetBundle.studentGiverIds().size()
-                + submittedGiverSetBundle.instructorGiverIds().size()
-                + submittedGiverSetBundle.teamGiverIds().size();
+                + submittedGiverSetBundle.instructorGiverIds().size();
     }
 
     private void validateFeedbackSession(FeedbackSession feedbackSession)

--- a/src/main/java/teammates/ui/output/FeedbackSessionSubmittedGiverSet.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionSubmittedGiverSet.java
@@ -12,11 +12,17 @@ public class FeedbackSessionSubmittedGiverSet extends ApiOutput {
     private final Set<UUID> studentGivers;
     private final Set<UUID> instructorGivers;
     private final Set<UUID> teamGivers;
+    private final Set<UUID> studentNonGivers;
+    private final Set<UUID> instructorNonGivers;
+    private final Set<UUID> teamNonGivers;
 
     public FeedbackSessionSubmittedGiverSet(SubmittedGiverSetBundle submittedGiverSetBundle) {
         this.studentGivers = submittedGiverSetBundle.studentGiverIds();
         this.instructorGivers = submittedGiverSetBundle.instructorGiverIds();
         this.teamGivers = submittedGiverSetBundle.teamGiverIds();
+        this.studentNonGivers = submittedGiverSetBundle.studentNonGiverIds();
+        this.instructorNonGivers = submittedGiverSetBundle.instructorNonGiverIds();
+        this.teamNonGivers = submittedGiverSetBundle.teamNonGiverIds();
     }
 
     public Set<UUID> getStudentGivers() {
@@ -29,5 +35,17 @@ public class FeedbackSessionSubmittedGiverSet extends ApiOutput {
 
     public Set<UUID> getTeamGivers() {
         return teamGivers;
+    }
+
+    public Set<UUID> getStudentNonGivers() {
+        return studentNonGivers;
+    }
+
+    public Set<UUID> getInstructorNonGivers() {
+        return instructorNonGivers;
+    }
+
+    public Set<UUID> getTeamNonGivers() {
+        return teamNonGivers;
     }
 }

--- a/src/main/java/teammates/ui/output/FeedbackSessionSubmittedGiverSet.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionSubmittedGiverSet.java
@@ -11,18 +11,14 @@ import teammates.common.datatransfer.SubmittedGiverSetBundle;
 public class FeedbackSessionSubmittedGiverSet extends ApiOutput {
     private final Set<UUID> studentGivers;
     private final Set<UUID> instructorGivers;
-    private final Set<UUID> teamGivers;
     private final Set<UUID> studentNonGivers;
     private final Set<UUID> instructorNonGivers;
-    private final Set<UUID> teamNonGivers;
 
     public FeedbackSessionSubmittedGiverSet(SubmittedGiverSetBundle submittedGiverSetBundle) {
         this.studentGivers = submittedGiverSetBundle.studentGiverIds();
         this.instructorGivers = submittedGiverSetBundle.instructorGiverIds();
-        this.teamGivers = submittedGiverSetBundle.teamGiverIds();
         this.studentNonGivers = submittedGiverSetBundle.studentNonGiverIds();
         this.instructorNonGivers = submittedGiverSetBundle.instructorNonGiverIds();
-        this.teamNonGivers = submittedGiverSetBundle.teamNonGiverIds();
     }
 
     public Set<UUID> getStudentGivers() {
@@ -33,19 +29,11 @@ public class FeedbackSessionSubmittedGiverSet extends ApiOutput {
         return instructorGivers;
     }
 
-    public Set<UUID> getTeamGivers() {
-        return teamGivers;
-    }
-
     public Set<UUID> getStudentNonGivers() {
         return studentNonGivers;
     }
 
     public Set<UUID> getInstructorNonGivers() {
         return instructorNonGivers;
-    }
-
-    public Set<UUID> getTeamNonGivers() {
-        return teamNonGivers;
     }
 }

--- a/src/main/java/teammates/ui/output/FeedbackSessionSubmittedGiverSet.java
+++ b/src/main/java/teammates/ui/output/FeedbackSessionSubmittedGiverSet.java
@@ -1,18 +1,33 @@
 package teammates.ui.output;
 
 import java.util.Set;
+import java.util.UUID;
+
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
 
 /**
  * The API output format of all givers who submitted a feedback session.
  */
 public class FeedbackSessionSubmittedGiverSet extends ApiOutput {
-    private final Set<String> giverIdentifiers;
+    private final Set<UUID> studentGivers;
+    private final Set<UUID> instructorGivers;
+    private final Set<UUID> teamGivers;
 
-    public FeedbackSessionSubmittedGiverSet(Set<String> giverIdentifiers) {
-        this.giverIdentifiers = giverIdentifiers;
+    public FeedbackSessionSubmittedGiverSet(SubmittedGiverSetBundle submittedGiverSetBundle) {
+        this.studentGivers = submittedGiverSetBundle.studentGiverIds();
+        this.instructorGivers = submittedGiverSetBundle.instructorGiverIds();
+        this.teamGivers = submittedGiverSetBundle.teamGiverIds();
     }
 
-    public Set<String> getGiverIdentifiers() {
-        return giverIdentifiers;
+    public Set<UUID> getStudentGivers() {
+        return studentGivers;
+    }
+
+    public Set<UUID> getInstructorGivers() {
+        return instructorGivers;
+    }
+
+    public Set<UUID> getTeamGivers() {
+        return teamGivers;
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -41,7 +41,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
 
         SubmittedGiverSetBundle submittedGiverSetBundle;
         try {
-            submittedGiverSetBundle = logic.getSubmittedGiverSetThatAnsweredFeedbackSession(feedbackSessionId);
+            submittedGiverSetBundle = logic.getSubmittedGiverSet(feedbackSessionId);
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
         }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -1,8 +1,8 @@
 package teammates.ui.webapi;
 
-import java.util.Set;
 import java.util.UUID;
 
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
@@ -39,14 +39,14 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
     public JsonResult execute() {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        Set<String> giverSet;
+        SubmittedGiverSetBundle submittedGiverSetBundle;
         try {
-            giverSet = logic.getGiverSetThatAnsweredFeedbackSession(feedbackSessionId);
+            submittedGiverSetBundle = logic.getSubmittedGiverSetThatAnsweredFeedbackSession(feedbackSessionId);
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);
         }
 
-        FeedbackSessionSubmittedGiverSet output = new FeedbackSessionSubmittedGiverSet(giverSet);
+        FeedbackSessionSubmittedGiverSet output = new FeedbackSessionSubmittedGiverSet(submittedGiverSetBundle);
         return new JsonResult(output);
     }
 }

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
+import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.exception.InvalidParametersException;
@@ -34,6 +36,7 @@ import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.Team;
 import teammates.test.BaseTestCase;
 import teammates.ui.output.ResponseVisibleSetting;
 import teammates.ui.output.SessionVisibleSetting;
@@ -412,6 +415,84 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
         int result = fsLogic.getActualTotalSubmission(session);
 
         assertEquals(0, result);
+    }
+
+    @Test
+    public void testGetSubmittedGiverSet_hasIndividualAndTeamQuestions_ignoresTeamResponsesForStudentSubmissions()
+            throws EntityDoesNotExistException {
+        Course course = getTypicalCourse();
+        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
+        UUID sessionId = UUID.randomUUID();
+        session.setId(sessionId);
+
+        FeedbackQuestion studentQuestion = getTypicalFeedbackQuestionForSession(session);
+        studentQuestion.setGiverType(QuestionGiverType.STUDENTS);
+        FeedbackQuestion teamQuestion = getTypicalFeedbackQuestionForSession(session);
+        teamQuestion.setGiverType(QuestionGiverType.TEAMS);
+        session.setFeedbackQuestions(Set.of(studentQuestion, teamQuestion));
+
+        Team team = new Team("Team A");
+        Student student1 = getTypicalStudent();
+        student1.setId(UUID.randomUUID());
+        student1.setTeam(team);
+        Student student2 = getTypicalStudent();
+        student2.setId(UUID.randomUUID());
+        student2.setTeam(team);
+
+        FeedbackResponse teamResponse = getTypicalFeedbackResponseForQuestion(teamQuestion);
+        teamResponse.setGiver(new ResponseGiver(team));
+        teamQuestion.addFeedbackResponse(teamResponse);
+
+        when(fsDb.getFeedbackSession(sessionId)).thenReturn(session);
+        when(usersLogic.getStudentsForCourse(course.getId())).thenReturn(List.of(student1, student2));
+        when(usersLogic.getInstructorsForCourse(course.getId())).thenReturn(List.of());
+        when(fqLogic.hasFeedbackQuestionsForStudents(session.getFeedbackQuestions())).thenReturn(true);
+        when(fqLogic.hasFeedbackQuestionsForGiverType(session.getFeedbackQuestions(), QuestionGiverType.STUDENTS))
+                .thenReturn(true);
+        when(fqLogic.hasFeedbackQuestionsForInstructors(session.getFeedbackQuestions(), false)).thenReturn(false);
+
+        SubmittedGiverSetBundle submittedGiverSet = fsLogic.getSubmittedGiverSet(sessionId);
+
+        assertTrue(submittedGiverSet.studentGiverIds().isEmpty());
+        assertEquals(Set.of(student1.getId(), student2.getId()), submittedGiverSet.studentNonGiverIds());
+    }
+
+    @Test
+    public void testGetSubmittedGiverSet_teamOnlyQuestions_teamResponseMarksAllMembersSubmitted()
+            throws EntityDoesNotExistException {
+        Course course = getTypicalCourse();
+        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
+        UUID sessionId = UUID.randomUUID();
+        session.setId(sessionId);
+
+        FeedbackQuestion teamQuestion = getTypicalFeedbackQuestionForSession(session);
+        teamQuestion.setGiverType(QuestionGiverType.TEAMS);
+        session.setFeedbackQuestions(Set.of(teamQuestion));
+
+        Team team = new Team("Team A");
+        Student student1 = getTypicalStudent();
+        student1.setId(UUID.randomUUID());
+        student1.setTeam(team);
+        Student student2 = getTypicalStudent();
+        student2.setId(UUID.randomUUID());
+        student2.setTeam(team);
+
+        FeedbackResponse teamResponse = getTypicalFeedbackResponseForQuestion(teamQuestion);
+        teamResponse.setGiver(new ResponseGiver(team));
+        teamQuestion.addFeedbackResponse(teamResponse);
+
+        when(fsDb.getFeedbackSession(sessionId)).thenReturn(session);
+        when(usersLogic.getStudentsForCourse(course.getId())).thenReturn(List.of(student1, student2));
+        when(usersLogic.getInstructorsForCourse(course.getId())).thenReturn(List.of());
+        when(fqLogic.hasFeedbackQuestionsForStudents(session.getFeedbackQuestions())).thenReturn(true);
+        when(fqLogic.hasFeedbackQuestionsForGiverType(session.getFeedbackQuestions(), QuestionGiverType.STUDENTS))
+                .thenReturn(false);
+        when(fqLogic.hasFeedbackQuestionsForInstructors(session.getFeedbackQuestions(), false)).thenReturn(false);
+
+        SubmittedGiverSetBundle submittedGiverSet = fsLogic.getSubmittedGiverSet(sessionId);
+
+        assertEquals(Set.of(student1.getId(), student2.getId()), submittedGiverSet.studentGiverIds());
+        assertTrue(submittedGiverSet.studentNonGiverIds().isEmpty());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
@@ -71,8 +71,6 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
                 Set.of(studentGiverId),
                 Collections.emptySet(),
                 Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet(),
                 Collections.emptySet());
 
         when(mockLogic.getSubmittedGiverSet(typicalFeedbackSession.getId()))
@@ -84,10 +82,8 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
 
         assertEquals(Set.of(studentGiverId), output.getStudentGivers());
         assertEquals(Collections.emptySet(), output.getInstructorGivers());
-        assertEquals(Collections.emptySet(), output.getTeamGivers());
         assertEquals(Collections.emptySet(), output.getStudentNonGivers());
         assertEquals(Collections.emptySet(), output.getInstructorNonGivers());
-        assertEquals(Collections.emptySet(), output.getTeamNonGivers());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
@@ -70,9 +70,12 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
         SubmittedGiverSetBundle submittedGiverSetBundle = new SubmittedGiverSetBundle(
                 Set.of(studentGiverId),
                 Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet(),
                 Collections.emptySet());
 
-        when(mockLogic.getSubmittedGiverSetThatAnsweredFeedbackSession(typicalFeedbackSession.getId()))
+        when(mockLogic.getSubmittedGiverSet(typicalFeedbackSession.getId()))
                 .thenReturn(submittedGiverSetBundle);
 
         GetFeedbackSessionSubmittedGiverSetAction action = getAction(params);
@@ -82,6 +85,9 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
         assertEquals(Set.of(studentGiverId), output.getStudentGivers());
         assertEquals(Collections.emptySet(), output.getInstructorGivers());
         assertEquals(Collections.emptySet(), output.getTeamGivers());
+        assertEquals(Collections.emptySet(), output.getStudentNonGivers());
+        assertEquals(Collections.emptySet(), output.getInstructorNonGivers());
+        assertEquals(Collections.emptySet(), output.getTeamNonGivers());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionTest.java
@@ -3,13 +3,15 @@ package teammates.ui.webapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
@@ -64,16 +66,22 @@ public class GetFeedbackSessionSubmittedGiverSetActionTest
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, typicalFeedbackSession.getId().toString(),
         };
-        String giverIdentifier = typicalFeedbackResponse.getGiver().getIdentifier();
+        UUID studentGiverId = typicalFeedbackResponse.getGiver().getGiverUserId();
+        SubmittedGiverSetBundle submittedGiverSetBundle = new SubmittedGiverSetBundle(
+                Set.of(studentGiverId),
+                Collections.emptySet(),
+                Collections.emptySet());
 
-        when(mockLogic.getGiverSetThatAnsweredFeedbackSession(typicalFeedbackSession.getId()))
-                .thenReturn(new HashSet<>(Arrays.asList(giverIdentifier)));
+        when(mockLogic.getSubmittedGiverSetThatAnsweredFeedbackSession(typicalFeedbackSession.getId()))
+                .thenReturn(submittedGiverSetBundle);
 
         GetFeedbackSessionSubmittedGiverSetAction action = getAction(params);
         JsonResult result = getJsonResult(action);
         FeedbackSessionSubmittedGiverSet output = (FeedbackSessionSubmittedGiverSet) result.getOutput();
 
-        assertEquals(new HashSet<>(Arrays.asList(giverIdentifier)), output.getGiverIdentifiers());
+        assertEquals(Set.of(studentGiverId), output.getStudentGivers());
+        assertEquals(Collections.emptySet(), output.getInstructorGivers());
+        assertEquals(Collections.emptySet(), output.getTeamGivers());
     }
 
     @Test

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -237,8 +237,8 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
       .subscribe({
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
           this.studentsOfCourse.forEach((studentColumnModel: StudentExtensionTableColumnModel) => {
-            studentColumnModel.hasSubmittedSession = feedbackSessionSubmittedGiverSet.giverIdentifiers.includes(
-              studentColumnModel.email,
+            studentColumnModel.hasSubmittedSession = feedbackSessionSubmittedGiverSet.studentGivers.includes(
+              studentColumnModel.userId,
             );
           });
         },
@@ -310,8 +310,8 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
       .subscribe({
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
           this.instructorsOfCourse.forEach((instructorColumnModel: InstructorExtensionTableColumnModel) => {
-            instructorColumnModel.hasSubmittedSession = feedbackSessionSubmittedGiverSet.giverIdentifiers.includes(
-              instructorColumnModel.email,
+            instructorColumnModel.hasSubmittedSession = feedbackSessionSubmittedGiverSet.instructorGivers.includes(
+              instructorColumnModel.userId,
             );
           });
         },

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -237,7 +237,7 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
       .subscribe({
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
           this.studentsOfCourse.forEach((studentColumnModel: StudentExtensionTableColumnModel) => {
-            studentColumnModel.hasSubmittedSession = feedbackSessionSubmittedGiverSet.studentGivers.includes(
+            studentColumnModel.hasSubmittedSession = !feedbackSessionSubmittedGiverSet.studentNonGivers.includes(
               studentColumnModel.userId,
             );
           });
@@ -310,7 +310,7 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
       .subscribe({
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
           this.instructorsOfCourse.forEach((instructorColumnModel: InstructorExtensionTableColumnModel) => {
-            instructorColumnModel.hasSubmittedSession = feedbackSessionSubmittedGiverSet.instructorGivers.includes(
+            instructorColumnModel.hasSubmittedSession = !feedbackSessionSubmittedGiverSet.instructorNonGivers.includes(
               instructorColumnModel.userId,
             );
           });

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
@@ -126,6 +126,9 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     studentGivers: [testStudent2.userId],
     instructorGivers: [],
     teamGivers: [],
+    studentNonGivers: [],
+    instructorNonGivers: [],
+    teamNonGivers: [],
   };
 
   const testTimeString = '5 Apr 2000 2:00:00';
@@ -691,6 +694,9 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
       studentGivers: [testStudent2.userId],
       instructorGivers: [testInstructor1.userId],
       teamGivers: [],
+      studentNonGivers: [],
+      instructorNonGivers: [],
+      teamNonGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet));
     component.ngOnInit();
@@ -739,6 +745,9 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
       studentGivers: [],
       instructorGivers: [testInstructor1.userId],
       teamGivers: [],
+      studentNonGivers: [],
+      instructorNonGivers: [],
+      teamNonGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet)); // Alice and Alex have not submitted yet
     component.ngOnInit();

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
@@ -126,8 +126,8 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     studentGivers: [testStudent2.userId],
     instructorGivers: [],
     teamGivers: [],
-    studentNonGivers: [],
-    instructorNonGivers: [],
+    studentNonGivers: [testStudent1.userId, testStudent3.userId],
+    instructorNonGivers: [testInstructor1.userId, testInstructor2.userId],
     teamNonGivers: [],
   };
 
@@ -694,8 +694,8 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
       studentGivers: [testStudent2.userId],
       instructorGivers: [testInstructor1.userId],
       teamGivers: [],
-      studentNonGivers: [],
-      instructorNonGivers: [],
+      studentNonGivers: [testStudent1.userId, testStudent3.userId],
+      instructorNonGivers: [testInstructor2.userId],
       teamNonGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet));
@@ -746,7 +746,7 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
       instructorGivers: [testInstructor1.userId],
       teamGivers: [],
       studentNonGivers: [],
-      instructorNonGivers: [],
+      instructorNonGivers: [testInstructor2.userId],
       teamNonGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet)); // Alice and Alex have not submitted yet

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
@@ -123,7 +123,9 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
   };
 
   const testFeedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet = {
-    giverIdentifiers: [testStudent2.email],
+    studentGivers: [testStudent2.userId],
+    instructorGivers: [],
+    teamGivers: [],
   };
 
   const testTimeString = '5 Apr 2000 2:00:00';
@@ -686,7 +688,9 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     );
 
     const giverSet: FeedbackSessionSubmittedGiverSet = {
-      giverIdentifiers: [testStudent2.email, testInstructor1.email],
+      studentGivers: [testStudent2.userId],
+      instructorGivers: [testInstructor1.userId],
+      teamGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet));
     component.ngOnInit();
@@ -732,7 +736,9 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     );
 
     const giverSet: FeedbackSessionSubmittedGiverSet = {
-      giverIdentifiers: [testInstructor1.email],
+      studentGivers: [],
+      instructorGivers: [testInstructor1.userId],
+      teamGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet)); // Alice and Alex have not submitted yet
     component.ngOnInit();

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.spec.ts
@@ -125,10 +125,8 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
   const testFeedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet = {
     studentGivers: [testStudent2.userId],
     instructorGivers: [],
-    teamGivers: [],
     studentNonGivers: [testStudent1.userId, testStudent3.userId],
     instructorNonGivers: [testInstructor1.userId, testInstructor2.userId],
-    teamNonGivers: [],
   };
 
   const testTimeString = '5 Apr 2000 2:00:00';
@@ -693,10 +691,8 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     const giverSet: FeedbackSessionSubmittedGiverSet = {
       studentGivers: [testStudent2.userId],
       instructorGivers: [testInstructor1.userId],
-      teamGivers: [],
       studentNonGivers: [testStudent1.userId, testStudent3.userId],
       instructorNonGivers: [testInstructor2.userId],
-      teamNonGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet));
     component.ngOnInit();
@@ -744,10 +740,8 @@ describe('InstructorSessionIndividualExtensionPageComponent', () => {
     const giverSet: FeedbackSessionSubmittedGiverSet = {
       studentGivers: [],
       instructorGivers: [testInstructor1.userId],
-      teamGivers: [],
       studentNonGivers: [],
       instructorNonGivers: [testInstructor2.userId],
-      teamNonGivers: [],
     };
     vi.spyOn(feedbackSessionsService, 'getFeedbackSessionSubmittedGiverSet').mockReturnValue(of(giverSet)); // Alice and Alex have not submitted yet
     component.ngOnInit();

--- a/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
@@ -3,7 +3,7 @@ import { forkJoin } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { InstructorSessionBasePageComponent } from './instructor-session-base-page.component';
 import { StudentService } from '../../services/student.service';
-import { FeedbackSessionSubmittedGiverSet, Instructor, Instructors, Student, Students } from '../../types/api-output';
+import { Instructor, Instructors, Student, Students } from '../../types/api-output';
 import { Intent } from '../../types/api-request';
 import { ResendResultsLinkToRespondentModalComponent } from '../components/sessions-table/resend-results-link-to-respondent-modal/resend-results-link-to-respondent-modal.component';
 import {
@@ -121,29 +121,28 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
     const feedbackSessionName = model.feedbackSession.feedbackSessionName;
     const feedbackSessionId = model.feedbackSession.feedbackSessionId;
 
-    forkJoin([
-      this.studentService.getStudentsFromCourse({ courseId }),
-      this.feedbackSessionsService.getFeedbackSessionSubmittedGiverSet({ feedbackSessionId }),
-      this.instructorService.loadInstructors({ courseId, intent: Intent.FULL_DETAIL }),
-    ])
+    forkJoin({
+      students: this.studentService.getStudentsFromCourse({ courseId }),
+      submittedGiverSet: this.feedbackSessionsService.getFeedbackSessionSubmittedGiverSet({ feedbackSessionId }),
+      instructors: this.instructorService.loadInstructors({ courseId, intent: Intent.FULL_DETAIL }),
+    })
       .pipe(
         finalize(() => {
           this.isSendReminderLoading = false;
         }),
       )
       .subscribe({
-        next: (result: any[]) => {
-          const students: Student[] = (result[0] as Students).students;
-          const submittedGiverSet: FeedbackSessionSubmittedGiverSet = result[1] as FeedbackSessionSubmittedGiverSet;
-          const studentGiverSet: Set<string> = new Set(submittedGiverSet.studentGivers);
-          const instructorGiverSet: Set<string> = new Set(submittedGiverSet.instructorGivers);
-          const instructors: Instructor[] = (result[2] as Instructors).instructors;
+        next: ({ students, submittedGiverSet, instructors }) => {
+          const studentsList = students.students;
+          const instructorsList = instructors.instructors;
+          const studentNonGiverSet = new Set(submittedGiverSet.studentNonGivers);
+          const instructorNonGiverSet = new Set(submittedGiverSet.instructorNonGivers);
 
-          const modalRef: NgbModalRef = this.ngbModal.open(SendRemindersToRespondentsModalComponent);
+          const modalRef = this.ngbModal.open(SendRemindersToRespondentsModalComponent);
 
           modalRef.componentInstance.courseId = courseId;
           modalRef.componentInstance.feedbackSessionName = feedbackSessionName;
-          modalRef.componentInstance.studentListInfoTableRowModels = students.map(
+          modalRef.componentInstance.studentListInfoTableRowModels = studentsList.map(
             (student: Student) =>
               ({
                 id: student.userId,
@@ -152,21 +151,21 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
                 teamName: student.teamName,
                 sectionName: student.sectionName,
 
-                hasSubmittedSession: studentGiverSet.has(student.userId),
+                hasSubmittedSession: !studentNonGiverSet.has(student.userId),
 
-                isSelected: selectAllRespondents && !studentGiverSet.has(student.userId),
+                isSelected: selectAllRespondents && studentNonGiverSet.has(student.userId),
               }) satisfies StudentListInfoTableRowModel,
           );
-          modalRef.componentInstance.instructorListInfoTableRowModels = instructors.map(
+          modalRef.componentInstance.instructorListInfoTableRowModels = instructorsList.map(
             (instructor: Instructor) =>
               ({
                 id: instructor.userId,
                 email: instructor.email,
                 name: instructor.name,
 
-                hasSubmittedSession: instructorGiverSet.has(instructor.userId),
+                hasSubmittedSession: !instructorNonGiverSet.has(instructor.userId),
 
-                isSelected: selectAllRespondents && !instructorGiverSet.has(instructor.userId),
+                isSelected: selectAllRespondents && instructorNonGiverSet.has(instructor.userId),
               }) satisfies InstructorListInfoTableRowModel,
           );
 

--- a/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-modal-page.component.ts
@@ -134,7 +134,9 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
       .subscribe({
         next: (result: any[]) => {
           const students: Student[] = (result[0] as Students).students;
-          const giverSet: Set<string> = new Set((result[1] as FeedbackSessionSubmittedGiverSet).giverIdentifiers);
+          const submittedGiverSet: FeedbackSessionSubmittedGiverSet = result[1] as FeedbackSessionSubmittedGiverSet;
+          const studentGiverSet: Set<string> = new Set(submittedGiverSet.studentGivers);
+          const instructorGiverSet: Set<string> = new Set(submittedGiverSet.instructorGivers);
           const instructors: Instructor[] = (result[2] as Instructors).instructors;
 
           const modalRef: NgbModalRef = this.ngbModal.open(SendRemindersToRespondentsModalComponent);
@@ -150,9 +152,9 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
                 teamName: student.teamName,
                 sectionName: student.sectionName,
 
-                hasSubmittedSession: giverSet.has(student.email),
+                hasSubmittedSession: studentGiverSet.has(student.userId),
 
-                isSelected: selectAllRespondents && !giverSet.has(student.email),
+                isSelected: selectAllRespondents && !studentGiverSet.has(student.userId),
               }) satisfies StudentListInfoTableRowModel,
           );
           modalRef.componentInstance.instructorListInfoTableRowModels = instructors.map(
@@ -162,9 +164,9 @@ export abstract class InstructorSessionModalPageComponent extends InstructorSess
                 email: instructor.email,
                 name: instructor.name,
 
-                hasSubmittedSession: giverSet.has(instructor.email),
+                hasSubmittedSession: instructorGiverSet.has(instructor.userId),
 
-                isSelected: selectAllRespondents && !giverSet.has(instructor.email),
+                isSelected: selectAllRespondents && !instructorGiverSet.has(instructor.userId),
               }) satisfies InstructorListInfoTableRowModel,
           );
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -351,8 +351,8 @@ export class InstructorSessionResultPageComponent implements OnInit {
       .subscribe({
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
           // TODO team is missing
-          this.noResponseStudents = this.allStudentsInCourse.filter(
-            (student: Student) => !feedbackSessionSubmittedGiverSet.studentGivers.includes(student.userId),
+          this.noResponseStudents = this.allStudentsInCourse.filter((student: Student) =>
+            feedbackSessionSubmittedGiverSet.studentNonGivers.includes(student.userId),
           );
           this.isNoResponseStudentsLoaded = true;
         },

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -350,7 +350,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
       })
       .subscribe({
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
-          // TODO team is missing
           this.noResponseStudents = this.allStudentsInCourse.filter((student: Student) =>
             feedbackSessionSubmittedGiverSet.studentNonGivers.includes(student.userId),
           );

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -352,7 +352,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
         next: (feedbackSessionSubmittedGiverSet: FeedbackSessionSubmittedGiverSet) => {
           // TODO team is missing
           this.noResponseStudents = this.allStudentsInCourse.filter(
-            (student: Student) => !feedbackSessionSubmittedGiverSet.giverIdentifiers.includes(student.email),
+            (student: Student) => !feedbackSessionSubmittedGiverSet.studentGivers.includes(student.userId),
           );
           this.isNoResponseStudentsLoaded = true;
         },

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -274,15 +274,15 @@ export class FeedbackSessionsService {
     const allStudentsObservable: Observable<Students> = this.studentService.getStudentsFromCourse({
       courseId,
     });
-    const studentsWithResponseObservable: Observable<FeedbackSessionSubmittedGiverSet> =
+    const submittedGiverSetObservable: Observable<FeedbackSessionSubmittedGiverSet> =
       this.getFeedbackSessionSubmittedGiverSet({
         feedbackSessionId,
       });
-    return forkJoin([allStudentsObservable, studentsWithResponseObservable]).pipe(
-      map((result: any[]) => {
-        const allStudents: Student[] = (result[0] as Students).students;
-        const studentIdsWithResponse: string[] = (result[1] as FeedbackSessionSubmittedGiverSet).studentGivers;
-        return allStudents.filter((student: Student) => !studentIdsWithResponse.includes(student.userId));
+    return forkJoin({ allStudents: allStudentsObservable, submittedGiverSet: submittedGiverSetObservable }).pipe(
+      map(({ allStudents, submittedGiverSet }) => {
+        const allStudentsList: Student[] = allStudents.students;
+        const studentIdsWithoutResponse: string[] = submittedGiverSet.studentNonGivers;
+        return allStudentsList.filter((student: Student) => studentIdsWithoutResponse.includes(student.userId));
       }),
     );
   }

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -281,8 +281,8 @@ export class FeedbackSessionsService {
     return forkJoin([allStudentsObservable, studentsWithResponseObservable]).pipe(
       map((result: any[]) => {
         const allStudents: Student[] = (result[0] as Students).students;
-        const studentEmailsWithResponse: string[] = (result[1] as FeedbackSessionSubmittedGiverSet).giverIdentifiers;
-        return allStudents.filter((student: Student) => !studentEmailsWithResponse.includes(student.email));
+        const studentIdsWithResponse: string[] = (result[1] as FeedbackSessionSubmittedGiverSet).studentGivers;
+        return allStudents.filter((student: Student) => !studentIdsWithResponse.includes(student.userId));
       }),
     );
   }

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -339,10 +339,8 @@ export interface FeedbackSessionStats extends ApiOutput {
 export interface FeedbackSessionSubmittedGiverSet extends ApiOutput {
   studentGivers: string[];
   instructorGivers: string[];
-  teamGivers: string[];
   studentNonGivers: string[];
   instructorNonGivers: string[];
-  teamNonGivers: string[];
 }
 
 export interface FeedbackTextQuestionDetails extends FeedbackQuestionDetails {

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -337,7 +337,9 @@ export interface FeedbackSessionStats extends ApiOutput {
 }
 
 export interface FeedbackSessionSubmittedGiverSet extends ApiOutput {
-  giverIdentifiers: string[];
+  studentGivers: string[];
+  instructorGivers: string[];
+  teamGivers: string[];
 }
 
 export interface FeedbackTextQuestionDetails extends FeedbackQuestionDetails {

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -340,6 +340,9 @@ export interface FeedbackSessionSubmittedGiverSet extends ApiOutput {
   studentGivers: string[];
   instructorGivers: string[];
   teamGivers: string[];
+  studentNonGivers: string[];
+  instructorNonGivers: string[];
+  teamNonGivers: string[];
 }
 
 export interface FeedbackTextQuestionDetails extends FeedbackQuestionDetails {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #14022
Fixes #11737

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Reworks api to return list of student, instructor giver and non-giver IDs.
2. For call sites that are actually checking for non-giver IDs, those are used instead of giver IDs.