### PR TITLE
[#13721] Remove unused questionId parameter from GetUserSessionResultsAction

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/GetUserSessionResultsActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/GetUserSessionResultsActionIT.java
@@ -63,7 +63,7 @@ public class GetUserSessionResultsActionIT extends BaseActionIT<GetUserSessionRe
 
         SessionResultsData output = (SessionResultsData) result.getOutput();
         SessionResultsData expectedResults = SessionResultsData.initForUser(
-                logic.getSessionResultsForUser(accessibleFeedbackSession, instructor, null, false),
+                logic.getSessionResultsForUser(accessibleFeedbackSession, instructor, false),
                 instructor);
 
         assertTrue(isSessionResultsDataEqual(expectedResults, output));
@@ -81,7 +81,7 @@ public class GetUserSessionResultsActionIT extends BaseActionIT<GetUserSessionRe
 
         output = (SessionResultsData) result.getOutput();
         expectedResults = SessionResultsData.initForUser(
-                logic.getSessionResultsForUser(accessibleFeedbackSession, student, null, false),
+                logic.getSessionResultsForUser(accessibleFeedbackSession, student, false),
                 student);
 
         assertTrue(isSessionResultsDataEqual(expectedResults, output));

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1231,15 +1231,13 @@ public class Logic {
      *
      * @param feedbackSession the feedback session
      * @param user the user viewing the feedback session
-     * @param questionId if not null, will only return partial bundle for the question
      * @param isPreviewResults true if getting session results for preview purpose
      * @return the session result bundle
      */
     public SessionResultsBundle getSessionResultsForUser(
-            FeedbackSession feedbackSession, User user,
-            @Nullable UUID questionId, boolean isPreviewResults) {
+            FeedbackSession feedbackSession, User user, boolean isPreviewResults) {
         return feedbackResponsesLogic.getSessionResultsForUser(
-                feedbackSession, user, questionId, isPreviewResults);
+                feedbackSession, user, isPreviewResults);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -683,20 +683,18 @@ public final class FeedbackResponsesLogic {
      *
      * @param feedbackSession the feedback session
      * @param user the user viewing the feedback session
-     * @param questionId if not null, will only return partial bundle for the question
      * @param isPreviewResults true if getting session results for preview purpose
      * @return the session result bundle
      */
     public SessionResultsBundle getSessionResultsForUser(
-            FeedbackSession feedbackSession, User user,
-            @Nullable UUID questionId, boolean isPreviewResults) {
+            FeedbackSession feedbackSession, User user, boolean isPreviewResults) {
         String courseId = feedbackSession.getCourseId();
         CourseRoster roster = new CourseRoster(
                 usersLogic.getStudentsForCourse(courseId),
                 usersLogic.getInstructorsForCourse(courseId));
 
         // load question(s)
-        List<FeedbackQuestion> allQuestions = getQuestionsForSession(feedbackSession, questionId)
+        List<FeedbackQuestion> allQuestions = fqLogic.getFeedbackQuestionsForSession(feedbackSession)
                 .stream()
                 .filter(question -> isQuestionRelevantForUserResult(question, user))
                 .toList();

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -54,14 +54,6 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             Instructor instructor = getInstructorOfCourseForSubmission(courseId, true);
             checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;
-        case INSTRUCTOR_RESULT:
-            instructor = getInstructorOfCourseForResult(courseId);
-            checkAccessControlForInstructorFeedbackResult(instructor, feedbackSession);
-            break;
-        case STUDENT_RESULT:
-            student = getStudentOfCourseForResult(courseId);
-            checkAccessControlForStudentFeedbackResult(student, feedbackSession);
-            break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }
@@ -96,7 +88,7 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
                 dynamicallyGeneratedOptions.put(question.getId(), options);
             }
             break;
-        case FULL_DETAIL, INSTRUCTOR_RESULT, STUDENT_RESULT:
+        case FULL_DETAIL:
             questions = logic.getFeedbackQuestionsForSession(feedbackSession);
             break;
         default:
@@ -117,7 +109,7 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
                 })
                 .toList();
 
