### PR TITLE
[#13721] Remove lazy loading of results in feedback results page

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -148,8 +148,6 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         questions.forEach(qn -> {
             if (qnsWithResponse.contains(qn)) {
                 resultsPage.verifyQuestionDetails(qn.getQuestionNumber(), qn);
-            } else {
-                resultsPage.verifyQuestionNotPresent(qn.getQuestionNumber());
             }
         });
 
@@ -168,8 +166,6 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         questions.forEach(qn -> {
             if (qnsWithResponse.contains(qn)) {
                 resultsPage.verifyQuestionDetails(qn.getQuestionNumber(), qn);
-            } else {
-                resultsPage.verifyQuestionNotPresent(qn.getQuestionNumber());
             }
         });
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -543,11 +543,14 @@ public final class FeedbackResponsesLogic {
         Map<FeedbackResponse, List<ResponseInstructorComment>> relatedCommentsMap = new HashMap<>();
         Set<FeedbackQuestion> relatedQuestionsNotVisibleForPreviewSet = new HashSet<>();
         Set<FeedbackQuestion> relatedQuestionsWithCommentNotVisibleForPreview = new HashSet<>();
-        if (isCourseWide) {
-            // all questions are related questions when viewing course-wide result
-            for (FeedbackQuestion qn : allQuestions) {
-                relatedQuestions.add(qn);
-            }
+        // always include all questions so question cards still render,
+        // even when no responses are visible or responses are omitted in preview.
+        for (FeedbackQuestion qn : allQuestions) {
+            relatedQuestions.add(qn);
+        }
+
+        if (isPreviewResults) {
+            relatedQuestionsNotVisibleForPreviewSet.addAll(questionsNotVisibleToInstructors);
         }
 
         Set<String> studentsEmailInTeam = new HashSet<>();
@@ -587,7 +590,6 @@ public final class FeedbackResponsesLogic {
             // if previewing results and corresponding question should not be visible to instructors,
             // note down the question and do not add the response
             if (isPreviewResults && questionsNotVisibleToInstructors.contains(response.getFeedbackQuestion())) {
-                relatedQuestionsNotVisibleForPreviewSet.add(response.getFeedbackQuestion());
                 continue;
             }
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -525,17 +525,13 @@ public final class FeedbackResponsesLogic {
 
     private SessionResultsBundle buildResultsBundle(
             boolean isCourseWide, String sectionName, User user,
-            CourseRoster roster, List<FeedbackQuestion> allQuestions,
+            CourseRoster roster, List<FeedbackQuestion> relatedQuestions,
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
-        // related questions, responses, and comment
-        List<FeedbackQuestion> relatedQuestions = new ArrayList<>();
         List<FeedbackResponse> relatedResponses = new ArrayList<>();
         Map<FeedbackResponse, List<ResponseInstructorComment>> relatedCommentsMap = new HashMap<>();
         Set<FeedbackQuestion> relatedQuestionsNotVisibleForPreviewSet = new HashSet<>();
         Set<FeedbackQuestion> relatedQuestionsWithCommentNotVisibleForPreview = new HashSet<>();
-        for (FeedbackQuestion qn : allQuestions) {
-            relatedQuestions.add(qn);
-
+        for (FeedbackQuestion qn : relatedQuestions) {
             // set questions that should not be visible to instructors if results are being previewed
             if (isPreviewResults && !checkCanInstructorsSeeQuestion(qn)) {
                 relatedQuestionsNotVisibleForPreviewSet.add(qn);
@@ -576,8 +572,6 @@ public final class FeedbackResponsesLogic {
                 continue;
             }
 
-            // if there are viewable responses, the corresponding question becomes related
-            relatedQuestions.add(response.getFeedbackQuestion());
             relatedResponses.add(response);
 
             // generate giver/recipient name visibility table

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -539,8 +539,7 @@ public final class FeedbackResponsesLogic {
         for (FeedbackQuestion qn : allQuestions) {
             relatedQuestions.add(qn);
 
-            // Mark preview-hidden questions up-front so omitted responses message can still show
-            // even when there are currently no responses.
+            // set questions that should not be visible to instructors if results are being previewed
             if (isPreviewResults && !checkCanInstructorsSeeQuestion(qn)) {
                 questionsNotVisibleToInstructors.add(qn);
                 relatedQuestionsNotVisibleForPreviewSet.add(qn);

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -527,9 +527,6 @@ public final class FeedbackResponsesLogic {
             boolean isCourseWide, String sectionName, User user,
             CourseRoster roster, List<FeedbackQuestion> allQuestions,
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
-
-        Set<FeedbackQuestion> questionsNotVisibleToInstructors = new HashSet<>();
-
         // related questions, responses, and comment
         List<FeedbackQuestion> relatedQuestions = new ArrayList<>();
         List<FeedbackResponse> relatedResponses = new ArrayList<>();
@@ -541,7 +538,6 @@ public final class FeedbackResponsesLogic {
 
             // set questions that should not be visible to instructors if results are being previewed
             if (isPreviewResults && !checkCanInstructorsSeeQuestion(qn)) {
-                questionsNotVisibleToInstructors.add(qn);
                 relatedQuestionsNotVisibleForPreviewSet.add(qn);
             }
         }
@@ -577,12 +573,6 @@ public final class FeedbackResponsesLogic {
                     response.getGiver(), response.getRecipient(),
                     correspondingQuestion);
             if (!isVisibleResponse) {
-                continue;
-            }
-
-            // if previewing results and corresponding question should not be visible to instructors,
-            // note down the question and do not add the response
-            if (isPreviewResults && questionsNotVisibleToInstructors.contains(response.getFeedbackQuestion())) {
                 continue;
             }
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -529,13 +529,6 @@ public final class FeedbackResponsesLogic {
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
 
         Set<FeedbackQuestion> questionsNotVisibleToInstructors = new HashSet<>();
-        for (FeedbackQuestion qn : allQuestions) {
-
-            // set questions that should not be visible to instructors if results are being previewed
-            if (isPreviewResults && !checkCanInstructorsSeeQuestion(qn)) {
-                questionsNotVisibleToInstructors.add(qn);
-            }
-        }
 
         // related questions, responses, and comment
         List<FeedbackQuestion> relatedQuestions = new ArrayList<>();
@@ -543,14 +536,15 @@ public final class FeedbackResponsesLogic {
         Map<FeedbackResponse, List<ResponseInstructorComment>> relatedCommentsMap = new HashMap<>();
         Set<FeedbackQuestion> relatedQuestionsNotVisibleForPreviewSet = new HashSet<>();
         Set<FeedbackQuestion> relatedQuestionsWithCommentNotVisibleForPreview = new HashSet<>();
-        // always include all questions so question cards still render,
-        // even when no responses are visible or responses are omitted in preview.
         for (FeedbackQuestion qn : allQuestions) {
             relatedQuestions.add(qn);
-        }
 
-        if (isPreviewResults) {
-            relatedQuestionsNotVisibleForPreviewSet.addAll(questionsNotVisibleToInstructors);
+            // Mark preview-hidden questions up-front so omitted responses message can still show
+            // even when there are currently no responses.
+            if (isPreviewResults && !checkCanInstructorsSeeQuestion(qn)) {
+                questionsNotVisibleToInstructors.add(qn);
+                relatedQuestionsNotVisibleForPreviewSet.add(qn);
+            }
         }
 
         Set<String> studentsEmailInTeam = new HashSet<>();
@@ -719,8 +713,10 @@ public final class FeedbackResponsesLogic {
                 usersLogic.getInstructorsForCourse(courseId));
 
         // load question(s)
-        List<FeedbackQuestion> allQuestions = getQuestionsForSession(feedbackSession, questionId);
-        RequestTracer.checkRemainingTime();
+        List<FeedbackQuestion> allQuestions = getQuestionsForSession(feedbackSession, questionId)
+                .stream()
+                .filter(question -> isQuestionRelevantForUserResult(question, user))
+                .toList();
 
         // load response(s)
         List<FeedbackResponse> allResponses = new ArrayList<>();
@@ -736,9 +732,32 @@ public final class FeedbackResponsesLogic {
 
             allResponses.addAll(viewableResponses);
         }
-        RequestTracer.checkRemainingTime();
 
         return buildResultsBundle(false, null, user, roster, allQuestions, allResponses, isPreviewResults);
+    }
+
+    /**
+     * Returns whether the question is relevant to the user in user-scoped result view.
+     */
+    private boolean isQuestionRelevantForUserResult(FeedbackQuestion question, User user) {
+        if (user instanceof Instructor instructor) {
+            boolean isRelevantAsGiver = question.getGiverType() == QuestionGiverType.INSTRUCTORS
+                    || question.getGiverType() == QuestionGiverType.SELF
+                            && SanitizationHelper.areEmailsEqual(
+                                    question.getFeedbackSession().getCreatorEmail(), instructor.getEmail());
+            boolean isRelevantAsRecipient = isResponseOfFeedbackQuestionVisibleToInstructor(question)
+                    && question.getRecipientType() == QuestionRecipientType.INSTRUCTORS;
+            return isRelevantAsGiver || isRelevantAsRecipient;
+        }
+
+        if (user instanceof Student) {
+            boolean isRelevantAsGiver = question.getGiverType() == QuestionGiverType.STUDENTS
+                    || question.getGiverType() == QuestionGiverType.TEAMS;
+            boolean isRelevantAsRecipient = isResponseOfFeedbackQuestionVisibleToStudent(question);
+            return isRelevantAsGiver || isRelevantAsRecipient;
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 
 import jakarta.annotation.Nullable;
@@ -76,17 +75,24 @@ public class SessionResultsData extends ApiOutput {
 
         questionsWithResponses.forEach((question, responses) -> {
             FeedbackQuestionDetails questionDetails = question.getQuestionDetailsCopy();
+            boolean hasResponseButNotVisibleForPreview = bundle.getQuestionsNotVisibleForPreviewSet()
+                .contains(question);
             // check if question has comments (on any responses) not visible for preview
             boolean hasCommentNotVisibleForPreview = bundle.getQuestionsWithCommentNotVisibleForPreviewSet()
                     .contains(question);
+
+            String questionStatistics = hasResponseButNotVisibleForPreview
+                ? ""
+                : questionDetails.getQuestionResultStatisticsJson(question, user.getEmail(), bundle);
             QuestionOutput qnOutput = new QuestionOutput(question,
-                    questionDetails.getQuestionResultStatisticsJson(question, user.getEmail(), bundle),
-                    false, hasCommentNotVisibleForPreview);
+                questionStatistics,
+                hasResponseButNotVisibleForPreview,
+                hasCommentNotVisibleForPreview);
             Map<ResponseRecipient, List<ResponseOutput>> otherResponsesMap = new HashMap<>();
 
             qnOutput.getFeedbackQuestion().hideInformationForStudent();
 
-            if (questionDetails.isIndividualResponsesShownToStudents()) {
+            if (!hasResponseButNotVisibleForPreview && questionDetails.isIndividualResponsesShownToStudents()) {
                 for (FeedbackResponse response : responses) {
                     boolean isUserGiver = Objects.equals(user, response.getGiver().getGiverUser());
                     boolean isUserRecipient = Objects.equals(user, response.getRecipient().getRecipientUser());
@@ -113,13 +119,6 @@ public class SessionResultsData extends ApiOutput {
             }
             qnOutput.otherResponses.addAll(otherResponsesMap.values());
 
-            sessionResultsData.questions.add(qnOutput);
-        });
-
-        Set<FeedbackQuestion> questionsWithResponsesNotVisibleForPreview =
-                bundle.getQuestionsNotVisibleForPreviewSet();
-        questionsWithResponsesNotVisibleForPreview.forEach(question -> {
-            QuestionOutput qnOutput = new QuestionOutput(question, "", true, false);
             sessionResultsData.questions.add(qnOutput);
         });
 

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -76,18 +76,18 @@ public class SessionResultsData extends ApiOutput {
         questionsWithResponses.forEach((question, responses) -> {
             FeedbackQuestionDetails questionDetails = question.getQuestionDetailsCopy();
             boolean hasResponseButNotVisibleForPreview = bundle.getQuestionsNotVisibleForPreviewSet()
-                .contains(question);
+                    .contains(question);
             // check if question has comments (on any responses) not visible for preview
             boolean hasCommentNotVisibleForPreview = bundle.getQuestionsWithCommentNotVisibleForPreviewSet()
                     .contains(question);
 
             String questionStatistics = hasResponseButNotVisibleForPreview
-                ? ""
-                : questionDetails.getQuestionResultStatisticsJson(question, user.getEmail(), bundle);
+                    ? ""
+                    : questionDetails.getQuestionResultStatisticsJson(question, user.getEmail(), bundle);
             QuestionOutput qnOutput = new QuestionOutput(question,
-                questionStatistics,
-                hasResponseButNotVisibleForPreview,
-                hasCommentNotVisibleForPreview);
+                    questionStatistics,
+                    hasResponseButNotVisibleForPreview,
+                    hasCommentNotVisibleForPreview);
             Map<ResponseRecipient, List<ResponseOutput>> otherResponsesMap = new HashMap<>();
 
             qnOutput.getFeedbackQuestion().hideInformationForStudent();

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -3,442 +3,410 @@
 exports[`QuestionResponsePanelComponent > should snap with feedback session with questions 1`] = `
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
-  feedbackSessionsService={[Function _FeedbackSessionsService]}
   intent={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
   regKey=""
   session={[Function Object]}
-  statusMessageService={[Function _StatusMessageService]}
 >
   <div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-1-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 1:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            How well did team member perform?
+          </span>
+          <button
+            class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
+          >
+             [more] 
+          </button>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-1-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="other-response"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <strong>
+            Other responses (to you): 
+          </strong>
+          Responses are not visible to you. 
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 1:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                How well did team member perform?
-              </span>
-              <button
-                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-              >
-                 [more] 
-              </button>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="other-response"
-            >
-              <strong>
-                Other responses (to you): 
-              </strong>
-              Responses are not visible to you. 
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient1
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                    <b>
+                      To:
+                    </b>
+                     recipient1
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div><div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-2-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 2:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            Rate your teammates in contribution
+          </span>
+          <button
+            class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
+          >
+             [more] 
+          </button>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-2-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="other-response"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <strong>
+            Other responses (to you): 
+          </strong>
+          Responses are not visible to you. 
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 2:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                Rate your teammates in contribution
-              </span>
-              <button
-                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-              >
-                 [more] 
-              </button>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="other-response"
-            >
-              <strong>
-                Other responses (to you): 
-              </strong>
-              Responses are not visible to you. 
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient2
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
-              </div>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                    <b>
+                      To:
+                    </b>
+                     recipient2
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient3
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
+          </div>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
+              >
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
+                  >
+                    <b>
+                      To:
+                    </b>
+                     recipient3
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div><div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-3-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 3:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            Rate your teammates proficiency
+          </span>
+          <button
+            class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
+          >
+             [more] 
+          </button>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-3-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="other-response"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <strong>
+            Other responses (to you): 
+          </strong>
+          Responses are not visible to you. 
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 3:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                Rate your teammates proficiency
-              </span>
-              <button
-                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-              >
-                 [more] 
-              </button>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="other-response"
-            >
-              <strong>
-                Other responses (to you): 
-              </strong>
-              Responses are not visible to you. 
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient3
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
+                    <b>
+                      To:
+                    </b>
+                     recipient3
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-comment-table>
+                            <div
+                              class="card"
                             >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-comment-table>
-                                <div
-                                  class="card"
+                              <ul
+                                class="list-group list-group-flush"
+                              >
+                                <li
+                                  class="list-group-item"
                                 >
-                                  <ul
-                                    class="list-group list-group-flush"
-                                  >
-                                    <li
-                                      class="list-group-item"
+                                  <tm-comment-row>
+                                    <div
+                                      class="card"
                                     >
-                                      <tm-comment-row>
+                                      <div
+                                        class="card-body"
+                                      >
                                         <div
-                                          class="card"
+                                          class="row comment-row"
                                         >
                                           <div
-                                            class="card-body"
+                                            class="col-12"
                                           >
-                                            <div
-                                              class="row comment-row"
+                                            <span
+                                              class="comment-giver-name"
                                             >
-                                              <div
-                                                class="col-12"
-                                              >
-                                                <span
-                                                  class="comment-giver-name"
-                                                >
-                                                  comment-giver-name-1 commented at 
-                                                </span>
-                                                <span
-                                                  class="ngb-tooltip-class"
-                                                  style="margin-right: 0.25rem;"
-                                                >
-                                                   17 Jan 1:09 PM
-                                                </span>
-                                                <i
-                                                  aria-hidden="true"
-                                                  class="fa fa-eye"
-                                                />
-                                                <div
-                                                  class="float-end"
-                                                >
-                                                </div>
-                                              </div>
-                                              <div
-                                                class="comment-text col-12"
-                                              >
-                                                this is a text
-                                              </div>
+                                              comment-giver-name-1 commented at 
+                                            </span>
+                                            <span
+                                              class="ngb-tooltip-class"
+                                              style="margin-right: 0.25rem;"
+                                            >
+                                               17 Jan 1:09 PM
+                                            </span>
+                                            <i
+                                              aria-hidden="true"
+                                              class="fa fa-eye"
+                                            />
+                                            <div
+                                              class="float-end"
+                                            >
                                             </div>
                                           </div>
+                                          <div
+                                            class="comment-text col-12"
+                                          >
+                                            this is a text
+                                          </div>
                                         </div>
-                                      </tm-comment-row>
-                                    </li>
-                                  </ul>
-                                </div>
-                              </tm-comment-table>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                                      </div>
+                                    </div>
+                                  </tm-comment-row>
+                                </li>
+                              </ul>
+                            </div>
+                          </tm-comment-table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div>
 </tm-question-response-panel>
 `;
@@ -446,312 +414,290 @@ exports[`QuestionResponsePanelComponent > should snap with feedback session with
 exports[`QuestionResponsePanelComponent > should snap with feedback session with questions of anonymous responses 1`] = `
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
-  feedbackSessionsService={[Function _FeedbackSessionsService]}
   intent={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
   regKey=""
   session={[Function Object]}
-  statusMessageService={[Function _StatusMessageService]}
 >
   <div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-1-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 1:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            What comments do you have regarding each of your team members? (response is confidential and will only be shown to the instructor).
+          </span>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-1-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="other-response"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <strong>
+            Other responses (to you): 
+          </strong>
+          Responses are not visible to you. 
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 1:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
+                  >
+                    <b>
+                      To:
+                    </b>
+                     recipient1
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </tm-student-view-responses>
+          </div>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                What comments do you have regarding each of your team members? (response is confidential and will only be shown to the instructor).
-              </span>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="other-response"
-            >
-              <strong>
-                Other responses (to you): 
-              </strong>
-              Responses are not visible to you. 
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient1
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
-              </div>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                    <b>
+                      To:
+                    </b>
+                     recipient2
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient2
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+            </tm-student-view-responses>
+          </div>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
+              >
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient3
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                    <b>
+                      To:
+                    </b>
+                     recipient3
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div><div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-2-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 2:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            How are the team dynamics thus far? (response is confidential and will only be shown to the instructor).
+          </span>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-2-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="other-response"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <strong>
+            Other responses (to you): 
+          </strong>
+          Responses are not visible to you. 
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 2:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                How are the team dynamics thus far? (response is confidential and will only be shown to the instructor).
-              </span>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="other-response"
-            >
-              <strong>
-                Other responses (to you): 
-              </strong>
-              Responses are not visible to you. 
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         team1
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                    <b>
+                      To:
+                    </b>
+                     team1
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div>
 </tm-question-response-panel>
 `;
@@ -759,347 +705,315 @@ exports[`QuestionResponsePanelComponent > should snap with feedback session with
 exports[`QuestionResponsePanelComponent > should snap with questions and responses when previewing results 1`] = `
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
-  feedbackSessionsService={[Function _FeedbackSessionsService]}
   intent={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
   regKey=""
   session={[Function Object]}
-  statusMessageService={[Function _StatusMessageService]}
 >
   <div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-1-responses"
   >
-    <div />
-    <tm-loading-retry>
-      <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-1-responses"
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
       >
-        <div
-          class="card-body"
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
+          <h2
+            class="question-number"
           >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
-              >
-                Question 1:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                How well did team member perform?
-              </span>
-              <button
-                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-              >
-                 [more] 
-              </button>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="alert alert-warning other-response non-visible-response-alert"
-            role="alert"
+            Question 1:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
           >
-            <i
-              class="fas fa-eye-slash"
-            />
-             Responses received for this question are omitted from this preview because some or all parts of them are not visible to instructors, as per their visibility settings. 
-          </div>
-        </div>
+            How well did team member perform?
+          </span>
+          <button
+            class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
+          >
+             [more] 
+          </button>
+        </span>
+      </tm-question-text-with-info>
+      <div
+        class="alert alert-warning other-response non-visible-response-alert"
+        role="alert"
+      >
+        <i
+          class="fas fa-eye-slash"
+        />
+         Responses received for this question are omitted from this preview because some or all parts of them are not visible to instructors, as per their visibility settings. 
       </div>
-    </tm-loading-retry>
+    </div>
   </div><div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-3-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 3:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            Rate your teammates proficiency
+          </span>
+          <button
+            class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
+          >
+             [more] 
+          </button>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-3-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="alert alert-warning my-3 non-visible-comment-alert"
+          role="alert"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <i
+            class="fas fa-eye-slash"
+          />
+           Some comments (on responses) received for this question are omitted from this preview because they are not visible to instructors, as per their visibility settings. 
+        </div>
+        <div
+          class="other-response"
+        >
+          <strong>
+            Other responses (to you): 
+          </strong>
+          Responses are not visible to you. 
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 3:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                Rate your teammates proficiency
-              </span>
-              <button
-                class="additional-info-button info-font-size me-auto border-0 p-0 bg-transparent text-primary"
-              >
-                 [more] 
-              </button>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="alert alert-warning my-3 non-visible-comment-alert"
-              role="alert"
-            >
-              <i
-                class="fas fa-eye-slash"
-              />
-               Some comments (on responses) received for this question are omitted from this preview because they are not visible to instructors, as per their visibility settings. 
-            </div>
-            <div
-              class="other-response"
-            >
-              <strong>
-                Other responses (to you): 
-              </strong>
-              Responses are not visible to you. 
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         recipient3
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
+                    <b>
+                      To:
+                    </b>
+                     recipient3
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-comment-table>
+                            <div
+                              class="card"
                             >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-comment-table>
-                                <div
-                                  class="card"
+                              <ul
+                                class="list-group list-group-flush"
+                              >
+                                <li
+                                  class="list-group-item"
                                 >
-                                  <ul
-                                    class="list-group list-group-flush"
-                                  >
-                                    <li
-                                      class="list-group-item"
+                                  <tm-comment-row>
+                                    <div
+                                      class="card"
                                     >
-                                      <tm-comment-row>
+                                      <div
+                                        class="card-body"
+                                      >
                                         <div
-                                          class="card"
+                                          class="row comment-row"
                                         >
                                           <div
-                                            class="card-body"
+                                            class="col-12"
                                           >
-                                            <div
-                                              class="row comment-row"
+                                            <span
+                                              class="comment-giver-name"
                                             >
-                                              <div
-                                                class="col-12"
-                                              >
-                                                <span
-                                                  class="comment-giver-name"
-                                                >
-                                                  comment-giver-name-1 commented at 
-                                                </span>
-                                                <span
-                                                  class="ngb-tooltip-class"
-                                                  style="margin-right: 0.25rem;"
-                                                >
-                                                   17 Jan 1:09 PM
-                                                </span>
-                                                <i
-                                                  aria-hidden="true"
-                                                  class="fa fa-eye"
-                                                />
-                                                <div
-                                                  class="float-end"
-                                                >
-                                                </div>
-                                              </div>
-                                              <div
-                                                class="comment-text col-12"
-                                              >
-                                                this is a text
-                                              </div>
+                                              comment-giver-name-1 commented at 
+                                            </span>
+                                            <span
+                                              class="ngb-tooltip-class"
+                                              style="margin-right: 0.25rem;"
+                                            >
+                                               17 Jan 1:09 PM
+                                            </span>
+                                            <i
+                                              aria-hidden="true"
+                                              class="fa fa-eye"
+                                            />
+                                            <div
+                                              class="float-end"
+                                            >
                                             </div>
                                           </div>
+                                          <div
+                                            class="comment-text col-12"
+                                          >
+                                            this is a text
+                                          </div>
                                         </div>
-                                      </tm-comment-row>
-                                    </li>
-                                  </ul>
-                                </div>
-                              </tm-comment-table>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                                      </div>
+                                    </div>
+                                  </tm-comment-row>
+                                </li>
+                              </ul>
+                            </div>
+                          </tm-comment-table>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div><div
-    inviewport=""
+    class="card bg-light mt-4"
+    id="question-4-responses"
   >
-    <div />
-    <tm-loading-retry>
+    <div
+      class="card-body"
+    >
+      <tm-question-text-with-info
+        class="question-text-with-info"
+      >
+        <span
+          class="d-flex flex-column flex-sm-row align-items-sm-center"
+        >
+          <h2
+            class="question-number"
+          >
+            Question 4:
+          </h2>
+          <span
+            class="question-text mx-sm-2"
+          >
+            Do you have any feedback for the course?
+          </span>
+        </span>
+      </tm-question-text-with-info>
       <div
-        aria-hidden="true"
-      />
-      <div
-        class="card bg-light mt-4"
-        id="question-4-responses"
+        class="all-responses"
       >
         <div
-          class="card-body"
+          class="other-responses"
         >
-          <tm-question-text-with-info
-            class="question-text-with-info"
-          >
-            <span
-              class="d-flex flex-column flex-sm-row align-items-sm-center"
-            >
-              <h2
-                class="question-number"
+          <tm-single-statistics>
+          </tm-single-statistics>
+          <div>
+          </div>
+        </div>
+        <div
+          class="given-responses mt-4"
+        >
+          <strong>
+            Your own responses (to others):
+          </strong>
+          <div>
+            <tm-student-view-responses>
+              <div
+                class="border-info card mt-4"
               >
-                Question 4:
-              </h2>
-              <span
-                class="question-text mx-sm-2"
-              >
-                Do you have any feedback for the course?
-              </span>
-            </span>
-          </tm-question-text-with-info>
-          <div
-            class="all-responses"
-          >
-            <div
-              class="other-responses"
-            >
-              <tm-single-statistics>
-              </tm-single-statistics>
-              <div>
-              </div>
-            </div>
-            <div
-              class="given-responses mt-4"
-            >
-              <strong>
-                Your own responses (to others):
-              </strong>
-              <div>
-                <tm-student-view-responses>
-                  <div
-                    class="border-info card mt-4"
+                <div
+                  class="card-header bg-info"
+                >
+                  <span
+                    class="response-recipient"
                   >
-                    <div
-                      class="card-header bg-info"
-                    >
-                      <span
-                        class="response-recipient"
-                      >
-                        <b>
-                          To:
-                        </b>
-                         -
-                      </span>
-                    </div>
-                    <div
-                      class="card-body table-responsive"
-                      style="padding: 0;"
-                    >
-                      <table
-                        class="table"
-                      >
-                        <tbody>
-                          <tr>
-                            <td
-                              class="response-giver"
-                            >
-                              <strong>
-                                From:
-                              </strong>
-                               giver1
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <tm-single-response>
-                                <tm-text-question-response>
-                                  <div>
-                                    Yes
-                                  </div>
-                                </tm-text-question-response>
-                              </tm-single-response>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                  </div>
-                </tm-student-view-responses>
+                    <b>
+                      To:
+                    </b>
+                     -
+                  </span>
+                </div>
+                <div
+                  class="card-body table-responsive"
+                  style="padding: 0;"
+                >
+                  <table
+                    class="table"
+                  >
+                    <tbody>
+                      <tr>
+                        <td
+                          class="response-giver"
+                        >
+                          <strong>
+                            From:
+                          </strong>
+                           giver1
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <tm-single-response>
+                            <tm-text-question-response>
+                              <div>
+                                Yes
+                              </div>
+                            </tm-text-question-response>
+                          </tm-single-response>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
+            </tm-student-view-responses>
           </div>
         </div>
       </div>
-    </tm-loading-retry>
+    </div>
   </div>
 </tm-question-response-panel>
 `;

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -1,101 +1,90 @@
 @for (question of questions; track question) {
-  <div inViewport (inViewportAction)="loadQuestion($event, question)">
-    <div *tmIsLoading="question.isLoading && !question.errorMessage"></div>
-    <tm-loading-retry
-      [shouldShowRetry]="!!question.errorMessage"
-      [message]="question.errorMessage"
-      (retryEvent)="loadQuestionResults(question)"
-    >
-      @if (question.hasResponse) {
-        <div id="question-{{ question.feedbackQuestion.questionNumber }}-responses" class="card bg-light mt-4">
-          <div class="card-body">
-            <tm-question-text-with-info
-              [questionNumber]="question.feedbackQuestion.questionNumber"
-              [questionDetails]="question.feedbackQuestion.questionDetails"
-              class="question-text-with-info"
-            ></tm-question-text-with-info>
-            @if (!question.hasResponseButNotVisibleForPreview) {
-              <div class="all-responses">
-                @if (question.hasCommentNotVisibleForPreview) {
-                  <div class="alert alert-warning my-3 non-visible-comment-alert" role="alert">
-                    <i class="fas fa-eye-slash"></i> Some comments (on responses) received for this question are omitted
-                    from this preview because they are not visible to instructors, as per their visibility settings.
-                  </div>
+  <div id="question-{{ question.feedbackQuestion.questionNumber }}-responses" class="card bg-light mt-4">
+    <div class="card-body">
+      <tm-question-text-with-info
+        [questionNumber]="question.feedbackQuestion.questionNumber"
+        [questionDetails]="question.feedbackQuestion.questionDetails"
+        class="question-text-with-info"
+      ></tm-question-text-with-info>
+      @if (!question.hasResponseButNotVisibleForPreview) {
+        <div class="all-responses">
+          @if (question.hasCommentNotVisibleForPreview) {
+            <div class="alert alert-warning my-3 non-visible-comment-alert" role="alert">
+              <i class="fas fa-eye-slash"></i> Some comments (on responses) received for this question are omitted
+              from this preview because they are not visible to instructors, as per their visibility settings.
+            </div>
+          }
+          @if (canUserSeeResponses(question)) {
+            <div class="other-responses">
+              <tm-single-statistics
+                [question]="question.feedbackQuestion.questionDetails"
+                [responses]="question.allResponses"
+                [statistics]="question.questionStatistics"
+                [isStudent]="true"
+              ></tm-single-statistics>
+              @if (RESPONSE_HIDDEN_QUESTIONS.includes(question.feedbackQuestion.questionType)) {
+                <div>
+                  <p style="color: gray; font-size: small">
+                    <i class="fas fa-info-circle" style="color: #087cfc"></i> Individual Responses are not configured
+                    to be shown for this question type.
+                  </p>
+                </div>
+              } @else {
+                @if (question.responsesToSelf.length) {
+                  <tm-student-view-responses
+                    [responses]="question.responsesToSelf"
+                    [feedbackQuestion]="question.feedbackQuestion"
+                    [timezone]="session.timeZone"
+                    [statistics]="question.questionStatistics"
+                  ></tm-student-view-responses>
                 }
-                @if (canUserSeeResponses(question)) {
-                  <div class="other-responses">
-                    <tm-single-statistics
-                      [question]="question.feedbackQuestion.questionDetails"
-                      [responses]="question.allResponses"
-                      [statistics]="question.questionStatistics"
-                      [isStudent]="true"
-                    ></tm-single-statistics>
-                    @if (RESPONSE_HIDDEN_QUESTIONS.includes(question.feedbackQuestion.questionType)) {
-                      <div>
-                        <p style="color: gray; font-size: small">
-                          <i class="fas fa-info-circle" style="color: #087cfc"></i> Individual Responses are not
-                          configured to be shown for this question type.
-                        </p>
-                      </div>
-                    } @else {
-                      @if (question.responsesToSelf.length) {
-                        <tm-student-view-responses
-                          [responses]="question.responsesToSelf"
-                          [feedbackQuestion]="question.feedbackQuestion"
-                          [timezone]="session.timeZone"
-                          [statistics]="question.questionStatistics"
-                        ></tm-student-view-responses>
-                      }
-                      @for (responsesForOtherRecipient of question.otherResponses; track responsesForOtherRecipient) {
-                        <div>
-                          @if (responsesForOtherRecipient.length) {
-                            <tm-student-view-responses
-                              [responses]="responsesForOtherRecipient"
-                              [feedbackQuestion]="question.feedbackQuestion"
-                              [timezone]="session.timeZone"
-                              [statistics]="question.questionStatistics"
-                            ></tm-student-view-responses>
-                          }
-                        </div>
-                      }
-                      @if (!question.otherResponses.length && !question.responsesToSelf.length) {
-                        <div class="other-response">
-                          <strong>Other responses (to you): </strong>No responses received yet.
-                        </div>
-                      }
+                @for (responsesForOtherRecipient of question.otherResponses; track responsesForOtherRecipient) {
+                  <div>
+                    @if (responsesForOtherRecipient.length) {
+                      <tm-student-view-responses
+                        [responses]="responsesForOtherRecipient"
+                        [feedbackQuestion]="question.feedbackQuestion"
+                        [timezone]="session.timeZone"
+                        [statistics]="question.questionStatistics"
+                      ></tm-student-view-responses>
                     }
                   </div>
-                } @else {
+                }
+                @if (!question.otherResponses.length && !question.responsesToSelf.length) {
                   <div class="other-response">
-                    <strong>Other responses (to you): </strong>Responses are not visible to you.
+                    <strong>Other responses (to you): </strong>No responses received yet.
                   </div>
                 }
-                @if (question.responsesFromSelf.length) {
-                  <div class="given-responses mt-4">
-                    <strong>Your own responses (to others):</strong>
-                    @for (responseFromSelf of question.responsesFromSelf; track responseFromSelf) {
-                      <div>
-                        <tm-student-view-responses
-                          [responses]="[responseFromSelf]"
-                          [isSelfResponses]="true"
-                          [feedbackQuestion]="question.feedbackQuestion"
-                          [timezone]="session.timeZone"
-                          [statistics]="question.questionStatistics"
-                        ></tm-student-view-responses>
-                      </div>
-                    }
-                  </div>
-                }
-              </div>
-            } @else {
-              <div class="alert alert-warning other-response non-visible-response-alert" role="alert">
-                <i class="fas fa-eye-slash"></i> Responses received for this question are omitted from this preview
-                because some or all parts of them are not visible to instructors, as per their visibility settings.
-              </div>
-            }
-          </div>
+              }
+            </div>
+          } @else {
+            <div class="other-response">
+              <strong>Other responses (to you): </strong>Responses are not visible to you.
+            </div>
+          }
+          @if (question.responsesFromSelf.length) {
+            <div class="given-responses mt-4">
+              <strong>Your own responses (to others):</strong>
+              @for (responseFromSelf of question.responsesFromSelf; track responseFromSelf) {
+                <div>
+                  <tm-student-view-responses
+                    [responses]="[responseFromSelf]"
+                    [isSelfResponses]="true"
+                    [feedbackQuestion]="question.feedbackQuestion"
+                    [timezone]="session.timeZone"
+                    [statistics]="question.questionStatistics"
+                  ></tm-student-view-responses>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="alert alert-warning other-response non-visible-response-alert" role="alert">
+          <i class="fas fa-eye-slash"></i> Responses received for this question are omitted from this preview because
+          some or all parts of them are not visible to instructors, as per their visibility settings.
         </div>
       }
-    </tm-loading-retry>
+    </div>
   </div>
 }

--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -10,8 +10,8 @@
         <div class="all-responses">
           @if (question.hasCommentNotVisibleForPreview) {
             <div class="alert alert-warning my-3 non-visible-comment-alert" role="alert">
-              <i class="fas fa-eye-slash"></i> Some comments (on responses) received for this question are omitted
-              from this preview because they are not visible to instructors, as per their visibility settings.
+              <i class="fas fa-eye-slash"></i> Some comments (on responses) received for this question are omitted from
+              this preview because they are not visible to instructors, as per their visibility settings.
             </div>
           }
           @if (canUserSeeResponses(question)) {
@@ -25,8 +25,8 @@
               @if (RESPONSE_HIDDEN_QUESTIONS.includes(question.feedbackQuestion.questionType)) {
                 <div>
                   <p style="color: gray; font-size: small">
-                    <i class="fas fa-info-circle" style="color: #087cfc"></i> Individual Responses are not configured
-                    to be shown for this question type.
+                    <i class="fas fa-info-circle" style="color: #087cfc"></i> Individual Responses are not configured to
+                    be shown for this question type.
                   </p>
                 </div>
               } @else {

--- a/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
@@ -2,10 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
 import { QuestionResponsePanelComponent } from './question-response-panel.component';
-import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
-import { StatusMessageService } from '../../../services/status-message.service';
 import {
   FeedbackContributionQuestionDetails,
   FeedbackContributionResponseDetails,
@@ -25,11 +22,9 @@ import {
   QuestionGiverType,
   QuestionRecipientType,
   ResponseVisibleSetting,
-  SessionResults,
   SessionVisibleSetting,
 } from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
-import { ErrorMessageOutput } from '../../error-message-output';
 import { FeedbackQuestionModel } from '../../pages-session/session-result-page/feedback-question.model';
 
 describe('QuestionResponsePanelComponent', () => {
@@ -196,15 +191,12 @@ describe('QuestionResponsePanelComponent', () => {
     otherResponses: [],
     isLoading: false,
     isLoaded: false,
-    hasResponse: true,
     hasResponseButNotVisibleForPreview: false,
     hasCommentNotVisibleForPreview: false,
   };
 
   let component: QuestionResponsePanelComponent;
   let fixture: ComponentFixture<QuestionResponsePanelComponent>;
-  let feedbackSessionsService: FeedbackSessionsService;
-  let statusMessageService: StatusMessageService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -212,8 +204,6 @@ describe('QuestionResponsePanelComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(QuestionResponsePanelComponent);
-    feedbackSessionsService = TestBed.inject(FeedbackSessionsService);
-    statusMessageService = TestBed.inject(StatusMessageService);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -251,7 +241,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [[]],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: false,
       },
@@ -308,7 +297,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [[]],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: false,
       },
@@ -347,7 +335,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [[]],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: false,
       },
@@ -455,7 +442,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: false,
       },
@@ -498,7 +484,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: false,
       },
@@ -520,7 +505,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [[]],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: true,
         hasCommentNotVisibleForPreview: false,
       },
@@ -559,7 +543,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [[]],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: true,
       },
@@ -588,7 +571,6 @@ describe('QuestionResponsePanelComponent', () => {
         otherResponses: [[]],
         isLoading: false,
         isLoaded: true,
-        hasResponse: true,
         hasResponseButNotVisibleForPreview: false,
         hasCommentNotVisibleForPreview: false,
       },
@@ -596,54 +578,6 @@ describe('QuestionResponsePanelComponent', () => {
 
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
-  });
-
-  it('should load the recipients and responses of a question if not yet loaded', () => {
-    component.session = testFeedbackSession;
-    component.questions = [testFeedbackQuestionModel];
-    const testFeedbackSessionResult: SessionResults = {
-      questions: [
-        {
-          feedbackQuestion: testQuestion1,
-          questionStatistics: '',
-          allResponses: [],
-          hasResponseButNotVisibleForPreview: false,
-          hasCommentNotVisibleForPreview: false,
-          responsesToSelf: [],
-          responsesFromSelf: [],
-          otherResponses: [],
-        },
-      ],
-    };
-
-    const fsSpy = vi
-      .spyOn(feedbackSessionsService, 'getUserSessionResults')
-      .mockReturnValue(of(testFeedbackSessionResult));
-    component.loadQuestion({ visible: true }, testFeedbackQuestionModel);
-
-    expect(fsSpy).toHaveBeenCalledTimes(1);
-    expect(fsSpy).toHaveBeenLastCalledWith({
-      intent: 'STUDENT_RESULT',
-      feedbackSessionId: testFeedbackSession.feedbackSessionId,
-      questionId: testQuestion1.feedbackQuestionId,
-      key: '',
-      previewAs: '',
-    });
-    expect(testFeedbackQuestionModel.isLoading).toBe(false);
-    expect(testFeedbackQuestionModel.isLoaded).toBe(true);
-    expect(testFeedbackQuestionModel.hasResponse).toBe(true);
-  });
-
-  it('should not load the recipients and responses of a question if already loaded', () => {
-    const fsSpy = vi.spyOn(feedbackSessionsService, 'getUserSessionResults');
-
-    testFeedbackQuestionModel.isLoaded = true;
-    component.loadQuestion({ visible: true }, testFeedbackQuestionModel);
-
-    testFeedbackQuestionModel.isLoading = true;
-    component.loadQuestion({ visible: true }, testFeedbackQuestionModel);
-
-    expect(fsSpy).not.toHaveBeenCalled();
   });
 
   it('canUserSeeResponses: should allow instructors to see responses when intent is INSTRUCTOR_RESULT', () => {
@@ -661,68 +595,24 @@ describe('QuestionResponsePanelComponent', () => {
     expect(canSee).toBe(false);
   });
 
-  it('loadQuestionResults: should not re-fetch data if question is already loaded', () => {
-    const fsSpy = vi.spyOn(feedbackSessionsService, 'getUserSessionResults');
+  it('canUserSeeResponses: should allow students when responses are visible to recipients and instructors', () => {
+    component.intent = Intent.STUDENT_RESULT;
+    testFeedbackQuestionModel.feedbackQuestion.showResponsesTo = [
+      FeedbackVisibilityType.RECIPIENT,
+      FeedbackVisibilityType.INSTRUCTORS,
+    ];
 
-    const testQuestionModel: FeedbackQuestionModel = {
-      ...testFeedbackQuestionModel,
-      isLoaded: true,
-    };
-    component.loadQuestionResults(testQuestionModel);
+    const canSee = component.canUserSeeResponses(testFeedbackQuestionModel);
 
-    expect(fsSpy).not.toHaveBeenCalled();
+    expect(canSee).toBe(true);
   });
 
-  it('loadQuestionResults: should handle no responses correctly and not show toast if errorMessage not set', () => {
-    const fsSpy = vi.spyOn(feedbackSessionsService, 'getUserSessionResults');
-    const toastSpy = vi.spyOn(statusMessageService, 'showSuccessToast');
+  it('should render a preloaded question response card', () => {
+    component.session = testFeedbackSession;
+    component.questions = [{ ...testFeedbackQuestionModel, isLoaded: true }];
 
-    testFeedbackQuestionModel.isLoaded = false;
+    fixture.detectChanges();
 
-    fsSpy.mockReturnValue(
-      of({
-        questions: [],
-      } as SessionResults),
-    );
-
-    component.loadQuestionResults(testFeedbackQuestionModel);
-
-    expect(testFeedbackQuestionModel.hasResponse).toBe(false);
-    expect(toastSpy).not.toHaveBeenCalled();
-  });
-
-  it('loadQuestionResults: should handle no responses correctly and show success toast if errorMessage is set', () => {
-    const fsSpy = vi.spyOn(feedbackSessionsService, 'getUserSessionResults');
-    const toastSpy = vi.spyOn(statusMessageService, 'showSuccessToast');
-
-    testFeedbackQuestionModel.isLoaded = false;
-    testFeedbackQuestionModel.errorMessage = 'Error occurred';
-
-    fsSpy.mockReturnValue(
-      of({
-        questions: [],
-      } as SessionResults),
-    );
-
-    component.loadQuestionResults(testFeedbackQuestionModel);
-
-    expect(testFeedbackQuestionModel.hasResponse).toBe(false);
-    expect(toastSpy).toHaveBeenCalledWith(
-      `Question ${testFeedbackQuestionModel.feedbackQuestion.questionNumber} has no responses.`,
-    );
-  });
-
-  it('loadQuestionResults: should handle errors correctly by setting errorMessage and showing a toast', () => {
-    const errorMessage = 'An error occurred';
-    testFeedbackQuestionModel.isLoaded = false;
-    vi.spyOn(feedbackSessionsService, 'getUserSessionResults').mockReturnValue(
-      throwError(() => ({ error: { message: errorMessage }, status: 400 }) as ErrorMessageOutput),
-    );
-    const showErrorToastSpy = vi.spyOn(statusMessageService, 'showErrorToast');
-
-    component.loadQuestionResults(testFeedbackQuestionModel);
-
-    expect(testFeedbackQuestionModel.errorMessage).toBe(errorMessage);
-    expect(showErrorToastSpy).toHaveBeenCalledWith(errorMessage);
+    expect(fixture.nativeElement.querySelector('#question-1-responses')).toBeTruthy();
   });
 });

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -1,22 +1,14 @@
-import { Component, Input, inject } from '@angular/core';
-import { DestroyableDirective, InViewportDirective } from 'ng-in-viewport';
-import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
-import { StatusMessageService } from '../../../services/status-message.service';
+import { Component, Input } from '@angular/core';
 import {
   FeedbackQuestionType,
   FeedbackSession,
   FeedbackSessionPublishStatus,
   FeedbackSessionSubmissionStatus,
-  QuestionOutput,
   ResponseVisibleSetting,
-  SessionResults,
   SessionVisibleSetting,
 } from '../../../types/api-output';
 import { FeedbackVisibilityType, Intent } from '../../../types/api-request';
-import { ErrorMessageOutput } from '../../error-message-output';
 import { FeedbackQuestionModel } from '../../pages-session/session-result-page/feedback-question.model';
-import { LoadingRetryComponent } from '../loading-retry/loading-retry.component';
-import { LoadingSpinnerDirective } from '../loading-spinner/loading-spinner.directive';
 import { SingleStatisticsComponent } from '../question-responses/single-statistics/single-statistics.component';
 import { StudentViewResponsesComponent } from '../question-responses/student-view-responses/student-view-responses.component';
 import { QuestionTextWithInfoComponent } from '../question-text-with-info/question-text-with-info.component';
@@ -28,20 +20,9 @@ import { QuestionTextWithInfoComponent } from '../question-text-with-info/questi
   selector: 'tm-question-response-panel',
   templateUrl: './question-response-panel.component.html',
   styleUrls: ['./question-response-panel.component.scss'],
-  imports: [
-    DestroyableDirective,
-    InViewportDirective,
-    LoadingSpinnerDirective,
-    LoadingRetryComponent,
-    QuestionTextWithInfoComponent,
-    SingleStatisticsComponent,
-    StudentViewResponsesComponent,
-  ],
+  imports: [QuestionTextWithInfoComponent, SingleStatisticsComponent, StudentViewResponsesComponent],
 })
 export class QuestionResponsePanelComponent {
-  private feedbackSessionsService = inject(FeedbackSessionsService);
-  private statusMessageService = inject(StatusMessageService);
-
   readonly RESPONSE_HIDDEN_QUESTIONS: FeedbackQuestionType[] = [FeedbackQuestionType.CONTRIB];
 
   @Input()
@@ -79,75 +60,15 @@ export class QuestionResponsePanelComponent {
     const showResponsesTo: FeedbackVisibilityType[] = question.feedbackQuestion.showResponsesTo;
     if (this.intent === Intent.STUDENT_RESULT) {
       return (
-        showResponsesTo.filter(
-          (visibilityType: FeedbackVisibilityType) => visibilityType !== FeedbackVisibilityType.INSTRUCTORS,
-        ).length > 0
+        showResponsesTo.includes(FeedbackVisibilityType.RECIPIENT) ||
+        showResponsesTo.includes(FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS) ||
+        showResponsesTo.includes(FeedbackVisibilityType.GIVER_TEAM_MEMBERS) ||
+        showResponsesTo.includes(FeedbackVisibilityType.STUDENTS)
       );
     }
     if (this.intent === Intent.INSTRUCTOR_RESULT) {
-      return (
-        showResponsesTo.filter(
-          (visibilityType: FeedbackVisibilityType) => visibilityType === FeedbackVisibilityType.INSTRUCTORS,
-        ).length > 0
-      );
+      return showResponsesTo.includes(FeedbackVisibilityType.INSTRUCTORS);
     }
     return false;
-  }
-
-  /**
-   * Loads responses for feedback question.
-   */
-  loadQuestionResults(question: FeedbackQuestionModel): void {
-    if (question.isLoaded) {
-      // Do not re-fetch data
-      return;
-    }
-    this.feedbackSessionsService
-      .getUserSessionResults({
-        questionId: question.feedbackQuestion.feedbackQuestionId,
-        feedbackSessionId: this.session.feedbackSessionId,
-        intent: this.intent,
-        key: this.regKey,
-        previewAs: this.previewAsPerson,
-      })
-      .subscribe({
-        next: (sessionResults: SessionResults) => {
-          const responses: QuestionOutput = sessionResults.questions[0];
-          if (responses) {
-            question.hasResponse = true;
-            question.feedbackQuestion = responses.feedbackQuestion;
-            question.allResponses = responses.allResponses;
-            question.otherResponses = responses.otherResponses;
-            question.questionStatistics = responses.questionStatistics;
-            question.responsesFromSelf = responses.responsesFromSelf;
-            question.responsesToSelf = responses.responsesToSelf;
-            question.hasResponseButNotVisibleForPreview = responses.hasResponseButNotVisibleForPreview;
-            question.hasCommentNotVisibleForPreview = responses.hasCommentNotVisibleForPreview;
-          } else {
-            question.hasResponse = false;
-            if (question.errorMessage) {
-              this.statusMessageService.showSuccessToast(
-                'Question '.concat(question.feedbackQuestion.questionNumber.toString()).concat(' has no responses.'),
-              );
-            }
-          }
-        },
-        complete: () => {
-          question.isLoaded = true;
-          question.isLoading = false;
-          question.errorMessage = '';
-        },
-        error: (resp: ErrorMessageOutput) => {
-          question.errorMessage = resp.error.message;
-          this.statusMessageService.showErrorToast(resp.error.message);
-        },
-      });
-  }
-
-  loadQuestion(event: any, question: FeedbackQuestionModel): void {
-    if (event?.visible && !question.isLoaded && !question.isLoading) {
-      question.isLoading = true;
-      this.loadQuestionResults(question);
-    }
   }
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-data.ts
@@ -422,7 +422,6 @@ export const EXAMPLE_QUESTIONS_WITH_RESPONSES: FeedbackQuestionModel[] = [
     otherResponses: [],
     isLoaded: true,
     isLoading: false,
-    hasResponse: true,
     hasResponseButNotVisibleForPreview: false,
     hasCommentNotVisibleForPreview: false,
   },

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -138,7 +138,7 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. This session has no questions. 
+           Nothing to show. There are no questions relevant to you to view in this session. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -439,7 +439,7 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. This session has no questions. 
+           Nothing to show. There are no questions relevant to you to view in this session. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -588,7 +588,7 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. This session has no questions. 
+           Nothing to show. There are no questions relevant to you to view in this session. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -968,7 +968,7 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. This session has no questions. 
+           Nothing to show. There are no questions relevant to you to view in this session. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -1117,7 +1117,7 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. This session has no questions. 
+           Nothing to show. There are no questions relevant to you to view in this session. 
         </div>
       </div>
       <tm-question-response-panel>

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -10,7 +10,6 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -139,7 +138,7 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. The responses are either not configured to be visible or there are no responses. 
+           Nothing to show. This session has no questions. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -159,7 +158,6 @@ exports[`SessionResultPageComponent > should snap when session results failed to
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -312,7 +310,6 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -442,7 +439,7 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. The responses are either not configured to be visible or there are no responses. 
+           Nothing to show. This session has no questions. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -462,7 +459,6 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -592,7 +588,7 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. The responses are either not configured to be visible or there are no responses. 
+           Nothing to show. This session has no questions. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -612,7 +608,6 @@ exports[`SessionResultPageComponent > should snap with session details and resul
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -694,7 +689,6 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -844,7 +838,6 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -975,7 +968,7 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. The responses are either not configured to be visible or there are no responses. 
+           Nothing to show. This session has no questions. 
         </div>
       </div>
       <tm-question-response-panel>
@@ -995,7 +988,6 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
   courseName=""
   courseService={[Function _CourseService]}
   entityType={[Function String]}
-  feedbackQuestionsService={[Function _FeedbackQuestionsService]}
   feedbackSessionId={[Function String]}
   feedbackSessionName=""
   feedbackSessionsService={[Function _FeedbackSessionsService]}
@@ -1125,7 +1117,7 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
           role="alert"
           style="background-color: #d1ecf1;"
         >
-           Nothing to show. The responses are either not configured to be visible or there are no responses. 
+           Nothing to show. This session has no questions. 
         </div>
       </div>
       <tm-question-response-panel>

--- a/src/web/app/pages-session/session-result-page/feedback-question.model.ts
+++ b/src/web/app/pages-session/session-result-page/feedback-question.model.ts
@@ -12,7 +12,6 @@ export interface FeedbackQuestionModel {
   otherResponses: ResponseOutput[][];
   isLoading: boolean;
   isLoaded: boolean;
-  hasResponse: boolean;
   errorMessage?: string;
   hasResponseButNotVisibleForPreview: boolean;
   hasCommentNotVisibleForPreview: boolean;

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -59,12 +59,6 @@
     </div>
   </div>
 }
-@if (!isFeedbackSessionResultsLoading && questions.length !== 0) {
-  <div class="alert alert-primary" role="alert">
-    <i class="fas fa-exclamation-circle"></i> Note: Questions without responses (i.e., no responses received or
-    responses are not meant to be visible to you) are not shown below.
-  </div>
-}
 <div *tmIsLoading="isCourseLoading || isFeedbackSessionDetailsLoading" class="card card-plain mt-3">
   <div class="card-body">
     <div class="row text-center">
@@ -128,7 +122,7 @@
             style="background-color: #d1ecf1"
             role="alert"
           >
-            Nothing to show. The responses are either not configured to be visible or there are no responses.
+            Nothing to show. This session has no questions.
           </div>
         </div>
       }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -122,7 +122,7 @@
             style="background-color: #d1ecf1"
             role="alert"
           >
-            Nothing to show. This session has no questions.
+            Nothing to show. There are no questions relevant to you to view in this session.
           </div>
         </div>
       }

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -7,7 +7,6 @@ import { FeedbackQuestionModel } from './feedback-question.model';
 import { SessionResultPageComponent } from './session-result-page.component';
 import { environment } from '../../../environments/environment';
 import { AuthService } from '../../../services/auth.service';
-import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { LogService } from '../../../services/log.service';
 import { NavigationService } from '../../../services/navigation.service';
@@ -16,7 +15,6 @@ import {
   AuthInfo,
   FeedbackMcqQuestionDetails,
   FeedbackQuestion,
-  FeedbackQuestions,
   FeedbackQuestionType,
   FeedbackSession,
   FeedbackSessionPublishStatus,
@@ -24,6 +22,7 @@ import {
   NumberOfEntitiesToGiveFeedbackToSetting,
   QuestionGiverType,
   QuestionRecipientType,
+  SessionResults,
   RegkeyValidity,
   ResponseVisibleSetting,
   SessionVisibleSetting,
@@ -93,7 +92,6 @@ describe('SessionResultPageComponent', () => {
   let authService: AuthService;
   let navService: NavigationService;
   let studentService: StudentService;
-  let feedbackQuestionsService: FeedbackQuestionsService;
   let feedbackSessionService: FeedbackSessionsService;
   let logService: LogService;
 
@@ -130,7 +128,6 @@ describe('SessionResultPageComponent', () => {
     authService = TestBed.inject(AuthService);
     navService = TestBed.inject(NavigationService);
     studentService = TestBed.inject(StudentService);
-    feedbackQuestionsService = TestBed.inject(FeedbackQuestionsService);
     feedbackSessionService = TestBed.inject(FeedbackSessionsService);
     logService = TestBed.inject(LogService);
     component = fixture.componentInstance;
@@ -138,6 +135,7 @@ describe('SessionResultPageComponent', () => {
     component.isCourseLoading = false;
     component.isFeedbackSessionDetailsLoading = false;
     component.isFeedbackSessionResultsLoading = false;
+    vi.spyOn(feedbackSessionService, 'getUserSessionResults').mockReturnValue(of({ questions: [] }));
     fixture.detectChanges();
   });
 
@@ -351,38 +349,47 @@ describe('SessionResultPageComponent', () => {
     expect(navSpy).toHaveBeenLastCalledWith('/web/join', { entitytype: 'student', key: 'reg-key' });
   });
 
-  it('should load feedback questions', () => {
+  it('should load session results and hydrate questions', () => {
     const testValidity: RegkeyValidity = {
       isAllowedAccess: true,
       isUsed: false,
       isValid: false,
     };
-    const testFeedbackQuestions: FeedbackQuestions = {
-      questions: [testFeedbackQuestion],
-    };
     const testFeedbackQuestionModel: FeedbackQuestionModel = {
       feedbackQuestion: testFeedbackQuestion,
-      questionStatistics: '',
+      questionStatistics: 'stats',
       allResponses: [],
       responsesToSelf: [],
       responsesFromSelf: [],
       otherResponses: [],
       isLoading: false,
-      isLoaded: false,
-      hasResponse: false,
+      isLoaded: true,
       hasResponseButNotVisibleForPreview: false,
       hasCommentNotVisibleForPreview: false,
     };
-
+    const testSessionResults: SessionResults = {
+      questions: [
+        {
+          feedbackQuestion: testFeedbackQuestion,
+          questionStatistics: 'stats',
+          allResponses: [],
+          hasResponseButNotVisibleForPreview: false,
+          hasCommentNotVisibleForPreview: false,
+          responsesToSelf: [],
+          responsesFromSelf: [],
+          otherResponses: [],
+        },
+      ],
+    };
     vi.spyOn(authService, 'getAuthUser').mockReturnValue(of(testInfo));
     vi.spyOn(authService, 'getAuthRegkeyValidity').mockReturnValue(of(testValidity));
     vi.spyOn(feedbackSessionService, 'getFeedbackSession').mockReturnValue(of(testFeedbackSession));
-    const getQuestionsSpy = vi
-      .spyOn(feedbackQuestionsService, 'getFeedbackQuestions')
-      .mockReturnValue(of(testFeedbackQuestions));
+    const getResultsSpy = vi
+      .spyOn(feedbackSessionService, 'getUserSessionResults')
+      .mockReturnValue(of(testSessionResults));
 
     component.ngOnInit();
-    expect(getQuestionsSpy).toHaveBeenLastCalledWith({
+    expect(getResultsSpy).toHaveBeenLastCalledWith({
       feedbackSessionId: testQueryParams['fsid'],
       intent: Intent.STUDENT_RESULT,
       key: testQueryParams['key'],

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -7,7 +7,6 @@ import { FeedbackQuestionModel } from './feedback-question.model';
 import { environment } from '../../../environments/environment';
 import { AuthService } from '../../../services/auth.service';
 import { CourseService } from '../../../services/course.service';
-import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorService } from '../../../services/instructor.service';
 import { LogService } from '../../../services/log.service';
@@ -18,13 +17,12 @@ import { TimezoneService } from '../../../services/timezone.service';
 import {
   AuthInfo,
   Course,
-  FeedbackQuestion,
-  FeedbackQuestions,
   FeedbackSession,
   FeedbackSessionLogType,
   FeedbackSessionPublishStatus,
   FeedbackSessionSubmissionStatus,
   Instructor,
+  QuestionOutput,
   RegkeyValidity,
   ResponseVisibleSetting,
   SessionVisibleSetting,
@@ -49,18 +47,17 @@ import { ErrorMessageOutput } from '../../error-message-output';
   imports: [LoadingSpinnerDirective, LoadingRetryComponent, QuestionResponsePanelComponent],
 })
 export class SessionResultPageComponent implements OnInit {
-  private feedbackQuestionsService = inject(FeedbackQuestionsService);
-  private feedbackSessionsService = inject(FeedbackSessionsService);
-  private route = inject(ActivatedRoute);
-  private timezoneService = inject(TimezoneService);
-  private navigationService = inject(NavigationService);
-  private authService = inject(AuthService);
-  private studentService = inject(StudentService);
-  private instructorService = inject(InstructorService);
-  private courseService = inject(CourseService);
-  private statusMessageService = inject(StatusMessageService);
-  private logService = inject(LogService);
-  private ngbModal = inject(NgbModal);
+  private readonly feedbackSessionsService = inject(FeedbackSessionsService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly timezoneService = inject(TimezoneService);
+  private readonly navigationService = inject(NavigationService);
+  private readonly authService = inject(AuthService);
+  private readonly studentService = inject(StudentService);
+  private readonly instructorService = inject(InstructorService);
+  private readonly courseService = inject(CourseService);
+  private readonly statusMessageService = inject(StatusMessageService);
+  private readonly logService = inject(LogService);
+  private readonly ngbModal = inject(NgbModal);
 
   // enum
   Intent!: typeof Intent;
@@ -110,7 +107,7 @@ export class SessionResultPageComponent implements OnInit {
   feedbackSessionId = '';
   studentId: string | undefined = '';
 
-  private backendUrl: string = environment.backendUrl;
+  private readonly backendUrl: string = environment.backendUrl;
 
   constructor() {
     this.Intent = Intent;
@@ -134,7 +131,7 @@ export class SessionResultPageComponent implements OnInit {
           this.intent = Intent.INSTRUCTOR_RESULT;
         }
 
-        const nextUrl = `${window.location.pathname}${window.location.search.replace(/&/g, '%26')}`;
+        const nextUrl = `${globalThis.location.pathname}${globalThis.location.search.replaceAll('&', '%26')}`;
         this.authService.getAuthUser(nextUrl).subscribe({
           next: (auth: AuthInfo) => {
             const isPreview = !!(auth.user && this.previewAsPerson);
@@ -177,7 +174,7 @@ export class SessionResultPageComponent implements OnInit {
                       );
                     } else {
                       // There is no logged in user for a valid, used registration key, redirect to login page
-                      window.location.href = `${this.backendUrl}${auth.loginUrl}`;
+                      globalThis.location.href = `${this.backendUrl}${auth.loginUrl}`;
                     }
                   } else {
                     // The registration key is invalid
@@ -318,47 +315,50 @@ export class SessionResultPageComponent implements OnInit {
           this.logStudentView();
           this.loadCourseInfo();
           this.loadPersonName();
-
-          this.feedbackQuestionsService
-            .getFeedbackQuestions({
-              feedbackSessionId: this.feedbackSessionId,
-              intent: this.intent,
-              key: this.regKey,
-              previewAs: this.previewAsPerson,
-            })
-            .pipe(
-              finalize(() => {
-                this.isFeedbackSessionResultsLoading = false;
-              }),
-            )
-            .subscribe({
-              next: (feedbackQuestions: FeedbackQuestions) => {
-                feedbackQuestions.questions.sort(
-                  (a: FeedbackQuestion, b: FeedbackQuestion) => a.questionNumber - b.questionNumber,
-                );
-                for (const question of feedbackQuestions.questions) {
-                  this.questions.push({
-                    feedbackQuestion: question,
-                    questionStatistics: '',
-                    allResponses: [],
-                    responsesToSelf: [],
-                    responsesFromSelf: [],
-                    otherResponses: [],
-                    isLoading: false,
-                    isLoaded: false,
-                    hasResponse: false,
-                    hasResponseButNotVisibleForPreview: false,
-                    hasCommentNotVisibleForPreview: false,
-                  });
-                }
-              },
-              error: (resp: ErrorMessageOutput) => {
-                this.handleError(resp);
-              },
-            });
+          this.loadFeedbackSessionResults();
         },
         error: (resp: ErrorMessageOutput) => {
           this.isFeedbackSessionResultsLoading = false;
+          this.handleError(resp);
+        },
+      });
+  }
+
+  private loadFeedbackSessionResults(): void {
+    this.isFeedbackSessionResultsLoading = true;
+    this.feedbackSessionsService
+      .getUserSessionResults({
+        feedbackSessionId: this.feedbackSessionId,
+        intent: this.intent,
+        key: this.regKey,
+        previewAs: this.previewAsPerson,
+      })
+      .pipe(
+        finalize(() => {
+          this.isFeedbackSessionResultsLoading = false;
+        }),
+      )
+      .subscribe({
+        next: (sessionResults) => {
+          sessionResults.questions.sort(
+            (a: QuestionOutput, b: QuestionOutput) =>
+              a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber,
+          );
+
+          this.questions = sessionResults.questions.map((question: QuestionOutput) => ({
+            feedbackQuestion: question.feedbackQuestion,
+            questionStatistics: question.questionStatistics,
+            allResponses: question.allResponses,
+            responsesToSelf: question.responsesToSelf,
+            responsesFromSelf: question.responsesFromSelf,
+            otherResponses: question.otherResponses,
+            isLoading: false,
+            isLoaded: true,
+            hasResponseButNotVisibleForPreview: question.hasResponseButNotVisibleForPreview,
+            hasCommentNotVisibleForPreview: question.hasCommentNotVisibleForPreview,
+          }));
+        },
+        error: (resp: ErrorMessageOutput) => {
           this.handleError(resp);
         },
       });


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

The feedback results page currently loads all questions first, and then issues a separate request to fetch the results for each individual question. This approach was originally implemented when result retrieval was relatively expensive, but that is no longer the case.

We can simplify the frontend logic significantly by fetching all questions and results together and removing the lazy loading mechanism.