### PR TITLE
[#13597] Migrate admin search tables away from Angular's Animations package

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
@@ -285,7 +285,8 @@ public class AdminSearchPage extends AppPage {
         List<WebElement> rows = browser.driver.findElements(By.cssSelector("tm-admin-account-search-table tbody tr"));
         for (WebElement row : rows) {
             List<WebElement> columns = row.findElements(By.tagName("td"));
-            if (removeSpanFromText(columns.get(ACCOUNT_REQUEST_COL_EMAIL - 1)
+            if (columns.size() >= ACCOUNT_REQUEST_COL_INSTITUTE
+                    && removeSpanFromText(columns.get(ACCOUNT_REQUEST_COL_EMAIL - 1)
                     .getAttribute("innerHTML")).contains(email)
                     && removeSpanFromText(columns.get(ACCOUNT_REQUEST_COL_INSTITUTE - 1)
                     .getAttribute("innerHTML")).contains(institute)) {

--- a/src/web/app/pages-admin/admin-search-page/admin-account-search-table/__snapshots__/admin-account-search-table.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-search-page/admin-account-search-table/__snapshots__/admin-account-search-table.component.spec.ts.snap
@@ -222,6 +222,27 @@ exports[`AdminAccountSearchTableComponent > should display account requests with
             </td>
           </tr>
           <tr>
+            <td
+              colspan="100"
+            >
+              <ul
+                class="list-group collapse"
+              >
+                <li
+                  class="list-group-item list-group-item-info"
+                >
+                  <strong>
+                    Account Registration Link
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
             <td>
               <div
                 class="d-flex align-items-center gap-2"
@@ -361,6 +382,27 @@ exports[`AdminAccountSearchTableComponent > should display account requests with
                   </button>
                 </div>
               </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              colspan="100"
+            >
+              <ul
+                class="list-group collapse"
+              >
+                <li
+                  class="list-group-item list-group-item-info"
+                >
+                  <strong>
+                    Account Registration Link
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+              </ul>
             </td>
           </tr>
         </tbody>
@@ -594,6 +636,27 @@ exports[`AdminAccountSearchTableComponent > should display account requests with
             </td>
           </tr>
           <tr>
+            <td
+              colspan="100"
+            >
+              <ul
+                class="list-group collapse"
+              >
+                <li
+                  class="list-group-item list-group-item-info"
+                >
+                  <strong>
+                    Account Registration Link
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
             <td>
               <div
                 class="d-flex align-items-center gap-2"
@@ -735,6 +798,27 @@ exports[`AdminAccountSearchTableComponent > should display account requests with
                   </button>
                 </div>
               </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              colspan="100"
+            >
+              <ul
+                class="list-group collapse"
+              >
+                <li
+                  class="list-group-item list-group-item-info"
+                >
+                  <strong>
+                    Account Registration Link
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+              </ul>
             </td>
           </tr>
         </tbody>
@@ -963,6 +1047,27 @@ exports[`AdminAccountSearchTableComponent > should snap with an expanded account
                   </button>
                 </div>
               </div>
+            </td>
+          </tr>
+          <tr>
+            <td
+              colspan="100"
+            >
+              <ul
+                class="list-group collapse"
+              >
+                <li
+                  class="list-group-item list-group-item-info"
+                >
+                  <strong>
+                    Account Registration Link
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+              </ul>
             </td>
           </tr>
         </tbody>

--- a/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.html
@@ -181,18 +181,16 @@
                 </div>
               </td>
             </tr>
-            @if (accountRequest.showLinks) {
-              <tr>
-                <td colspan="100">
-                  <ul class="list-group" @collapseAnim>
-                    <li class="list-group-item list-group-item-info">
-                      <strong>Account Registration Link</strong>
-                      <input [value]="accountRequest.registrationLink" disabled class="form-control" />
-                    </li>
-                  </ul>
-                </td>
-              </tr>
-            }
+            <tr>
+              <td colspan="100">
+                <ul class="list-group" [ngbCollapse]="!accountRequest.showLinks">
+                  <li class="list-group-item list-group-item-info">
+                    <strong>Account Registration Link</strong>
+                    <input [value]="accountRequest.registrationLink" disabled class="form-control" />
+                  </li>
+                </ul>
+              </td>
+            </tr>
           }
         </tbody>
       </table>

--- a/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-account-search-table/admin-account-search-table.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 import { NgbDropdown, NgbDropdownToggle, NgbDropdownMenu } from '@ng-bootstrap/ng-bootstrap/dropdown';
 import { NgbModalRef, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
@@ -15,7 +16,6 @@ import { RejectWithReasonModalComponentResult } from '../../../components/accoun
 import { RejectWithReasonModalComponent } from '../../../components/account-requests-table/admin-reject-with-reason-modal/admin-reject-with-reason-modal.component';
 import { AjaxLoadingComponent } from '../../../components/ajax-loading/ajax-loading.component';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
-import { collapseAnim } from '../../../components/teammates-common/collapse-anim';
 
 /**
  * Account requests table component for admin search.
@@ -24,9 +24,9 @@ import { collapseAnim } from '../../../components/teammates-common/collapse-anim
   selector: 'tm-admin-account-search-table',
   templateUrl: './admin-account-search-table.component.html',
   styleUrls: ['./admin-account-search-table.component.scss'],
-  animations: [collapseAnim],
   imports: [
     NgbTooltip,
+    NgbCollapse,
     AjaxLoadingComponent,
     NgbDropdown,
     NgbDropdownToggle,

--- a/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/__snapshots__/admin-instructor-search-table.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/__snapshots__/admin-instructor-search-table.component.spec.ts.snap
@@ -140,6 +140,82 @@ exports[`AdminInstructorSearchTableComponent > should snap with a deleted course
               </button>
             </td>
           </tr>
+          <tr>
+            <td
+              colspan="5"
+            >
+              <ul
+                class="list-group collapse"
+              >
+                <li
+                  class="list-group-item list-group-item-success has-success"
+                >
+                  <strong>
+                    Email
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+                <li
+                  class="list-group-item list-group-item-info"
+                >
+                  <strong>
+                    Course Join Link
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+                <li
+                  class="list-group-item list-group-item-light"
+                >
+                  <strong>
+                    sessionName startTime - endTime
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+                <li
+                  class="list-group-item list-group-item-warning"
+                >
+                  <strong>
+                    sessionName startTime - endTime
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+                <li
+                  class="list-group-item list-group-item-danger"
+                >
+                  <strong>
+                    sessionName startTime - endTime
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+                <li
+                  class="list-group-item list-group-item-success"
+                >
+                  <strong>
+                    sessionName startTime - endTime
+                  </strong>
+                  <input
+                    class="form-control"
+                    disabled=""
+                  />
+                </li>
+              </ul>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -289,7 +365,7 @@ exports[`AdminInstructorSearchTableComponent > should snap with an expanded inst
               colspan="5"
             >
               <ul
-                class="list-group"
+                class="list-group collapse show"
               >
                 <li
                   class="list-group-item list-group-item-success has-success"

--- a/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.html
@@ -105,54 +105,52 @@
               </button>
             </td>
           </tr>
-          @if (instructor.showLinks) {
-            <tr>
-              <td colspan="5">
-                <ul class="list-group">
-                  <li class="list-group-item list-group-item-success has-success">
-                    <strong>Email</strong>
-                    <input [value]="instructor.email" disabled class="form-control" />
+          <tr>
+            <td colspan="5">
+              <ul class="list-group" [ngbCollapse]="!instructor.showLinks">
+                <li class="list-group-item list-group-item-success has-success">
+                  <strong>Email</strong>
+                  <input [value]="instructor.email" disabled class="form-control" />
+                </li>
+                <li class="list-group-item list-group-item-info">
+                  <strong>Course Join Link</strong>
+                  <input [value]="instructor.courseJoinLink" disabled class="form-control" />
+                </li>
+                @for (awaitingFs of instructor.awaitingSessions | keyvalue; track awaitingFs) {
+                  <li class="list-group-item list-group-item-light">
+                    <strong>{{
+                      awaitingFs.value.name + ' ' + awaitingFs.value.startTime + ' - ' + awaitingFs.value.endTime
+                    }}</strong>
+                    <input [value]="awaitingFs.value.feedbackSessionUrl" disabled class="form-control" />
                   </li>
-                  <li class="list-group-item list-group-item-info">
-                    <strong>Course Join Link</strong>
-                    <input [value]="instructor.courseJoinLink" disabled class="form-control" />
+                }
+                @for (openFs of instructor.openSessions | keyvalue; track openFs) {
+                  <li class="list-group-item list-group-item-warning">
+                    <strong>{{
+                      openFs.value.name + ' ' + openFs.value.startTime + ' - ' + openFs.value.endTime
+                    }}</strong>
+                    <input [value]="openFs.value.feedbackSessionUrl" disabled class="form-control" />
                   </li>
-                  @for (awaitingFs of instructor.awaitingSessions | keyvalue; track awaitingFs) {
-                    <li class="list-group-item list-group-item-light">
-                      <strong>{{
-                        awaitingFs.value.name + ' ' + awaitingFs.value.startTime + ' - ' + awaitingFs.value.endTime
-                      }}</strong>
-                      <input [value]="awaitingFs.value.feedbackSessionUrl" disabled class="form-control" />
-                    </li>
-                  }
-                  @for (openFs of instructor.openSessions | keyvalue; track openFs) {
-                    <li class="list-group-item list-group-item-warning">
-                      <strong>{{
-                        openFs.value.name + ' ' + openFs.value.startTime + ' - ' + openFs.value.endTime
-                      }}</strong>
-                      <input [value]="openFs.value.feedbackSessionUrl" disabled class="form-control" />
-                    </li>
-                  }
-                  @for (notOpenFs of instructor.notOpenSessions | keyvalue; track notOpenFs) {
-                    <li class="list-group-item list-group-item-danger">
-                      <strong>{{
-                        notOpenFs.value.name + ' ' + notOpenFs.value.startTime + ' - ' + notOpenFs.value.endTime
-                      }}</strong>
-                      <input [value]="notOpenFs.value.feedbackSessionUrl" disabled class="form-control" />
-                    </li>
-                  }
-                  @for (publishedFs of instructor.publishedSessions | keyvalue; track publishedFs) {
-                    <li class="list-group-item list-group-item-success">
-                      <strong>{{
-                        publishedFs.value.name + ' ' + publishedFs.value.startTime + ' - ' + publishedFs.value.endTime
-                      }}</strong>
-                      <input [value]="publishedFs.value.feedbackSessionUrl" disabled class="form-control" />
-                    </li>
-                  }
-                </ul>
-              </td>
-            </tr>
-          }
+                }
+                @for (notOpenFs of instructor.notOpenSessions | keyvalue; track notOpenFs) {
+                  <li class="list-group-item list-group-item-danger">
+                    <strong>{{
+                      notOpenFs.value.name + ' ' + notOpenFs.value.startTime + ' - ' + notOpenFs.value.endTime
+                    }}</strong>
+                    <input [value]="notOpenFs.value.feedbackSessionUrl" disabled class="form-control" />
+                  </li>
+                }
+                @for (publishedFs of instructor.publishedSessions | keyvalue; track publishedFs) {
+                  <li class="list-group-item list-group-item-success">
+                    <strong>{{
+                      publishedFs.value.name + ' ' + publishedFs.value.startTime + ' - ' + publishedFs.value.endTime
+                    }}</strong>
+                    <input [value]="publishedFs.value.feedbackSessionUrl" disabled class="form-control" />
+                  </li>
+                }
+              </ul>
+            </td>
+          </tr>
         }
       </tbody>
     </table>

--- a/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.ts
@@ -1,5 +1,6 @@
 import { KeyValuePipe, NgClass } from '@angular/common';
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 import { AccountService } from '../../../../services/account.service';
@@ -16,7 +17,7 @@ import { SearchTermsHighlighterPipe } from '../../../pipes/search-terms-highligh
 @Component({
   selector: 'tm-admin-instructor-search-table',
   templateUrl: './admin-instructor-search-table.component.html',
-  imports: [NgClass, NgbTooltip, AjaxLoadingComponent, KeyValuePipe, SearchTermsHighlighterPipe],
+  imports: [NgClass, NgbTooltip, NgbCollapse, AjaxLoadingComponent, KeyValuePipe, SearchTermsHighlighterPipe],
 })
 export class AdminInstructorSearchTableComponent implements OnChanges {
   private statusMessageService = inject(StatusMessageService);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13597

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Migrate admin search tables to use NgbCollapse