-        if (intent == Intent.STUDENT_SUBMISSION || intent == Intent.STUDENT_RESULT) {
+        if (intent == Intent.STUDENT_SUBMISSION) {
             for (FeedbackQuestionData questionData : questionDatas) {
                 questionData.hideInformationForStudent();
             }

--- a/src/main/java/teammates/ui/webapi/GetUserSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetUserSessionResultsAction.java
@@ -64,7 +64,6 @@ public class GetUserSessionResultsAction extends BasicFeedbackSubmissionAction {
     @Override
     public JsonResult execute() {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
-        UUID questionId = getNullableUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
 
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
         boolean isPreviewResults = !StringHelper.isEmpty(previewAsPerson);
@@ -82,11 +81,11 @@ public class GetUserSessionResultsAction extends BasicFeedbackSubmissionAction {
         switch (intent) {
         case INSTRUCTOR_RESULT:
             Instructor instructor = getInstructorOfCourseForResult(courseId);
-            bundle = logic.getSessionResultsForUser(feedbackSession, instructor, questionId, isPreviewResults);
+            bundle = logic.getSessionResultsForUser(feedbackSession, instructor, isPreviewResults);
             return new JsonResult(SessionResultsData.initForUser(bundle, instructor));
         case STUDENT_RESULT:
             Student student = getStudentOfCourseForResult(courseId);
-            bundle = logic.getSessionResultsForUser(feedbackSession, student, questionId, isPreviewResults);
+            bundle = logic.getSessionResultsForUser(feedbackSession, student, isPreviewResults);
             return new JsonResult(SessionResultsData.initForUser(bundle, student));
         case FULL_DETAIL, INSTRUCTOR_SUBMISSION, STUDENT_SUBMISSION:
             throw new InvalidHttpParameterException("Invalid intent for this action");

--- a/src/main/java/teammates/ui/webapi/GetUserSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetUserSessionResultsAction.java
@@ -8,6 +8,7 @@ import teammates.common.util.StringHelper;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -76,21 +77,22 @@ public class GetUserSessionResultsAction extends BasicFeedbackSubmissionAction {
         }
 
         String courseId = feedbackSession.getCourseId();
-        SessionResultsBundle bundle;
+        User user;
 
         switch (intent) {
         case INSTRUCTOR_RESULT:
-            Instructor instructor = getInstructorOfCourseForResult(courseId);
-            bundle = logic.getSessionResultsForUser(feedbackSession, instructor, isPreviewResults);
-            return new JsonResult(SessionResultsData.initForUser(bundle, instructor));
+            user = getInstructorOfCourseForResult(courseId);
+            break;
         case STUDENT_RESULT:
-            Student student = getStudentOfCourseForResult(courseId);
-            bundle = logic.getSessionResultsForUser(feedbackSession, student, isPreviewResults);
-            return new JsonResult(SessionResultsData.initForUser(bundle, student));
+            user = getStudentOfCourseForResult(courseId);
+            break;
         case FULL_DETAIL, INSTRUCTOR_SUBMISSION, STUDENT_SUBMISSION:
             throw new InvalidHttpParameterException("Invalid intent for this action");
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }
+
+        SessionResultsBundle bundle = logic.getSessionResultsForUser(feedbackSession, user, isPreviewResults);
+        return new JsonResult(SessionResultsData.initForUser(bundle, user));
     }
 }

--- a/src/test/java/teammates/ui/webapi/GetUserSessionResultsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetUserSessionResultsActionTest.java
@@ -78,7 +78,7 @@ public class GetUserSessionResultsActionTest extends BaseActionTest<GetUserSessi
             when(mockLogic.getInstructorByGoogleId(session.getCourseId(), googleId)).thenReturn(instructorStub);
             when(mockLogic.getSessionResultsForUser(argThat(
                             argument -> Objects.equals(argument.getName(), session.getName())),
-                            eq(instructorStub), eq(null), eq(false)))
+                            eq(instructorStub), eq(false)))
                     .thenReturn(resultsStub);
             break;
         case STUDENT_RESULT:
@@ -86,7 +86,7 @@ public class GetUserSessionResultsActionTest extends BaseActionTest<GetUserSessi
             when(mockLogic.getStudentByGoogleId(session.getCourseId(), googleId)).thenReturn(studentStub);
             when(mockLogic.getSessionResultsForUser(argThat(
                             argument -> Objects.equals(argument.getName(), session.getName())),
-                            eq(studentStub), eq(null), eq(false)))
+                            eq(studentStub), eq(false)))
                     .thenReturn(resultsStub);
             break;
         case FULL_DETAIL, INSTRUCTOR_SUBMISSION, STUDENT_SUBMISSION:

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -501,7 +501,7 @@ export abstract class InstructorSessionBasePageComponent {
     this.feedbackQuestionsService
       .getFeedbackQuestions({
         feedbackSessionId: model.feedbackSession.feedbackSessionId,
-        intent: Intent.INSTRUCTOR_RESULT,
+        intent: Intent.FULL_DETAIL,
       })
       .pipe(
         switchMap((feedbackQuestions: FeedbackQuestions) => {

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -188,7 +188,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
     this.feedbackSessionsService
       .getFeedbackSession({
         feedbackSessionId,
-        intent: Intent.INSTRUCTOR_RESULT,
+        intent: Intent.FULL_DETAIL,
       })
       .subscribe({
         next: (feedbackSession: FeedbackSession) => {
@@ -258,7 +258,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
           this.feedbackQuestionsService
             .getFeedbackQuestions({
               feedbackSessionId,
-              intent: Intent.INSTRUCTOR_RESULT,
+              intent: Intent.FULL_DETAIL,
             })
             .subscribe({
               next: (feedbackQuestions: FeedbackQuestions) => {

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -391,7 +391,6 @@ export class FeedbackSessionsService {
   getUserSessionResults(queryParams: {
     feedbackSessionId: string;
     intent: Intent;
-    questionId?: string;
     key?: string;
     previewAs?: string;
   }): Observable<SessionResults> {
@@ -399,10 +398,6 @@ export class FeedbackSessionsService {
       fsid: queryParams.feedbackSessionId,
       intent: queryParams.intent,
     };
-
-    if (queryParams.questionId) {
-      paramMap['questionid'] = queryParams.questionId;
-    }
 
     if (queryParams.key) {
       paramMap['key'] = queryParams.key;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Remove unused questionId parameter from GetUserSessionResultsAction. Also removed STUDENT_RESULT and INSTRUCTOR_RESULT flows from GetFeedbackQuestionsAction as these are also unused.