### PR TITLE
[#14031] Remove direct Guava usage and dependency from backend build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     implementation("com.google.cloud:google-cloud-tasks")
     implementation("com.google.cloud:google-cloud-logging")
     implementation("tools.jackson.core:jackson-databind:3.1.1")
-    implementation("com.google.guava:guava:33.5.0-jre")
     implementation("commons-lang:commons-lang:2.6")
     implementation("com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20260102.1")
     implementation("com.helger:ph-commons:9.5.5") // necessary to add SpotBugs suppression

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -1,6 +1,5 @@
 package teammates.e2e.pageobjects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,6 +16,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
@@ -308,7 +308,7 @@ public abstract class AppPage {
         // HtmlUnitWebElement is mirrored as opposed to RemoteWebElement (which is used
         // with actual browsers) for convenience
         // and the implementation can differ.
-        checkNotNull(element);
+        Objects.requireNonNull(element);
 
         // Adapted from ExpectedConditions#stalenessOf which forces a staleness check.
         // This allows a meaningful

--- a/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
@@ -3,14 +3,13 @@ package teammates.it.ui.webapi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Sets;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.util.Const;
@@ -67,7 +66,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
         JsonResult result = getJsonResult(pageAction);
 
         FeedbackSessionSubmittedGiverSet output = (FeedbackSessionSubmittedGiverSet) result.getOutput();
-        Set<UUID> expectedStudentGivers = Sets.newHashSet(
+        Set<UUID> expectedStudentGivers = Set.of(
                 typicalBundle.students.get("student1InCourse1").getId(),
                 typicalBundle.students.get("student2InCourse1").getId(),
                 typicalBundle.students.get("student3InCourse1").getId());
@@ -77,19 +76,19 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
                 .map(Student::getId)
                 .filter(studentId -> !expectedStudentGivers.contains(studentId))
                 .collect(Collectors.toSet());
-        assertEquals(Sets.newHashSet(
+        assertEquals(Set.of(
                 typicalBundle.students.get("student1InCourse1").getId(),
                 typicalBundle.students.get("student2InCourse1").getId(),
                 typicalBundle.students.get("student3InCourse1").getId()),
-                Sets.newHashSet(output.getStudentGivers()));
+                new HashSet<>(output.getStudentGivers()));
         Set<UUID> expectedInstructorNonGivers = typicalBundle.instructors.values()
                 .stream()
                 .filter(instructor -> instructor.getCourseId().equals(fsa.getCourseId()))
                 .map(Instructor::getId)
                 .collect(Collectors.toSet());
         assertEquals(Collections.emptySet(), output.getInstructorGivers());
-        assertEquals(expectedStudentNonGivers, Sets.newHashSet(output.getStudentNonGivers()));
-        assertEquals(expectedInstructorNonGivers, Sets.newHashSet(output.getInstructorNonGivers()));
+        assertEquals(expectedStudentNonGivers, new HashSet<>(output.getStudentNonGivers()));
+        assertEquals(expectedInstructorNonGivers, new HashSet<>(output.getInstructorNonGivers()));
 
         ______TS("Session with student questions only should not produce instructor non-givers");
         FeedbackSession fsb = typicalBundle.feedbackSessions.get("session2InTypicalCourse");
@@ -101,7 +100,7 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
         JsonResult session2Result = getJsonResult(session2Action);
         FeedbackSessionSubmittedGiverSet session2Output = (FeedbackSessionSubmittedGiverSet) session2Result.getOutput();
 
-        Set<UUID> expectedSession2StudentGivers = Sets.newHashSet(typicalBundle.students.get("student1InCourse1").getId());
+        Set<UUID> expectedSession2StudentGivers = Set.of(typicalBundle.students.get("student1InCourse1").getId());
         Set<UUID> expectedSession2StudentNonGivers = typicalBundle.students.values()
                 .stream()
                 .filter(student -> student.getCourseId().equals(fsb.getCourseId()))
@@ -110,9 +109,9 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
                 .collect(Collectors.toSet());
 
         assertEquals(expectedSession2StudentGivers,
-                Sets.newHashSet(session2Output.getStudentGivers()));
+                new HashSet<>(session2Output.getStudentGivers()));
         assertEquals(expectedSession2StudentNonGivers,
-                Sets.newHashSet(session2Output.getStudentNonGivers()));
+                new HashSet<>(session2Output.getStudentNonGivers()));
         assertEquals(Collections.emptySet(), session2Output.getInstructorNonGivers());
     }
 

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -16,8 +16,6 @@ import javax.crypto.Mac;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import com.google.common.base.CharMatcher;
-
 import teammates.common.exception.InvalidParametersException;
 
 /**
@@ -206,7 +204,8 @@ public final class StringHelper {
         if (str == null) {
             return null;
         }
-        return CharMatcher.whitespace().trimFrom(str).replaceAll("\\s+", " ");
+        return str.replaceAll("^[\\s\\p{Zs}\\u0085\\u2028\\u2029]+|[\\s\\p{Zs}\\u0085\\u2028\\u2029]+$", "")
+                .replaceAll("\\s+", " ");
     }
 
     /**

--- a/src/test/java/teammates/common/util/StringHelperTest.java
+++ b/src/test/java/teammates/common/util/StringHelperTest.java
@@ -127,6 +127,9 @@ public class StringHelperTest extends BaseTestCase {
         str = " \u00A0 a    a   ";
         assertEquals("a a", StringHelper.removeExtraSpace(str));
 
+        str = "\u0085\u2028\u2029a    a\u2029\u2028\u0085";
+        assertEquals("a a", StringHelper.removeExtraSpace(str));
+
         str = "    ";
         assertEquals("", StringHelper.removeExtraSpace(str));
 

--- a/src/test/java/teammates/test/AssertHelper.java
+++ b/src/test/java/teammates/test/AssertHelper.java
@@ -7,8 +7,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import com.google.common.base.Joiner;
+import java.util.stream.Collectors;
 
 import teammates.common.util.JsonUtils;
 import teammates.common.util.TimeHelperExtension;
@@ -50,8 +49,8 @@ public final class AssertHelper {
      */
     public static void assertSameContentIgnoreOrder(List<?> a, List<?> b) {
 
-        String expectedListAsString = Joiner.on("\t").join(a);
-        String actualListAsString = Joiner.on("\t").join(b);
+        String expectedListAsString = a.stream().map(Object::toString).collect(Collectors.joining("\t"));
+        String actualListAsString = b.stream().map(Object::toString).collect(Collectors.joining("\t"));
 
         List<String> expectedStringTypeList = new ArrayList<>(Arrays.asList(expectedListAsString.split("\t")));
         List<String> actualStringTypeList = new ArrayList<>(Arrays.asList(actualListAsString.split("\t")));


### PR DESCRIPTION
Fixes #14031

**Outline of Solution**

Removed the remaining direct Guava usage from backend/test source code and replaced it with standard Java APIs.

Changes include:
- Replaced `CharMatcher.whitespace().trimFrom(...)` with Java regex-based trimming while preserving Guava whitespace behavior.
- Replaced `Joiner.on("\t").join(...)` with `Collectors.joining("\t")`.
- Replaced `Sets.newHashSet(...)` usages with standard `Set.of(...)` / `HashSet`.
- Replaced `checkNotNull(...)` with `Objects.requireNonNull(...)`.
- Removed the direct backend `implementation("com.google.guava:guava:33.5.0-jre")` dependency.

No UI changes.

Note: `dependencyInsight` still shows Guava transitively through Google Cloud libraries, but this PR removes the direct backend implementation dependency and direct source usage.

**Testing**

Local development environment was set up and verified before running checks.

- `rg "com\.google\.common" src/main/java src/test/java src/it/java src/e2e/java src/client/java`
- `git diff --check`
- `gradlew.bat dependencyInsight --dependency com.google.guava:guava --configuration compileClasspath`
- `gradlew.bat unitTests --tests teammates.common.util.StringHelperTest`
- `gradlew.bat lint --continue`
- `gradlew.bat componentTests --continue`
- `npm run format`
- `npm run lint` (completed with existing Angular deprecation warnings)