### PR TITLE
[#14036] Rework proof of submission feature into submission receipt

### DIFF
--- a/src/main/resources/userEmailTemplate-deadlineExtension.html
+++ b/src/main/resources/userEmailTemplate-deadlineExtension.html
@@ -71,7 +71,7 @@ ${instructorPreamble}
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/main/resources/userEmailTemplate-feedbackSession.html
+++ b/src/main/resources/userEmailTemplate-feedbackSession.html
@@ -60,7 +60,7 @@ ${instructorPreamble}
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
@@ -60,7 +60,7 @@ ${instructorPreamble}
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/main/resources/userEmailTemplateFragment-feedbackSessionResendAllLinks.html
+++ b/src/main/resources/userEmailTemplateFragment-feedbackSessionResendAllLinks.html
@@ -5,7 +5,7 @@
 To view/submit feedback for the above session, please go to this Web address: ${submitUrl}
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: ${reportUrl}

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -71,7 +71,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionGivenStudent.html
+++ b/src/test/resources/emails/deadlineExtensionGivenStudent.html
@@ -71,7 +71,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
@@ -71,7 +71,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionRevokedStudent.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedStudent.html
@@ -71,7 +71,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -71,7 +71,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionUpdatedStudent.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedStudent.html
@@ -71,7 +71,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailCopyToInstructor.html
@@ -72,7 +72,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailForInstructor.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailForInstructorWithExtension.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailForStudent.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailForStudentWithExtension.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailTestingSanitizationCopyToInstructor.html
@@ -72,7 +72,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingSoonEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailTestingSanitizationForStudent.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpenedEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpenedEmailCopyToInstructor.html
@@ -72,7 +72,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpenedEmailForInstructor.html
+++ b/src/test/resources/emails/sessionOpenedEmailForInstructor.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpenedEmailForStudent.html
+++ b/src/test/resources/emails/sessionOpenedEmailForStudent.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpenedEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpenedEmailTestingSanitizationCopyToInstructor.html
@@ -72,7 +72,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpenedEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionOpenedEmailTestingSanitizationForStudent.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -72,7 +72,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -60,7 +60,7 @@
       The above link is unique to you. Please do not share it with others.
     </li>
     <li>
-      After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+      After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
@@ -16,7 +16,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
@@ -28,7 +28,7 @@ To view the responses for this session, please go to this Web address: <a href="
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -40,7 +40,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -52,7 +52,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -16,7 +16,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
@@ -28,7 +28,7 @@ To view the responses for this session, please go to this Web address: <a href="
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -40,7 +40,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -52,7 +52,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -34,7 +34,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
@@ -46,7 +46,7 @@ To view the responses for this session, please go to this Web address: <a href="
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -58,7 +58,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -70,7 +70,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredStudent.html
@@ -44,7 +44,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
@@ -56,7 +56,7 @@ To view the responses for this session, please go to this Web address: <a href="
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -68,7 +68,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -80,7 +80,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
@@ -16,7 +16,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
@@ -28,7 +28,7 @@ To view the responses for this session, please go to this Web address: <a href="
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -40,7 +40,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -52,7 +52,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
@@ -41,7 +41,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
@@ -53,7 +53,7 @@ To view the responses for this session, please go to this Web address: <a href="
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -65,7 +65,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -77,7 +77,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
@@ -16,7 +16,7 @@
 To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTestingSanitizationCourse&fsname=Normal%20feedback%20session%20name&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTestingSanitizationCourse&fsname=Normal%20feedback%20session%20name&key=${regkey.enc}</a>
 <br>
 <br>
-After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
+After submitting, you are encouraged to download the submission receipt, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -3784,6 +3784,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
           <button
             class="btn btn-info"
             id="btn-download-submission-receipt"
+            ngbtooltip="Download a receipt of your submission."
             type="button"
           >
              Download Submission Receipt 
@@ -6857,6 +6858,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
           <button
             class="btn btn-info"
             id="btn-download-submission-receipt"
+            ngbtooltip="Download a receipt of your submission."
             type="button"
           >
              Download Submission Receipt 

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -23,6 +23,7 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed={[Function Boolean]}
@@ -30,6 +31,7 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading={[Function Boolean]}
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
   isModerationHintExpanded="false"
@@ -182,6 +184,7 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -189,6 +192,7 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading={[Function Boolean]}
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
   isModerationHintExpanded="false"
@@ -338,6 +342,7 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -345,6 +350,7 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading={[Function Boolean]}
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
   isModerationHintExpanded="false"
@@ -494,6 +500,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime={[Function String]}
   formattedSessionOpeningTime={[Function String]}
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -501,6 +508,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading="false"
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
   isModerationHintExpanded="false"
@@ -783,6 +791,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -790,6 +799,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading="false"
   isFeedbackSessionQuestionsLoading="false"
   isModerationHintExpanded="false"
@@ -3768,11 +3778,18 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
         </div>
       </tm-question-submission-form>
       <div
-        class="row"
+        class="d-flex justify-content-center gap-2 flex-wrap"
       >
-        <div
-          class="col-12 text-center"
-        >
+        <div>
+          <button
+            class="btn btn-info"
+            id="btn-download-submission-receipt"
+            type="button"
+          >
+             Download Submission Receipt 
+          </button>
+        </div>
+        <div>
           <button
             class="btn btn-success"
             id="btn-submit"
@@ -3811,6 +3828,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -3818,6 +3836,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading="false"
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading="false"
   isFeedbackSessionQuestionsLoading="false"
   isModerationHintExpanded="false"
@@ -6832,11 +6851,18 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
         </div>
       </tm-question-submission-form>
       <div
-        class="row"
+        class="d-flex justify-content-center gap-2 flex-wrap"
       >
-        <div
-          class="col-12 text-center"
-        >
+        <div>
+          <button
+            class="btn btn-info"
+            id="btn-download-submission-receipt"
+            type="button"
+          >
+             Download Submission Receipt 
+          </button>
+        </div>
+        <div>
           <button
             class="btn btn-success"
             disabled=""
@@ -6876,6 +6902,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -6883,6 +6910,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading={[Function Boolean]}
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
   isModerationHintExpanded="false"
@@ -7033,6 +7061,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
+  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -7040,6 +7069,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   instructorService={[Function _InstructorService]}
   intent={[Function String]}
   isCourseLoading={[Function Boolean]}
+  isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
   isModerationHintExpanded="false"

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -23,7 +23,6 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed={[Function Boolean]}
@@ -57,6 +56,7 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -184,7 +184,6 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -218,6 +217,7 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -342,7 +342,6 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -376,6 +375,7 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -500,7 +500,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime={[Function String]}
   formattedSessionOpeningTime={[Function String]}
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -534,6 +533,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -791,7 +791,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -825,6 +824,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -3829,7 +3829,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -3863,6 +3862,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -6904,7 +6904,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -6938,6 +6937,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}
@@ -7063,7 +7063,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   feedbackSessionSubmissionStatus={[Function String]}
   feedbackSessionTimezone=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
