### PR TITLE
[#14005] Renamed id field in AccountRequestData to accountRequestId

### DIFF
--- a/src/main/java/teammates/ui/output/AccountRequestData.java
+++ b/src/main/java/teammates/ui/output/AccountRequestData.java
@@ -13,8 +13,7 @@ import teammates.storage.entity.AccountRequest;
  * Output format of account request data.
  */
 public class AccountRequestData extends ApiOutput {
-    // TODO: rename to accountRequestId for consistency.
-    private final UUID id;
+    private final UUID accountRequestId;
     private final String email;
     private final String name;
     private final String institute;
@@ -27,9 +26,9 @@ public class AccountRequestData extends ApiOutput {
     private final long createdAt;
 
     @JsonCreator
-    private AccountRequestData(UUID id, String email, String name, String institute, String registrationKey,
+    private AccountRequestData(UUID accountRequestId, String email, String name, String institute, String registrationKey,
                                 AccountRequestStatus status, String comments, Long registeredAt, long createdAt) {
-        this.id = id;
+        this.accountRequestId = accountRequestId;
         this.email = email;
         this.name = name;
         this.institute = institute;
@@ -41,7 +40,7 @@ public class AccountRequestData extends ApiOutput {
     }
 
     public AccountRequestData(AccountRequest accountRequest) {
-        this.id = accountRequest.getId();
+        this.accountRequestId = accountRequest.getId();
         this.name = accountRequest.getName();
         this.email = accountRequest.getEmail();
         this.institute = accountRequest.getInstitute();
@@ -57,8 +56,8 @@ public class AccountRequestData extends ApiOutput {
         }
     }
 
-    public UUID getId() {
-        return id;
+    public UUID getAccountRequestId() {
+        return accountRequestId;
     }
 
     public String getInstitute() {

--- a/src/test/java/teammates/ui/webapi/CreateAccountRequestActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateAccountRequestActionTest.java
@@ -160,7 +160,7 @@ public class CreateAccountRequestActionTest extends BaseActionTest<CreateAccount
     }
 
     private void verifyAccountRequestCreated(AccountRequestData output, AccountRequest accountRequest) {
-        assertEquals(output.getId(), accountRequest.getId());
+        assertEquals(output.getAccountRequestId(), accountRequest.getId());
         assertEquals(output.getEmail(), accountRequest.getEmail());
         assertEquals(output.getName(), accountRequest.getName());
         assertEquals(output.getInstitute(), accountRequest.getInstitute());

--- a/src/test/java/teammates/ui/webapi/GetAccountRequestActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetAccountRequestActionTest.java
@@ -92,7 +92,7 @@ public class GetAccountRequestActionTest extends BaseActionTest<GetAccountReques
     }
 
     private void verifyAccountRequest(AccountRequestData output, AccountRequest accountRequest) {
-        assertEquals(output.getId(), accountRequest.getId());
+        assertEquals(output.getAccountRequestId(), accountRequest.getId());
         assertEquals(output.getEmail(), accountRequest.getEmail());
         assertEquals(output.getName(), accountRequest.getName());
         assertEquals(output.getInstitute(), accountRequest.getInstitute());

--- a/src/test/java/teammates/ui/webapi/SearchAccountRequestsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SearchAccountRequestsActionTest.java
@@ -71,7 +71,7 @@ public class SearchAccountRequestsActionTest extends BaseActionTest<SearchAccoun
             AccountRequest accountRequest = accountRequests.get(i);
             AccountRequestData accountRequestData = output.getAccountRequests().get(i);
 
-            assertEquals(accountRequest.getId(), accountRequestData.getId());
+            assertEquals(accountRequest.getId(), accountRequestData.getAccountRequestId());
             assertEquals(accountRequest.getEmail(), accountRequestData.getEmail());
             assertEquals(accountRequest.getName(), accountRequestData.getName());
             assertEquals(accountRequest.getInstitute(), accountRequestData.getInstitute());

--- a/src/web/app/components/account-requests-table/account-request-table.component.spec.ts
+++ b/src/web/app/components/account-requests-table/account-request-table.component.spec.ts
@@ -304,7 +304,7 @@ describe('AccountRequestTableComponent', () => {
     const modalSpy = vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef as any);
 
     const editedAccountRequest: AccountRequest = {
-      id: 'id',
+      accountRequestId: 'id',
       comments: 'new comment',
       email: 'new email',
       institute: 'new institute',
@@ -335,7 +335,7 @@ describe('AccountRequestTableComponent', () => {
     fixture.detectChanges();
 
     const approvedRequest: AccountRequest = {
-      id: component.accountRequests[0].id,
+      accountRequestId: component.accountRequests[0].id,
       comments: component.accountRequests[0].comments,
       email: component.accountRequests[0].email,
       institute: component.accountRequests[0].instituteAndCountry,
@@ -361,7 +361,7 @@ describe('AccountRequestTableComponent', () => {
     fixture.detectChanges();
 
     const rejectedRequest: AccountRequest = {
-      id: component.accountRequests[0].id,
+      accountRequestId: component.accountRequests[0].id,
       comments: component.accountRequests[0].comments,
       email: component.accountRequests[0].email,
       institute: component.accountRequests[0].instituteAndCountry,

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.spec.ts
@@ -34,7 +34,7 @@ describe('AdminHomePageComponent', () => {
   it('should create account request directly if all fields are filled', () => {
     const spyAccountService = vi.spyOn(accountService, 'createAccountRequest').mockReturnValue(
       of({
-        id: 'some.person@example.com%NUS',
+        accountRequestId: 'some.person@example.com%NUS',
         email: 'some.person@example.com',
         name: 'Some Person',
         institute: 'NUS',
@@ -111,7 +111,7 @@ describe('AdminHomePageComponent', () => {
   it('should not create any account request if multiple instructor details contain invalid format', () => {
     const spyAccountService = vi.spyOn(accountService, 'createAccountRequest').mockReturnValue(
       of({
-        id: 'some.person@example.com%NUS',
+        accountRequestId: 'some.person@example.com%NUS',
         email: 'some.person@example.com',
         name: 'Some Person',
         institute: 'NUS',
@@ -144,7 +144,7 @@ describe('AdminHomePageComponent', () => {
   it('should create account requests for all multiple instructor details split by vertical bars', () => {
     const spyAccountService = vi.spyOn(accountService, 'createAccountRequest').mockReturnValue(
       of({
-        id: 'some.person@example.com%NUS',
+        accountRequestId: 'some.person@example.com%NUS',
         email: 'some.person@example.com',
         name: 'Some Person',
         institute: 'NUS',
@@ -204,7 +204,7 @@ describe('AdminHomePageComponent', () => {
   it('should create account requests for all multiple instructor details split by tabs with empty lines', () => {
     const spyAccountService = vi.spyOn(accountService, 'createAccountRequest').mockReturnValue(
       of({
-        id: 'some.person@example.com%NUS',
+        accountRequestId: 'some.person@example.com%NUS',
         email: 'some.person@example.com',
         name: 'Some Person',
         institute: 'NUS',

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -153,7 +153,7 @@ export class AdminHomePageComponent implements OnInit {
     const timezone: string = this.timezoneService.guessTimezone() || 'UTC';
     return requests.accountRequests.map((request) => {
       return {
-        id: request.id,
+        id: request.accountRequestId,
         name: request.name,
         email: request.email,
         status: request.status,

--- a/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.html
@@ -39,7 +39,7 @@
           </tr>
         </thead>
         <tbody>
-          @for (accountRequest of accountRequests; track accountRequest.id; let i = $index) {
+          @for (accountRequest of accountRequests; track accountRequest.accountRequestId; let i = $index) {
             <tr (click)="toggleAccountRequestLinks(accountRequest)">
               <td>
                 <div class="d-flex align-items-center gap-2">

--- a/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.spec.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.spec.ts
@@ -24,7 +24,7 @@ describe('AdminAccountSearchTableComponent', () => {
   let ngbModal: NgbModal;
 
   const accountRequestDetailsBuilder = createBuilder<AccountRequestSearchResult>({
-    id: '',
+    accountRequestId: '',
     email: '',
     name: '',
     institute: '',
@@ -95,9 +95,9 @@ describe('AdminAccountSearchTableComponent', () => {
 
   it('should display account requests with no reset or expand links button', () => {
     const first: AccountRequestSearchResult = DEFAULT_ACCOUNT_REQUEST.build();
-    first.id = 'id-1';
+    first.accountRequestId = 'id-1';
     const second: AccountRequestSearchResult = DEFAULT_ACCOUNT_REQUEST.build();
-    second.id = 'id-2';
+    second.accountRequestId = 'id-2';
     const accountRequestResults: AccountRequestSearchResult[] = [first, second];
 
     component.accountRequests = accountRequestResults;
@@ -107,12 +107,12 @@ describe('AdminAccountSearchTableComponent', () => {
 
   it('should display account requests with reset button and expandable links buttons', () => {
     const approvedAccountRequestResult: AccountRequestSearchResult = DEFAULT_ACCOUNT_REQUEST.build();
-    approvedAccountRequestResult.id = 'approved-id';
+    approvedAccountRequestResult.accountRequestId = 'approved-id';
     approvedAccountRequestResult.status = AccountRequestStatus.APPROVED;
     approvedAccountRequestResult.registrationLink = 'registrationLink';
 
     const registeredAccountRequestResult: AccountRequestSearchResult = DEFAULT_ACCOUNT_REQUEST.build();
-    registeredAccountRequestResult.id = 'registered-id';
+    registeredAccountRequestResult.accountRequestId = 'registered-id';
     registeredAccountRequestResult.status = AccountRequestStatus.REGISTERED;
     registeredAccountRequestResult.registrationLink = 'registrationLink';
 
@@ -427,7 +427,7 @@ describe('AdminAccountSearchTableComponent', () => {
     const modalSpy = vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef as any);
 
     const editedAccountRequest: AccountRequest = {
-      id: 'id',
+      accountRequestId: 'id',
       comments: 'new comment',
       email: 'new email',
       institute: 'new institute',
@@ -458,7 +458,7 @@ describe('AdminAccountSearchTableComponent', () => {
     fixture.detectChanges();
 
     const approvedRequest: AccountRequest = {
-      id: component.accountRequests[0].id,
+      accountRequestId: component.accountRequests[0].accountRequestId,
       comments: component.accountRequests[0].comments,
       email: component.accountRequests[0].email,
       institute: component.accountRequests[0].institute,
@@ -484,7 +484,7 @@ describe('AdminAccountSearchTableComponent', () => {
     fixture.detectChanges();
 
     const rejectedRequest: AccountRequest = {
-      id: component.accountRequests[0].id,
+      accountRequestId: component.accountRequests[0].accountRequestId,
       comments: component.accountRequests[0].comments,
       email: component.accountRequests[0].email,
       institute: component.accountRequests[0].institute,

--- a/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.ts
@@ -90,7 +90,7 @@ export class AdminAccountSearchTableComponent implements OnChanges {
     modalRef.result.then(
       (res: EditRequestModalComponentResult) => {
         this.accountService
-          .editAccountRequest(accountRequest.id, {
+          .editAccountRequest(accountRequest.accountRequestId, {
             name: res.accountRequestName,
             email: res.accountRequestEmail,
             institute: res.accountRequestInstitution,
@@ -116,7 +116,7 @@ export class AdminAccountSearchTableComponent implements OnChanges {
 
   approveAccountRequest(accountRequest: AccountRequestSearchResult, index: number): void {
     this.isApprovingAccount[index] = true;
-    this.accountService.approveAccountRequest(accountRequest.id).subscribe({
+    this.accountService.approveAccountRequest(accountRequest.accountRequestId).subscribe({
       next: (resp: AccountRequest) => {
         accountRequest.status = resp.status;
         this.statusMessageService.showSuccessToast(
@@ -149,7 +149,7 @@ export class AdminAccountSearchTableComponent implements OnChanges {
 
     modalRef.result.then(
       () => {
-        this.accountService.resetAccountRequest(accountRequest.id).subscribe({
+        this.accountService.resetAccountRequest(accountRequest.accountRequestId).subscribe({
           next: () => {
             this.statusMessageService.showSuccessToast(
               `Reset successful. An email has been sent to ${accountRequest.email}.`,
@@ -179,7 +179,7 @@ export class AdminAccountSearchTableComponent implements OnChanges {
 
     modalRef.result.then(
       () => {
-        this.accountService.deleteAccountRequest(accountRequest.id).subscribe({
+        this.accountService.deleteAccountRequest(accountRequest.accountRequestId).subscribe({
           next: (resp: MessageOutput) => {
             this.statusMessageService.showSuccessToast(resp.message);
             this.accountRequests = this.accountRequests.filter((x: AccountRequestSearchResult) => x !== accountRequest);
@@ -209,7 +209,7 @@ export class AdminAccountSearchTableComponent implements OnChanges {
 
   rejectAccountRequest(accountRequest: AccountRequestSearchResult, index: number): void {
     this.isRejectingAccount[index] = true;
-    this.accountService.rejectAccountRequest(accountRequest.id).subscribe({
+    this.accountService.rejectAccountRequest(accountRequest.accountRequestId).subscribe({
       next: (resp: AccountRequest) => {
         accountRequest.status = resp.status;
         this.statusMessageService.showSuccessToast('Account request was successfully rejected.');
@@ -235,7 +235,7 @@ export class AdminAccountSearchTableComponent implements OnChanges {
     modalRef.result.then(
       (res: RejectWithReasonModalComponentResult) => {
         this.accountService
-          .rejectAccountRequest(accountRequest.id, res.rejectionReasonTitle, res.rejectionReasonBody)
+          .rejectAccountRequest(accountRequest.accountRequestId, res.rejectionReasonTitle, res.rejectionReasonBody)
           .subscribe({
             next: (resp: AccountRequest) => {
               accountRequest.status = resp.status;

--- a/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.spec.ts
+++ b/src/web/app/pages-static/request-page/instructor-request-form/instructor-request-form.component.spec.ts
@@ -25,7 +25,7 @@ describe('InstructorRequestFormComponent', () => {
     instructorInstitution: `${typicalModel.institution}, ${typicalModel.country}`,
   };
   const typicalAccountRequest: AccountRequest = {
-    id: 'id',
+    accountRequestId: 'id',
     email: typicalModel.email,
     name: typicalModel.name,
     institute: `${typicalModel.institution}, ${typicalModel.country}`,

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -195,7 +195,7 @@ describe('SearchService', () => {
   };
 
   const mockAccountRequest: AccountRequest = {
-    id: '132efa02-b208-4195-a262-a8eae25ceb95',
+    accountRequestId: '132efa02-b208-4195-a262-a8eae25ceb95',
     registrationKey: 'regkey',
     createdAt: 1585487897502,
     name: 'Test Instructor',
@@ -311,7 +311,7 @@ describe('SearchService', () => {
     };
     const result: AccountRequestSearchResult = service.joinAdminAccountRequest(accountRequest);
 
-    expect(result.id).toBe('132efa02-b208-4195-a262-a8eae25ceb95');
+    expect(result.accountRequestId).toBe('132efa02-b208-4195-a262-a8eae25ceb95');
     expect(result.email).toBe('test@example.com');
     expect(result.institute).toBe('Test Institute');
     expect(result.name).toBe('Test Instructor');

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -327,7 +327,7 @@ export class SearchService {
 
   joinAdminAccountRequest(accountRequest: AccountRequest): AccountRequestSearchResult {
     let accountRequestResult: AccountRequestSearchResult = {
-      id: '',
+      accountRequestId: '',
       name: '',
       email: '',
       institute: '',
@@ -339,8 +339,17 @@ export class SearchService {
       comments: '',
     };
 
-    const { id, registrationKey, createdAt, registeredAt, name, institute, email, status, comments }: AccountRequest =
-      accountRequest;
+    const {
+      accountRequestId,
+      registrationKey,
+      createdAt,
+      registeredAt,
+      name,
+      institute,
+      email,
+      status,
+      comments,
+    }: AccountRequest = accountRequest;
 
     const timezone: string = this.timezoneService.guessTimezone() || 'UTC';
     accountRequestResult.createdAtText = this.formatTimestampAsString(createdAt, timezone);
@@ -348,7 +357,15 @@ export class SearchService {
     accountRequestResult.comments = comments || '';
 
     const registrationLink: string = this.linkService.generateAccountRegistrationLink(registrationKey);
-    accountRequestResult = { ...accountRequestResult, id, name, email, institute, registrationLink, status };
+    accountRequestResult = {
+      ...accountRequestResult,
+      accountRequestId,
+      name,
+      email,
+      institute,
+      registrationLink,
+      status,
+    };
 
     return accountRequestResult;
   }
@@ -485,7 +502,7 @@ export interface AdminSearchResult {
  * Search results for account requests from the admin endpoint.
  */
 export interface AccountRequestSearchResult {
-  id: string;
+  accountRequestId: string;
   name: string;
   email: string;
   status: AccountRequestStatus;

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -11,7 +11,7 @@ export interface Account extends ApiOutput {
 }
 
 export interface AccountRequest extends ApiOutput {
-  id: string;
+  accountRequestId: string;
   email: string;
   name: string;
   institute: string;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #14005

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
Renamed the account request output identifier from `id` to `accountRequestId` for consistency with other API output DTOs.
Updated the corresponding frontend API types and account-request consumers to read `accountRequestId`, while preserving internal table row IDs where the UI model still expects `id`. Also updated related tests and formatting affected by the rename.

<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->