-  fileSaveService={[Function _FileSaveService]}
   formattedSessionClosingTime=""
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
@@ -7097,6 +7096,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   statusMessageService={[Function _StatusMessageService]}
   studentId=""
   studentService={[Function _StudentService]}
+  submissionReceiptService={[Function _SubmissionReceiptService]}
   timezoneService={[Function _TimezoneService]}
   ungroupableQuestions={[Function Set]}
   ungroupableQuestionsSorted={[Function Array]}

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -6857,6 +6857,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
         <div>
           <button
             class="btn btn-info"
+            disabled=""
             id="btn-download-submission-receipt"
             ngbtooltip="Download a receipt of your submission."
             type="button"

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -55,5 +55,12 @@
   }
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn modal-btn-ok btn-success" (click)="activeModal.close()">OK</button>
+  <button
+    type="button"
+    class="btn modal-btn-ok"
+    [ngClass]="{ 'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions }"
+    (click)="activeModal.close()"
+  >
+    OK
+  </button>
 </div>

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.html
@@ -47,11 +47,6 @@
     <p>All your responses have been successfully recorded!</p>
   }
   <p>Note that you can change your responses and submit them again any time before the session closes.</p>
-  @if (!hasFailToSaveQuestions) {
-    <p>
-      <b>You are encouraged to download the proof of submission, which will also contain your latest responses.</b>
-    </p>
-  }
   @if (!hasFailToSaveQuestions && questions.length === 1) {
     <span class="text-danger">
       <i class="fas fa-exclamation"></i>
@@ -60,20 +55,5 @@
   }
 </div>
 <div class="modal-footer">
-  <button
-    type="button"
-    class="btn modal-btn-ok btn-info"
-    [ngClass]="{ 'btn-danger': hasFailToSaveQuestions, 'btn-success': !hasFailToSaveQuestions }"
-    (click)="activeModal.close()"
-  >
-    Don't download proof of submission
-  </button>
-  <button
-    type="button"
-    class="btn btn-success"
-    (click)="downloadProofOfSubmission()"
-    [disabled]="isAllQuestionSavingFailed"
-  >
-    Download proof of submission
-  </button>
+  <button type="button" class="btn modal-btn-ok btn-success" (click)="activeModal.close()">OK</button>
 </div>

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
@@ -26,8 +26,4 @@ export class SavingCompleteModalComponent {
   get hasFailToSaveQuestions(): boolean {
     return Object.keys(this.failToSaveQuestions).length !== 0;
   }
-
-  get isAllQuestionSavingFailed(): boolean {
-    return Object.keys(this.failToSaveQuestions).length === this.questions.length;
-  }
 }

--- a/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
+++ b/src/web/app/pages-session/session-submission-page/saving-complete-modal/saving-complete-modal.component.ts
@@ -1,10 +1,6 @@
 import { NgClass, KeyValuePipe } from '@angular/common';
 import { Component, Input, inject } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
-import { FileSaveService } from '../../../../services/file-save.service';
-import { TimezoneService } from '../../../../services/timezone.service';
-import { FeedbackResponse } from '../../../../types/api-output';
-import { FeedbackResponseDetailsFactory } from '../../../../types/response-details-impl/feedback-response-details-factory';
 import { QuestionSubmissionFormModel } from '../../../components/question-submission-form/question-submission-form-model';
 
 /**
@@ -17,32 +13,9 @@ import { QuestionSubmissionFormModel } from '../../../components/question-submis
 })
 export class SavingCompleteModalComponent {
   activeModal = inject(NgbActiveModal);
-  private fileSaveService = inject(FileSaveService);
-  private timezoneService = inject(TimezoneService);
-
-  @Input()
-  courseId = '';
-
-  @Input()
-  feedbackSessionName = '';
-
-  @Input()
-  feedbackSessionTimezone = '';
-
-  @Input()
-  personEmail = '';
-
-  @Input()
-  personName = '';
-
-  @Input()
-  requestIds: Record<string, string> = {};
 
   @Input()
   questions: QuestionSubmissionFormModel[] = [];
-
-  @Input()
-  answers: Record<string, FeedbackResponse[]> = {};
 
   @Input()
   notYetAnsweredQuestions: number[] = [];
@@ -56,55 +29,5 @@ export class SavingCompleteModalComponent {
 
   get isAllQuestionSavingFailed(): boolean {
     return Object.keys(this.failToSaveQuestions).length === this.questions.length;
-  }
-
-  downloadProofOfSubmission(): void {
-    const time: number = new Date().getTime();
-    const formattedTime: string = this.timezoneService.formatToString(
-      time,
-      this.feedbackSessionTimezone,
-      'YYYYMMDDHHmmSSZZ',
-    );
-
-    const fileContent: string[] = [
-      'TEAMMATES Proof of Submission',
-      `${time}::${formattedTime}`,
-      '==============================',
-      `Submitted by: ${this.personName} [${this.personEmail}]`,
-      `Course: ${this.courseId}`,
-      `Session: ${this.feedbackSessionName}`,
-      '',
-      '',
-      '',
-    ];
-
-    for (const question of this.questions) {
-      fileContent.push(`${question.questionNumber}: ${question.questionBrief}`);
-      fileContent.push(question.feedbackQuestionId);
-
-      if (this.requestIds[question.feedbackQuestionId]) {
-        // Question is either answered or skipped
-        fileContent.push(this.requestIds[question.feedbackQuestionId]);
-
-        if (this.answers[question.feedbackQuestionId]) {
-          for (const answer of this.answers[question.feedbackQuestionId]) {
-            fileContent.push(`> ${answer.recipientIdentifier}`);
-            fileContent.push(
-              FeedbackResponseDetailsFactory.fromApiOutput(answer.responseDetails)
-                .getResponseCsvAnswers(question.questionDetails)
-                .join(','),
-            );
-          }
-        }
-      } else {
-        fileContent.push('ERROR! The response submission to this question failed.');
-      }
-
-      fileContent.push('');
-      fileContent.push('');
-    }
-
-    const blob: Blob = new Blob([fileContent.join('\r\n')], { type: 'text/plain' });
-    this.fileSaveService.saveFile(blob, `TEAMMATES Proof of Submission - ${time}`);
   }
 }

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -266,30 +266,43 @@
       }
     }
     @if (questionsNeedingSubmission.length === 0) {
-      <div class="row">
-        <div class="col-12 text-center">
-          <div class="alert alert-info" role="alert">There are no questions for you to answer here!</div>
-        </div>
+      <div class="text-center">
+        <div class="alert alert-info" role="alert">There are no questions for you to answer here!</div>
       </div>
-    }
-    <!-- Do not display if only one question can be answered, as a button to submit individual response exists -->
-    @if (questionsNeedingSubmission.length > 1) {
-      <div class="row">
-        <div class="col-12 text-center">
+    } @else {
+      <div class="d-flex justify-content-center gap-2 flex-wrap">
+        <div>
           <button
-            id="btn-submit"
-            type="submit"
-            class="btn btn-success"
-            ngbTooltip="You can save your responses at any time and come back later to continue."
-            (click)="saveFeedbackResponses(questionSubmissionForms, null)"
-            [disabled]="isSavingResponses || isSubmissionFormsDisabled"
+            id="btn-download-submission-receipt"
+            type="button"
+            class="btn btn-info"
+            (click)="downloadSubmissionReceipt()"
+            [disabled]="isSubmissionReceiptDownloadDisabled"
           >
-            @if (isSavingResponses) {
+            @if (isDownloadingSubmissionReceipt) {
               <tm-ajax-loading></tm-ajax-loading>
             }
-            Submit Responses for All Questions
+            Download Submission Receipt
           </button>
         </div>
+        <!-- Do not display if only one question can be answered, as a button to submit individual response exists -->
+        @if (questionsNeedingSubmission.length > 1) {
+          <div>
+            <button
+              id="btn-submit"
+              type="submit"
+              class="btn btn-success"
+              ngbTooltip="You can save your responses at any time and come back later to continue."
+              (click)="saveFeedbackResponses(questionSubmissionForms, null)"
+              [disabled]="isSavingResponses || isSubmissionFormsDisabled"
+            >
+              @if (isSavingResponses) {
+                <tm-ajax-loading></tm-ajax-loading>
+              }
+              Submit Responses for All Questions
+            </button>
+          </div>
+        }
       </div>
     }
   </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -278,7 +278,7 @@
             class="btn btn-info"
             ngbTooltip="Download a receipt of your submission."
             (click)="downloadSubmissionReceipt()"
-            [disabled]="isDownloadingSubmissionReceipt"
+            [disabled]="isDownloadingSubmissionReceipt || isSavingResponses || isSubmissionFormsDisabled"
           >
             @if (isDownloadingSubmissionReceipt) {
               <tm-ajax-loading></tm-ajax-loading>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -276,6 +276,7 @@
             id="btn-download-submission-receipt"
             type="button"
             class="btn btn-info"
+            ngbTooltip="Download a receipt of your submission."
             (click)="downloadSubmissionReceipt()"
             [disabled]="isSubmissionReceiptDownloadDisabled"
           >

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -278,7 +278,7 @@
             class="btn btn-info"
             ngbTooltip="Download a receipt of your submission."
             (click)="downloadSubmissionReceipt()"
-            [disabled]="isSubmissionReceiptDownloadDisabled"
+            [disabled]="isDownloadingSubmissionReceipt"
           >
             @if (isDownloadingSubmissionReceipt) {
               <tm-ajax-loading></tm-ajax-loading>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1210,8 +1210,6 @@ describe('SessionSubmissionPageComponent', () => {
     component.questionSubmissionForms[0].recipientSubmissionForms[0].status = ResponseSubmissionStatus.MODIFIED;
     component.questionSubmissionForms[1].recipientSubmissionForms[0].status = ResponseSubmissionStatus.SAVED;
 
-    expect(component.isSubmissionReceiptDownloadDisabled).toBe(false);
-
     component.downloadSubmissionReceipt();
 
     expect(getResponseSpy).not.toHaveBeenCalled();

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1193,9 +1193,28 @@ describe('SessionSubmissionPageComponent', () => {
     expect(component.questionSubmissionForms[0].recipientSubmissionForms[0].commentByGiver).toBeUndefined();
   });
 
-  it('should download submission receipt from submitted response status without refetching', async () => {
+  it('should download submission receipt using latest fetched responses', async () => {
     const saveFileSpy = vi.spyOn(TestBed.inject(FileSaveService), 'saveFile');
-    const getResponseSpy = vi.spyOn(feedbackResponsesService, 'getFeedbackResponse');
+    const getResponseSpy = vi
+      .spyOn(feedbackResponsesService, 'getFeedbackResponse')
+      .mockImplementation((queryParams: { questionId: string }) => {
+        if (queryParams.questionId === 'feedback-question-id-mcq') {
+          return of({ responses: [] });
+        }
+        return of({
+          responses: [
+            {
+              feedbackResponseId: 'response-id-3',
+              giverIdentifier: 'giver-identifier',
+              recipientIdentifier: 'gene-harris-id',
+              responseDetails: {
+                answer: 'answer',
+                questionType: FeedbackQuestionType.TEXT,
+              },
+            },
+          ],
+        });
+      });
 
     component.courseId = 'course-id';
     component.courseName = 'Test Course';
@@ -1208,11 +1227,23 @@ describe('SessionSubmissionPageComponent', () => {
       deepCopy(testTextQuestionSubmissionForm),
     ];
     component.questionSubmissionForms[0].recipientSubmissionForms[0].status = ResponseSubmissionStatus.MODIFIED;
-    component.questionSubmissionForms[1].recipientSubmissionForms[0].status = ResponseSubmissionStatus.SAVED;
+    component.questionSubmissionForms[1].recipientSubmissionForms[0].status = ResponseSubmissionStatus.NEW;
 
     component.downloadSubmissionReceipt();
 
-    expect(getResponseSpy).not.toHaveBeenCalled();
+    expect(getResponseSpy).toHaveBeenCalledTimes(2);
+    expect(getResponseSpy).toHaveBeenNthCalledWith(1, {
+      questionId: 'feedback-question-id-mcq',
+      intent: Intent.STUDENT_SUBMISSION,
+      key: 'reg-key',
+      moderatedPerson: '',
+    });
+    expect(getResponseSpy).toHaveBeenNthCalledWith(2, {
+      questionId: 'feedback-question-id-text',
+      intent: Intent.STUDENT_SUBMISSION,
+      key: 'reg-key',
+      moderatedPerson: '',
+    });
     expect(saveFileSpy).toHaveBeenCalledTimes(1);
 
     const [blob, fileName] = saveFileSpy.mock.calls[0];

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -11,6 +11,7 @@ import { AuthService } from '../../../services/auth.service';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
+import { FileSaveService } from '../../../services/file-save.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { NavigationService } from '../../../services/navigation.service';
 import { SimpleModalService } from '../../../services/simple-modal.service';
@@ -1109,18 +1110,10 @@ describe('SessionSubmissionPageComponent', () => {
       },
     );
 
-    expect(mockModalRef.componentInstance.requestIds).toEqual({
-      'feedback-question-id-mcq': '10',
-      'feedback-question-id-text': '20',
-    });
     expect(mockModalRef.componentInstance.questions).toEqual([
       testQuestionSubmissionForm1,
       testQuestionSubmissionForm2,
     ]);
-    expect(mockModalRef.componentInstance.answers).toEqual({
-      'feedback-question-id-mcq': [testResponse1],
-      'feedback-question-id-text': [testResponse2],
-    });
     expect(mockModalRef.componentInstance.notYetAnsweredQuestions).toHaveLength(1);
     expect(mockModalRef.componentInstance.failToSaveQuestions).toEqual({});
   });
@@ -1167,16 +1160,10 @@ describe('SessionSubmissionPageComponent', () => {
     );
 
     // only the valid response is saved
-    expect(mockModalRef.componentInstance.requestIds).toEqual({
-      [testQuestionSubmissionForm1.feedbackQuestionId]: '10',
-    });
     expect(mockModalRef.componentInstance.questions).toEqual([
       testQuestionSubmissionForm1,
       testQuestionSubmissionForm2,
     ]);
-    expect(mockModalRef.componentInstance.answers).toEqual({
-      [testQuestionSubmissionForm1.feedbackQuestionId]: [testResponse1],
-    });
     expect(mockModalRef.componentInstance.failToSaveQuestions).toEqual({
       [testQuestionSubmissionForm2.questionNumber]: 'Invalid responses provided. Please check question constraints.',
     });
@@ -1204,5 +1191,41 @@ describe('SessionSubmissionPageComponent', () => {
       moderatedPerson: '',
     });
     expect(component.questionSubmissionForms[0].recipientSubmissionForms[0].commentByGiver).toBeUndefined();
+  });
+
+  it('should download submission receipt from submitted response status without refetching', async () => {
+    const saveFileSpy = vi.spyOn(TestBed.inject(FileSaveService), 'saveFile');
+    const getResponseSpy = vi.spyOn(feedbackResponsesService, 'getFeedbackResponse');
+
+    component.courseId = 'course-id';
+    component.courseName = 'Test Course';
+    component.feedbackSessionName = 'First Session';
+    component.feedbackSessionTimezone = 'Asia/Singapore';
+    component.personName = 'Alice Betsy';
+    component.personEmail = 'alice@tmms.com';
+    component.questionSubmissionForms = [
+      deepCopy(testMcqQuestionSubmissionForm),
+      deepCopy(testTextQuestionSubmissionForm),
+    ];
+    component.questionSubmissionForms[0].recipientSubmissionForms[0].status = ResponseSubmissionStatus.MODIFIED;
+    component.questionSubmissionForms[1].recipientSubmissionForms[0].status = ResponseSubmissionStatus.SAVED;
+
+    expect(component.isSubmissionReceiptDownloadDisabled).toBe(false);
+
+    component.downloadSubmissionReceipt();
+
+    expect(getResponseSpy).not.toHaveBeenCalled();
+    expect(saveFileSpy).toHaveBeenCalledTimes(1);
+
+    const [blob, fileName] = saveFileSpy.mock.calls[0];
+    expect(fileName).toContain('TEAMMATES Submission Receipt - ');
+
+    const content: string = await blob.text();
+    expect(content).toContain('Questions Answered: 1 of 2');
+    expect(content).toContain('Question 1\nquestion brief');
+    expect(content).toContain('No submitted responses for this question.');
+    expect(content).toContain('Question 3\nquestion brief');
+    expect(content).toContain('Response ID: response-id-3');
+    expect(content).not.toContain('Response ID: response-id-1');
   });
 });

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -168,15 +168,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
   private backendUrl: string = environment.backendUrl;
 
-  get isSubmissionReceiptDownloadDisabled(): boolean {
-    const hasAtLeastOneSavedResponse = this.questionSubmissionForms.some((question: QuestionSubmissionFormModel) =>
-      question.recipientSubmissionForms.some(
-        (response: FeedbackResponseRecipientSubmissionFormModel) => response.status === ResponseSubmissionStatus.SAVED,
-      ),
-    );
-    return this.isDownloadingSubmissionReceipt || !hasAtLeastOneSavedResponse;
-  }
-
   constructor() {
     this.castAsSelectElement = castAsSelectElement;
     this.FeedbackSessionSubmissionStatus = FeedbackSessionSubmissionStatus;

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -16,13 +16,13 @@ import { DeadlineExtensionHelper } from '../../../services/deadline-extension-he
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackResponsesResponse, FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
-import { FileSaveService } from '../../../services/file-save.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { LogService } from '../../../services/log.service';
 import { NavigationService } from '../../../services/navigation.service';
 import { SimpleModalService } from '../../../services/simple-modal.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
+import { SubmissionReceiptService } from '../../../services/submission-receipt.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
   AuthInfo,
@@ -64,7 +64,6 @@ import { SimpleModalType } from '../../components/simple-modal/simple-modal-type
 import { SafeHtmlPipe } from '../../components/teammates-common/safe-html.pipe';
 import { PageScrollService } from '../../../services/page-scroll.service';
 import { ErrorMessageOutput } from '../../error-message-output';
-import { FeedbackResponseDetailsFactory } from '../../../types/response-details-impl/feedback-response-details-factory';
 
 interface FeedbackQuestionsResponse {
   questions: FeedbackQuestion[];
@@ -97,7 +96,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   private feedbackQuestionsService = inject(FeedbackQuestionsService);
   private feedbackResponsesService = inject(FeedbackResponsesService);
   private feedbackSessionsService = inject(FeedbackSessionsService);
-  private fileSaveService = inject(FileSaveService);
+  private submissionReceiptService = inject(SubmissionReceiptService);
   private studentService = inject(StudentService);
   private instructorService = inject(InstructorService);
   private courseService = inject(CourseService);
@@ -903,113 +902,36 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
   downloadSubmissionReceipt(): void {
     this.isDownloadingSubmissionReceipt = true;
-    try {
-      const submittedResponsesByQuestion: Record<string, FeedbackResponseRecipientSubmissionFormModel[]> =
-        this.getSubmittedResponsesByQuestion();
-      const hasResponses: boolean = Object.values(submittedResponsesByQuestion).some(
-        (responses: FeedbackResponseRecipientSubmissionFormModel[]) => responses.length > 0,
-      );
-
-      if (!hasResponses) {
-        this.statusMessageService.showWarningToast('No submitted responses found to include in submission receipt.');
-        this.isDownloadingSubmissionReceipt = false;
-        return;
-      }
-
-      const generatedAtMs: number = Date.now();
-      const generatedAtFormatted: string = this.timezoneService.formatToString(
-        generatedAtMs,
-        this.feedbackSessionTimezone,
-        'ddd, DD MMM, YYYY, hh:mm A zz',
-      );
-      const timeForFilename: string = this.timezoneService.formatToString(
-        generatedAtMs,
-        this.feedbackSessionTimezone,
-        'YYYYMMDDHHmmss',
-      );
-
-      const sortedQuestions: QuestionSubmissionFormModel[] = [...this.questionSubmissionForms].sort(
-        (a: QuestionSubmissionFormModel, b: QuestionSubmissionFormModel) => a.questionNumber - b.questionNumber,
-      );
-      const answeredQuestionsCount: number = sortedQuestions.filter(
-        (question: QuestionSubmissionFormModel) =>
-          (submittedResponsesByQuestion[question.feedbackQuestionId] || []).length > 0,
-      ).length;
-
-      const fileContent: string[] = [
-        'TEAMMATES Submission Receipt',
-        '============================',
-        `Generated At: ${generatedAtFormatted}`,
-        `Submitted by: ${this.personName} (${this.personEmail})`,
-        `Course: ${this.courseName} (${this.courseId})`,
-        `Session: ${this.feedbackSessionName}`,
-        `Questions Answered: ${answeredQuestionsCount} of ${sortedQuestions.length}`,
-        '============================',
-        '',
-      ];
-
-      sortedQuestions.forEach((question: QuestionSubmissionFormModel) => {
-        const questionResponses: FeedbackResponseRecipientSubmissionFormModel[] =
-          submittedResponsesByQuestion[question.feedbackQuestionId] || [];
-
-        fileContent.push(`Question ${question.questionNumber}`, `${question.questionBrief}`, '');
-
-        if (questionResponses.length === 0) {
-          fileContent.push('No submitted responses for this question.', '', '');
-          return;
-        }
-
-        const sortedResponses: FeedbackResponseRecipientSubmissionFormModel[] = [...questionResponses].sort(
-          (a: FeedbackResponseRecipientSubmissionFormModel, b: FeedbackResponseRecipientSubmissionFormModel) =>
-            a.recipientIdentifier.localeCompare(b.recipientIdentifier),
-        );
-
-        sortedResponses.forEach((response: FeedbackResponseRecipientSubmissionFormModel) => {
-          const recipient: FeedbackResponseRecipient | undefined = question.recipientList.find(
-            (item: FeedbackResponseRecipient) => item.recipientIdentifier === response.recipientIdentifier,
-          );
-          const recipientLabel: string = recipient?.recipientName
-            ? `${recipient.recipientName} [${response.recipientIdentifier}]`
-            : response.recipientIdentifier;
-
-          fileContent.push(
-            `Recipient: ${recipientLabel}`,
-            `Response ID: ${response.responseId}`,
-            `Answer: ${FeedbackResponseDetailsFactory.fromApiOutput(response.responseDetails)
-              .getResponseCsvAnswers(question.questionDetails)
-              .join(', ')}`,
-          );
-
-          if (response.commentByGiver?.commentType === 'giver') {
-            fileContent.push(`Comment by giver: ${response.commentByGiver.originalCommentFormModel.commentText}`);
+    this.submissionReceiptService
+      .downloadSubmissionReceipt({
+        questionSubmissionForms: this.questionSubmissionForms,
+        intent: this.intent,
+        key: this.regKey,
+        moderatedPerson: this.moderatedPerson,
+        feedbackSessionTimezone: this.feedbackSessionTimezone,
+        personName: this.personName,
+        personEmail: this.personEmail,
+        courseName: this.courseName,
+        courseId: this.courseId,
+        feedbackSessionName: this.feedbackSessionName,
+      })
+      .pipe(
+        finalize(() => {
+          this.isDownloadingSubmissionReceipt = false;
+        }),
+      )
+      .subscribe({
+        next: (hasResponses: boolean) => {
+          if (!hasResponses) {
+            this.statusMessageService.showWarningToast(
+              'No submitted responses found to include in submission receipt.',
+            );
           }
-
-          fileContent.push('');
-        });
-
-        fileContent.push('');
+        },
+        error: () => {
+          this.statusMessageService.showErrorToast('An error occurred while generating the submission receipt.');
+        },
       });
-
-      const blob: Blob = new Blob([fileContent.join('\n')], { type: 'text/plain' });
-      this.fileSaveService.saveFile(blob, `TEAMMATES Submission Receipt - ${timeForFilename}.txt`);
-    } catch (error) {
-      console.error('Error generating submission receipt:', error);
-      this.statusMessageService.showErrorToast('An error occurred while generating the submission receipt.');
-    } finally {
-      this.isDownloadingSubmissionReceipt = false;
-    }
-  }
-
-  private getSubmittedResponsesByQuestion(): Record<string, FeedbackResponseRecipientSubmissionFormModel[]> {
-    const responsesByQuestion: Record<string, FeedbackResponseRecipientSubmissionFormModel[]> = {};
-
-    this.questionSubmissionForms.forEach((question: QuestionSubmissionFormModel) => {
-      responsesByQuestion[question.feedbackQuestionId] = question.recipientSubmissionForms.filter(
-        (response: FeedbackResponseRecipientSubmissionFormModel) => response.status === ResponseSubmissionStatus.SAVED,
-      );
-    });
-
-    return responsesByQuestion;
   }
 
   /**

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -912,95 +912,101 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
   downloadSubmissionReceipt(): void {
     this.isDownloadingSubmissionReceipt = true;
-    const submittedResponsesByQuestion: Record<string, FeedbackResponseRecipientSubmissionFormModel[]> =
-      this.getSubmittedResponsesByQuestion();
-    const hasResponses: boolean = Object.values(submittedResponsesByQuestion).some(
-      (responses: FeedbackResponseRecipientSubmissionFormModel[]) => responses.length > 0,
-    );
+    try {
+      const submittedResponsesByQuestion: Record<string, FeedbackResponseRecipientSubmissionFormModel[]> =
+        this.getSubmittedResponsesByQuestion();
+      const hasResponses: boolean = Object.values(submittedResponsesByQuestion).some(
+        (responses: FeedbackResponseRecipientSubmissionFormModel[]) => responses.length > 0,
+      );
 
-    if (!hasResponses) {
-      this.statusMessageService.showWarningToast('No submitted responses found to include in submission receipt.');
-      this.isDownloadingSubmissionReceipt = false;
-      return;
-    }
-
-    const generatedAtMs: number = Date.now();
-    const generatedAtFormatted: string = this.timezoneService.formatToString(
-      generatedAtMs,
-      this.feedbackSessionTimezone,
-      'ddd, DD MMM, YYYY, hh:mm A zz',
-    );
-    const timeForFilename: string = this.timezoneService.formatToString(
-      generatedAtMs,
-      this.feedbackSessionTimezone,
-      'YYYYMMDDHHmmss',
-    );
-
-    const sortedQuestions: QuestionSubmissionFormModel[] = [...this.questionSubmissionForms].sort(
-      (a: QuestionSubmissionFormModel, b: QuestionSubmissionFormModel) => a.questionNumber - b.questionNumber,
-    );
-    const answeredQuestionsCount: number = sortedQuestions.filter(
-      (question: QuestionSubmissionFormModel) =>
-        (submittedResponsesByQuestion[question.feedbackQuestionId] || []).length > 0,
-    ).length;
-
-    const fileContent: string[] = [
-      'TEAMMATES Submission Receipt',
-      '============================',
-      `Generated At: ${generatedAtFormatted}`,
-      `Submitted by: ${this.personName} (${this.personEmail})`,
-      `Course: ${this.courseName} (${this.courseId})`,
-      `Session: ${this.feedbackSessionName}`,
-      `Questions Answered: ${answeredQuestionsCount} of ${sortedQuestions.length}`,
-      '============================',
-      '',
-    ];
-
-    sortedQuestions.forEach((question: QuestionSubmissionFormModel) => {
-      const questionResponses: FeedbackResponseRecipientSubmissionFormModel[] =
-        submittedResponsesByQuestion[question.feedbackQuestionId] || [];
-
-      fileContent.push(`Question ${question.questionNumber}`, `${question.questionBrief}`, '');
-
-      if (questionResponses.length === 0) {
-        fileContent.push('No submitted responses for this question.', '', '');
+      if (!hasResponses) {
+        this.statusMessageService.showWarningToast('No submitted responses found to include in submission receipt.');
+        this.isDownloadingSubmissionReceipt = false;
         return;
       }
 
-      const sortedResponses: FeedbackResponseRecipientSubmissionFormModel[] = [...questionResponses].sort(
-        (a: FeedbackResponseRecipientSubmissionFormModel, b: FeedbackResponseRecipientSubmissionFormModel) =>
-          a.recipientIdentifier.localeCompare(b.recipientIdentifier),
+      const generatedAtMs: number = Date.now();
+      const generatedAtFormatted: string = this.timezoneService.formatToString(
+        generatedAtMs,
+        this.feedbackSessionTimezone,
+        'ddd, DD MMM, YYYY, hh:mm A zz',
+      );
+      const timeForFilename: string = this.timezoneService.formatToString(
+        generatedAtMs,
+        this.feedbackSessionTimezone,
+        'YYYYMMDDHHmmss',
       );
 
-      sortedResponses.forEach((response: FeedbackResponseRecipientSubmissionFormModel) => {
-        const recipient: FeedbackResponseRecipient | undefined = question.recipientList.find(
-          (item: FeedbackResponseRecipient) => item.recipientIdentifier === response.recipientIdentifier,
-        );
-        const recipientLabel: string = recipient?.recipientName
-          ? `${recipient.recipientName} [${response.recipientIdentifier}]`
-          : response.recipientIdentifier;
+      const sortedQuestions: QuestionSubmissionFormModel[] = [...this.questionSubmissionForms].sort(
+        (a: QuestionSubmissionFormModel, b: QuestionSubmissionFormModel) => a.questionNumber - b.questionNumber,
+      );
+      const answeredQuestionsCount: number = sortedQuestions.filter(
+        (question: QuestionSubmissionFormModel) =>
+          (submittedResponsesByQuestion[question.feedbackQuestionId] || []).length > 0,
+      ).length;
 
-        fileContent.push(
-          `Recipient: ${recipientLabel}`,
-          `Response ID: ${response.responseId}`,
-          `Answer: ${FeedbackResponseDetailsFactory.fromApiOutput(response.responseDetails)
-            .getResponseCsvAnswers(question.questionDetails)
-            .join(', ')}`,
-        );
+      const fileContent: string[] = [
+        'TEAMMATES Submission Receipt',
+        '============================',
+        `Generated At: ${generatedAtFormatted}`,
+        `Submitted by: ${this.personName} (${this.personEmail})`,
+        `Course: ${this.courseName} (${this.courseId})`,
+        `Session: ${this.feedbackSessionName}`,
+        `Questions Answered: ${answeredQuestionsCount} of ${sortedQuestions.length}`,
+        '============================',
+        '',
+      ];
 
-        if (response.commentByGiver?.commentType === 'giver') {
-          fileContent.push(`Comment by giver: ${response.commentByGiver.originalCommentFormModel.commentText}`);
+      sortedQuestions.forEach((question: QuestionSubmissionFormModel) => {
+        const questionResponses: FeedbackResponseRecipientSubmissionFormModel[] =
+          submittedResponsesByQuestion[question.feedbackQuestionId] || [];
+
+        fileContent.push(`Question ${question.questionNumber}`, `${question.questionBrief}`, '');
+
+        if (questionResponses.length === 0) {
+          fileContent.push('No submitted responses for this question.', '', '');
+          return;
         }
+
+        const sortedResponses: FeedbackResponseRecipientSubmissionFormModel[] = [...questionResponses].sort(
+          (a: FeedbackResponseRecipientSubmissionFormModel, b: FeedbackResponseRecipientSubmissionFormModel) =>
+            a.recipientIdentifier.localeCompare(b.recipientIdentifier),
+        );
+
+        sortedResponses.forEach((response: FeedbackResponseRecipientSubmissionFormModel) => {
+          const recipient: FeedbackResponseRecipient | undefined = question.recipientList.find(
+            (item: FeedbackResponseRecipient) => item.recipientIdentifier === response.recipientIdentifier,
+          );
+          const recipientLabel: string = recipient?.recipientName
+            ? `${recipient.recipientName} [${response.recipientIdentifier}]`
+            : response.recipientIdentifier;
+
+          fileContent.push(
+            `Recipient: ${recipientLabel}`,
+            `Response ID: ${response.responseId}`,
+            `Answer: ${FeedbackResponseDetailsFactory.fromApiOutput(response.responseDetails)
+              .getResponseCsvAnswers(question.questionDetails)
+              .join(', ')}`,
+          );
+
+          if (response.commentByGiver?.commentType === 'giver') {
+            fileContent.push(`Comment by giver: ${response.commentByGiver.originalCommentFormModel.commentText}`);
+          }
+
+          fileContent.push('');
+        });
 
         fileContent.push('');
       });
 
-      fileContent.push('');
-    });
-
-    const blob: Blob = new Blob([fileContent.join('\n')], { type: 'text/plain' });
-    this.fileSaveService.saveFile(blob, `TEAMMATES Submission Receipt - ${timeForFilename}`);
-    this.isDownloadingSubmissionReceipt = false;
+      const blob: Blob = new Blob([fileContent.join('\n')], { type: 'text/plain' });
+      this.fileSaveService.saveFile(blob, `TEAMMATES Submission Receipt - ${timeForFilename}.txt`);
+    } catch (error) {
+      console.error('Error generating submission receipt:', error);
+      this.statusMessageService.showErrorToast('An error occurred while generating the submission receipt.');
+    } finally {
+      this.isDownloadingSubmissionReceipt = false;
+    }
   }
 
   private getSubmittedResponsesByQuestion(): Record<string, FeedbackResponseRecipientSubmissionFormModel[]> {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -16,6 +16,7 @@ import { DeadlineExtensionHelper } from '../../../services/deadline-extension-he
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackResponsesResponse, FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
+import { FileSaveService } from '../../../services/file-save.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { LogService } from '../../../services/log.service';
 import { NavigationService } from '../../../services/navigation.service';
@@ -63,6 +64,7 @@ import { SimpleModalType } from '../../components/simple-modal/simple-modal-type
 import { SafeHtmlPipe } from '../../components/teammates-common/safe-html.pipe';
 import { PageScrollService } from '../../../services/page-scroll.service';
 import { ErrorMessageOutput } from '../../error-message-output';
+import { FeedbackResponseDetailsFactory } from '../../../types/response-details-impl/feedback-response-details-factory';
 
 interface FeedbackQuestionsResponse {
   questions: FeedbackQuestion[];
@@ -95,6 +97,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   private feedbackQuestionsService = inject(FeedbackQuestionsService);
   private feedbackResponsesService = inject(FeedbackResponsesService);
   private feedbackSessionsService = inject(FeedbackSessionsService);
+  private fileSaveService = inject(FileSaveService);
   private studentService = inject(StudentService);
   private instructorService = inject(InstructorService);
   private courseService = inject(CourseService);
@@ -139,6 +142,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   questionSubmissionForms: QuestionSubmissionFormModel[] = [];
 
   isSavingResponses = false;
+  isDownloadingSubmissionReceipt = false;
   isSubmissionFormsDisabled = false;
 
   isModerationHintExpanded = false;
@@ -163,6 +167,15 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   studentId: string | undefined = '';
 
   private backendUrl: string = environment.backendUrl;
+
+  get isSubmissionReceiptDownloadDisabled(): boolean {
+    const hasAtLeastOneSavedResponse = this.questionSubmissionForms.some((question: QuestionSubmissionFormModel) =>
+      question.recipientSubmissionForms.some(
+        (response: FeedbackResponseRecipientSubmissionFormModel) => response.status === ResponseSubmissionStatus.SAVED,
+      ),
+    );
+    return this.isDownloadingSubmissionReceipt || !hasAtLeastOneSavedResponse;
+  }
 
   constructor() {
     this.castAsSelectElement = castAsSelectElement;
@@ -796,7 +809,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   saveFeedbackResponses(questionSubmissionForms: QuestionSubmissionFormModel[], recipientId: string | null): void {
     const notYetAnsweredQuestions: Set<number> = new Set();
     const requestIds: Record<string, string> = {};
-    const answers: Record<string, FeedbackResponse[]> = {};
     const failToSaveQuestions: Record<number, string> = {}; // Map of question number to error message
     const savingRequests: Observable<any>[] = [];
 
@@ -847,9 +859,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                 const responsesMap: Record<string, FeedbackResponse> = {};
                 resp.responses.forEach((response: FeedbackResponse) => {
                   responsesMap[response.recipientIdentifier] = response;
-                  answers[questionSubmissionFormModel.feedbackQuestionId] =
-                    answers[questionSubmissionFormModel.feedbackQuestionId] || [];
-                  answers[questionSubmissionFormModel.feedbackQuestionId].push(response);
                 });
                 requestIds[questionSubmissionFormModel.feedbackQuestionId] = resp.requestId || '';
 
@@ -893,19 +902,117 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
           this.isSavingResponses = false;
 
           const modalRef: NgbModalRef = this.ngbModal.open(SavingCompleteModalComponent);
-          modalRef.componentInstance.requestIds = requestIds;
-          modalRef.componentInstance.courseId = this.courseId;
-          modalRef.componentInstance.feedbackSessionName = this.feedbackSessionName;
-          modalRef.componentInstance.feedbackSessionTimezone = this.feedbackSessionTimezone;
-          modalRef.componentInstance.personEmail = this.personEmail;
-          modalRef.componentInstance.personName = this.personName;
           modalRef.componentInstance.questions = questionSubmissionForms;
-          modalRef.componentInstance.answers = answers;
           modalRef.componentInstance.notYetAnsweredQuestions = Array.from(notYetAnsweredQuestions.values());
           modalRef.componentInstance.failToSaveQuestions = failToSaveQuestions;
         }),
       )
       .subscribe();
+  }
+
+  downloadSubmissionReceipt(): void {
+    this.isDownloadingSubmissionReceipt = true;
+    const submittedResponsesByQuestion: Record<string, FeedbackResponseRecipientSubmissionFormModel[]> =
+      this.getSubmittedResponsesByQuestion();
+    const hasResponses: boolean = Object.values(submittedResponsesByQuestion).some(
+      (responses: FeedbackResponseRecipientSubmissionFormModel[]) => responses.length > 0,
+    );
+
+    if (!hasResponses) {
+      this.statusMessageService.showWarningToast('No submitted responses found to include in submission receipt.');
+      this.isDownloadingSubmissionReceipt = false;
+      return;
+    }
+
+    const generatedAtMs: number = Date.now();
+    const generatedAtFormatted: string = this.timezoneService.formatToString(
+      generatedAtMs,
+      this.feedbackSessionTimezone,
+      'ddd, DD MMM, YYYY, hh:mm A zz',
+    );
+    const timeForFilename: string = this.timezoneService.formatToString(
+      generatedAtMs,
+      this.feedbackSessionTimezone,
+      'YYYYMMDDHHmmss',
+    );
+
+    const sortedQuestions: QuestionSubmissionFormModel[] = [...this.questionSubmissionForms].sort(
+      (a: QuestionSubmissionFormModel, b: QuestionSubmissionFormModel) => a.questionNumber - b.questionNumber,
+    );
+    const answeredQuestionsCount: number = sortedQuestions.filter(
+      (question: QuestionSubmissionFormModel) =>
+        (submittedResponsesByQuestion[question.feedbackQuestionId] || []).length > 0,
+    ).length;
+
+    const fileContent: string[] = [
+      'TEAMMATES Submission Receipt',
+      '============================',
+      `Generated At: ${generatedAtFormatted}`,
+      `Submitted by: ${this.personName} (${this.personEmail})`,
+      `Course: ${this.courseName} (${this.courseId})`,
+      `Session: ${this.feedbackSessionName}`,
+      `Questions Answered: ${answeredQuestionsCount} of ${sortedQuestions.length}`,
+      '============================',
+      '',
+    ];
+
+    sortedQuestions.forEach((question: QuestionSubmissionFormModel) => {
+      const questionResponses: FeedbackResponseRecipientSubmissionFormModel[] =
+        submittedResponsesByQuestion[question.feedbackQuestionId] || [];
+
+      fileContent.push(`Question ${question.questionNumber}`, `${question.questionBrief}`, '');
+
+      if (questionResponses.length === 0) {
+        fileContent.push('No submitted responses for this question.', '', '');
+        return;
+      }
+
+      const sortedResponses: FeedbackResponseRecipientSubmissionFormModel[] = [...questionResponses].sort(
+        (a: FeedbackResponseRecipientSubmissionFormModel, b: FeedbackResponseRecipientSubmissionFormModel) =>
+          a.recipientIdentifier.localeCompare(b.recipientIdentifier),
+      );
+
+      sortedResponses.forEach((response: FeedbackResponseRecipientSubmissionFormModel) => {
+        const recipient: FeedbackResponseRecipient | undefined = question.recipientList.find(
+          (item: FeedbackResponseRecipient) => item.recipientIdentifier === response.recipientIdentifier,
+        );
+        const recipientLabel: string = recipient?.recipientName
+          ? `${recipient.recipientName} [${response.recipientIdentifier}]`
+          : response.recipientIdentifier;
+
+        fileContent.push(
+          `Recipient: ${recipientLabel}`,
+          `Response ID: ${response.responseId}`,
+          `Answer: ${FeedbackResponseDetailsFactory.fromApiOutput(response.responseDetails)
+            .getResponseCsvAnswers(question.questionDetails)
+            .join(', ')}`,
+        );
+
+        if (response.commentByGiver?.commentType === 'giver') {
+          fileContent.push(`Comment by giver: ${response.commentByGiver.originalCommentFormModel.commentText}`);
+        }
+
+        fileContent.push('');
+      });
+
+      fileContent.push('');
+    });
+
+    const blob: Blob = new Blob([fileContent.join('\n')], { type: 'text/plain' });
+    this.fileSaveService.saveFile(blob, `TEAMMATES Submission Receipt - ${timeForFilename}`);
+    this.isDownloadingSubmissionReceipt = false;
+  }
+
+  private getSubmittedResponsesByQuestion(): Record<string, FeedbackResponseRecipientSubmissionFormModel[]> {
+    const responsesByQuestion: Record<string, FeedbackResponseRecipientSubmissionFormModel[]> = {};
+
+    this.questionSubmissionForms.forEach((question: QuestionSubmissionFormModel) => {
+      responsesByQuestion[question.feedbackQuestionId] = question.recipientSubmissionForms.filter(
+        (response: FeedbackResponseRecipientSubmissionFormModel) => response.status === ResponseSubmissionStatus.SAVED,
+      );
+    });
+
+    return responsesByQuestion;
   }
 
   /**

--- a/src/web/services/submission-receipt.service.ts
+++ b/src/web/services/submission-receipt.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, inject } from '@angular/core';
+import { forkJoin, map, Observable, of } from 'rxjs';
+import { FileSaveService } from './file-save.service';
+import { FeedbackResponsesResponse, FeedbackResponsesService } from './feedback-responses.service';
+import { TimezoneService } from './timezone.service';
+import { FeedbackResponse } from '../types/api-output';
+import { Intent } from '../types/api-request';
+import {
+  FeedbackResponseRecipient,
+  QuestionSubmissionFormModel,
+} from '../app/components/question-submission-form/question-submission-form-model';
+import { FeedbackResponseDetailsFactory } from '../types/response-details-impl/feedback-response-details-factory';
+
+interface QuestionResponses {
+  question: QuestionSubmissionFormModel;
+  responses: FeedbackResponse[];
+}
+
+export interface SubmissionReceiptRequest {
+  questionSubmissionForms: QuestionSubmissionFormModel[];
+  intent: Intent;
+  key: string;
+  moderatedPerson: string;
+  feedbackSessionTimezone: string;
+  personName: string;
+  personEmail: string;
+  courseName: string;
+  courseId: string;
+  feedbackSessionName: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SubmissionReceiptService {
+  private readonly feedbackResponsesService = inject(FeedbackResponsesService);
+  private readonly timezoneService = inject(TimezoneService);
+  private readonly fileSaveService = inject(FileSaveService);
+
+  /**
+   * Downloads a submission receipt using latest responses from the server.
+   * Returns true if there are submitted responses to include in the receipt.
+   */
+  downloadSubmissionReceipt(request: SubmissionReceiptRequest): Observable<boolean> {
+    if (request.questionSubmissionForms.length === 0) {
+      return of(false);
+    }
+
+    const responseRequests: Observable<QuestionResponses>[] = request.questionSubmissionForms.map(
+      (question: QuestionSubmissionFormModel) =>
+        this.feedbackResponsesService
+          .getFeedbackResponse({
+            questionId: question.feedbackQuestionId,
+            intent: request.intent,
+            key: request.key,
+            moderatedPerson: request.moderatedPerson,
+          })
+          .pipe(
+            map((response: FeedbackResponsesResponse) => ({
+              question,
+              responses: response.responses,
+            })),
+          ),
+    );
+
+    return forkJoin(responseRequests).pipe(
+      map((questionsWithResponses: QuestionResponses[]) => {
+        const sortedQuestionsWithResponses: QuestionResponses[] = [...questionsWithResponses].sort(
+          (a: QuestionResponses, b: QuestionResponses) => a.question.questionNumber - b.question.questionNumber,
+        );
+
+        const answeredQuestionsCount: number = sortedQuestionsWithResponses.filter(
+          (entry: QuestionResponses) => entry.responses.length > 0,
+        ).length;
+
+        if (answeredQuestionsCount === 0) {
+          return false;
+        }
+
+        const generatedAtMs: number = Date.now();
+        const generatedAtFormatted: string = this.timezoneService.formatToString(
+          generatedAtMs,
+          request.feedbackSessionTimezone,
+          'ddd, DD MMM, YYYY, hh:mm A zz',
+        );
+        const timeForFilename: string = this.timezoneService.formatToString(
+          generatedAtMs,
+          request.feedbackSessionTimezone,
+          'YYYYMMDDHHmmss',
+        );
+
+        const fileContent: string[] = [
+          'TEAMMATES Submission Receipt',
+          '============================',
+          `Generated At: ${generatedAtFormatted}`,
+          `Submitted by: ${request.personName} (${request.personEmail})`,
+          `Course: ${request.courseName} (${request.courseId})`,
+          `Session: ${request.feedbackSessionName}`,
+          `Questions Answered: ${answeredQuestionsCount} of ${sortedQuestionsWithResponses.length}`,
+          '============================',
+          '',
+        ];
+
+        sortedQuestionsWithResponses.forEach((entry: QuestionResponses) => {
+          this.appendQuestionContent(fileContent, entry);
+        });
+
+        const blob: Blob = new Blob([fileContent.join('\n')], { type: 'text/plain' });
+        this.fileSaveService.saveFile(blob, `TEAMMATES Submission Receipt - ${timeForFilename}.txt`);
+        return true;
+      }),
+    );
+  }
+
+  private appendQuestionContent(fileContent: string[], entry: QuestionResponses): void {
+    const question: QuestionSubmissionFormModel = entry.question;
+    const questionResponses: FeedbackResponse[] = [...entry.responses].sort(
+      (a: FeedbackResponse, b: FeedbackResponse) => a.recipientIdentifier.localeCompare(b.recipientIdentifier),
+    );
+
+    fileContent.push(`Question ${question.questionNumber}`, `${question.questionBrief}`, '');
+
+    if (questionResponses.length === 0) {
+      fileContent.push('No submitted responses for this question.', '', '');
+      return;
+    }
+
+    questionResponses.forEach((response: FeedbackResponse) => {
+      const recipientLabel: string = this.getRecipientLabel(question, response);
+
+      fileContent.push(
+        `Recipient: ${recipientLabel}`,
+        `Response ID: ${response.feedbackResponseId}`,
+        `Answer: ${FeedbackResponseDetailsFactory.fromApiOutput(response.responseDetails)
+          .getResponseCsvAnswers(question.questionDetails)
+          .join(', ')}`,
+      );
+
+      if (response.giverComment) {
+        fileContent.push(`Comment by giver: ${response.giverComment}`);
+      }
+
+      fileContent.push('');
+    });
+
+    fileContent.push('');
+  }
+
+  private getRecipientLabel(question: QuestionSubmissionFormModel, response: FeedbackResponse): string {
+    const recipient: FeedbackResponseRecipient | undefined = question.recipientList.find(
+      (item: FeedbackResponseRecipient) => item.recipientIdentifier === response.recipientIdentifier,
+    );
+    return recipient?.recipientName
+      ? `${recipient.recipientName} [${response.recipientIdentifier}]`
+      : response.recipientIdentifier;
+  }
+}


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #14036

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Proof of submission renamed to submission receipt as per issue. The download button is no longer in the success modal. Instead, it is moved to the bottom of page near the Submit responses for All Questions button. The contents of the submission receipt have also been updated to be (slightly) more user friendly.


<img width="708" height="288" alt="Screenshot 2026-05-30 at 13 20 39" src="https://github.com/user-attachments/assets/e3a83b42-6e6e-4718-8573-57d1a673941e" />

<img width="681" height="279" alt="Screenshot 2026-05-30 at 13 20 48" src="https://github.com/user-attachments/assets/aade0fb6-140d-4faa-8db3-1579f9b451c6" />

<img width="768" height="534" alt="Screenshot 2026-05-30 at 13 21 04" src="https://github.com/user-attachments/assets/5553b30a-d658-4309-baa2-894a25cecda4" />