### PR TITLE
[#13721] Classify question answerability as validation errors instead of authorization errors

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -446,15 +446,6 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
         verifyCanAccess(submissionParams);
 
-        ______TS("Failure with student: student answers question with incorrect giver");
-        setStartTime(session, -1);
-        setEndTime(session, 3);
-
-        questionNumber = 4;
-        submissionParams = buildSubmissionParams(session, questionNumber, Intent.STUDENT_SUBMISSION);
-
-        verifyCannotAccess(submissionParams);
-
         ______TS("Failure with student: student logged out");
         logoutUser();
         setStartTime(session, -1);
@@ -523,16 +514,6 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         submissionParams = buildSubmissionParams(session, questionNumber, Intent.INSTRUCTOR_SUBMISSION);
 
         verifyCanAccess(submissionParams);
-
-        ______TS("Failure with instructor: instructor answers question with incorrect giver");
-        loginInstructor("instructor1OfCourse1");
-        setStartTime(session, -1);
-        setEndTime(session, 3);
-
-        questionNumber = 1;
-        submissionParams = buildSubmissionParams(session, questionNumber, Intent.INSTRUCTOR_SUBMISSION);
-
-        verifyCannotAccess(submissionParams);
 
         ______TS("Failure with instructor: instructor logged out");
         logoutUser();

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -448,6 +448,12 @@ public final class FeedbackQuestionsLogic {
         List<Instructor> instructors = usersLogic.getInstructorsForCourse(question.getCourseId());
         CourseRoster courseRoster = new CourseRoster(students, instructors);
 
+        // If the giver is not of the correct type, then return an empty set as
+        // there are no valid recipients for this giver.
+        if (!isGiverValidForQuestion(question, responseGiver)) {
+            return Collections.emptySet();
+        }
+
         return getRecipientsOfQuestion(question, responseGiver, courseRoster);
     }
 
@@ -573,7 +579,6 @@ public final class FeedbackQuestionsLogic {
                 return Set.of(new ResponseRecipient(student.getTeam()));
             }
 
-            // TODO: check why instructors are allowed to have OWN_TEAM as recipient type, and whether this case can happen
             return Set.of();
         case OWN_TEAM_MEMBERS:
             String teamName = responseGiver.getTeamName();
@@ -632,6 +637,17 @@ public final class FeedbackQuestionsLogic {
 
         // Shift question numbers down for all questions after the deleted one
         shiftQuestionNumbersDown(questionNumberToDelete, questionsToShiftQnNumber);
+    }
+
+    private boolean isGiverValidForQuestion(FeedbackQuestion question, ResponseGiver giver) {
+        QuestionGiverType giverType = question.getGiverType();
+        return switch (giverType) {
+        case STUDENTS -> giver.isGiverStudent();
+        case INSTRUCTORS -> giver.isGiverInstructor();
+        case TEAMS -> giver.isGiverTeam();
+        case SESSION_CREATOR -> giver.isGiverInstructor()
+                && giver.getGiverUser().getEmail().equals(question.getFeedbackSession().getCreatorEmail());
+        };
     }
 
     // Shifts all question numbers after questionNumberToShiftFrom down by one.

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -646,7 +646,8 @@ public final class FeedbackQuestionsLogic {
         case INSTRUCTORS -> giver.isGiverInstructor();
         case TEAMS -> giver.isGiverTeam();
         case SESSION_CREATOR -> giver.isGiverInstructor()
-                && giver.getGiverUser().getEmail().equals(question.getFeedbackSession().getCreatorEmail());
+                && SanitizationHelper.areEmailsEqual(
+                        giver.getGiverUser().getEmail(), question.getFeedbackSession().getCreatorEmail());
         };
     }
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -207,6 +207,11 @@ public final class FeedbackResponsesLogic {
     public List<FeedbackResponse> submitFeedbackResponsesFromStudent(
             FeedbackQuestion feedbackQuestion, Student student, FeedbackResponsesRequest submitRequest)
             throws InvalidOperationException, InvalidParametersException {
+        if (feedbackQuestion.getGiverType() != QuestionGiverType.STUDENTS
+                && feedbackQuestion.getGiverType() != QuestionGiverType.TEAMS) {
+            throw new InvalidOperationException("Feedback question is not answerable for students");
+        }
+
         ResponseGiver responseGiver = feedbackQuestion.getGiverType() == QuestionGiverType.TEAMS
                 ? new ResponseGiver(student.getTeam())
                 : new ResponseGiver(student);
@@ -222,6 +227,11 @@ public final class FeedbackResponsesLogic {
     public List<FeedbackResponse> submitFeedbackResponsesFromInstructor(
             FeedbackQuestion feedbackQuestion, Instructor instructor, FeedbackResponsesRequest submitRequest)
             throws InvalidOperationException, InvalidParametersException {
+        if (feedbackQuestion.getGiverType() != QuestionGiverType.INSTRUCTORS
+                && feedbackQuestion.getGiverType() != QuestionGiverType.SESSION_CREATOR) {
+            throw new InvalidOperationException("Feedback question is not answerable for instructors");
+        }
+
         ResponseGiver responseGiver = new ResponseGiver(instructor);
         List<FeedbackResponse> existingResponses = getFeedbackResponsesFromInstructorForQuestion(
                 feedbackQuestion, instructor);

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseGiverCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackResponseGiverCommentAction.java
@@ -41,7 +41,6 @@ public class DeleteFeedbackResponseGiverCommentAction extends BasicFeedbackSubmi
         switch (intent) {
         case STUDENT_SUBMISSION:
             Student student = getStudentOfCourseForSubmission(courseId, false);
-            gateKeeper.verifyAnswerableForStudent(question);
             verifyInstructorCanSeeQuestionIfInModeration(question);
             checkAccessControlForStudentFeedbackSubmission(student, session);
             verifySessionOpenExceptForModeration(session, student);
@@ -49,7 +48,6 @@ public class DeleteFeedbackResponseGiverCommentAction extends BasicFeedbackSubmi
             break;
         case INSTRUCTOR_SUBMISSION:
             Instructor instructorAsFeedbackParticipant = getInstructorOfCourseForSubmission(courseId, false);
-            gateKeeper.verifyAnswerableForInstructor(question);
             verifyInstructorCanSeeQuestionIfInModeration(question);
             checkAccessControlForInstructorFeedbackSubmission(instructorAsFeedbackParticipant, session);
             verifySessionOpenExceptForModeration(session, instructorAsFeedbackParticipant);

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -1,11 +1,9 @@
 package teammates.ui.webapi;
 
 import teammates.common.datatransfer.AuthContext;
-import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.util.Const;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
-import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.ResponseGiver;
@@ -197,32 +195,6 @@ final class GateKeeper {
                                                   + "] is not accessible to instructor [" + instructor.getEmail()
                                                   + "] for privilege [" + privilegeName + "] on section ["
                                                   + sectionName + "]");
-        }
-    }
-
-    /**
-     * Verifies that the feedback question is for student to answer.
-     */
-    void verifyAnswerableForStudent(FeedbackQuestion feedbackQuestion)
-            throws UnauthorizedAccessException {
-        verifyNotNull(feedbackQuestion, "feedback question");
-
-        if (feedbackQuestion.getGiverType() != QuestionGiverType.STUDENTS
-                && feedbackQuestion.getGiverType() != QuestionGiverType.TEAMS) {
-            throw new UnauthorizedAccessException("Feedback question is not answerable for students", true);
-        }
-    }
-
-    /**
-     * Verifies that the feedback question is for instructor to answer.
-     */
-    void verifyAnswerableForInstructor(FeedbackQuestion feedbackQuestion)
-            throws UnauthorizedAccessException {
-        verifyNotNull(feedbackQuestion, "feedback question");
-
-        if (feedbackQuestion.getGiverType() != QuestionGiverType.INSTRUCTORS
-                && feedbackQuestion.getGiverType() != QuestionGiverType.SESSION_CREATOR) {
-            throw new UnauthorizedAccessException("Feedback question is not answerable for instructors", true);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionRecipientsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionRecipientsAction.java
@@ -52,12 +52,10 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
                                                 feedbackQuestion.getCourseId());
         switch (intent) {
         case STUDENT_SUBMISSION:
-            gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
             Student student = getStudentOfCourseForSubmission(feedbackSession.getCourseId(), true);
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
-            gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
             Instructor instructor = getInstructorOfCourseForSubmission(feedbackSession.getCourseId(), true);
             checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;
@@ -68,21 +66,14 @@ public class GetFeedbackQuestionRecipientsAction extends BasicFeedbackSubmission
 
     @Override
     public JsonResult execute() {
-        FeedbackQuestion feedbackQuestion = null;
-        String courseId;
+        UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
 
-        UUID feedbackQuestionId;
-
-        feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-
-        feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
-
-        if (feedbackQuestion != null) {
-            courseId = feedbackQuestion.getCourseId();
-        } else {
+        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+        if (feedbackQuestion == null) {
             throw new EntityNotFoundException("Feedback Question not found");
         }
 
+        String courseId = feedbackQuestion.getCourseId();
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
 
         ResponseGiver responseGiver;

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -27,12 +27,8 @@ public class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        FeedbackQuestion feedbackQuestion = null;
-
-        UUID feedbackQuestionId;
-
-        feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+        UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
 
         if (feedbackQuestion == null) {
             throw new EntityNotFoundException("Feedback Question not found");
@@ -47,12 +43,10 @@ public class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         switch (intent) {
         case STUDENT_SUBMISSION:
-            gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
             Student student = getStudentOfCourseForSubmission(feedbackSession.getCourseId(), false);
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
-            gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
             Instructor instructor = getInstructorOfCourseForSubmission(feedbackSession.getCourseId(), false);
             checkAccessControlForInstructorFeedbackSubmission(instructor, feedbackSession);
             break;
@@ -63,12 +57,8 @@ public class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
 
     @Override
     public JsonResult execute() {
-        FeedbackQuestion feedbackQuestion = null;
-
-        UUID feedbackQuestionId;
-
-        feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+        UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
 
         if (feedbackQuestion == null) {
             throw new EntityNotFoundException("Feedback Question not found");

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -51,7 +51,6 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         switch (intent) {
         case STUDENT_SUBMISSION:
-            gateKeeper.verifyAnswerableForStudent(feedbackQuestion);
             Student student = getStudentOfCourseForSubmission(feedbackQuestion.getCourseId(), false);
             if (student == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent student entity");
@@ -60,7 +59,6 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
-            gateKeeper.verifyAnswerableForInstructor(feedbackQuestion);
             Instructor instructor = getInstructorOfCourseForSubmission(feedbackQuestion.getCourseId(), false);
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -421,6 +421,38 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
     }
 
     @Test
+    public void testSubmitFeedbackResponsesFromStudent_nonStudentGiverType_throwsInvalidOperationException() {
+        Course course = getTypicalCourse();
+        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
+        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
+        question.setId(UUID.randomUUID());
+        question.setGiverType(QuestionGiverType.INSTRUCTORS);
+        Student giver = getTypicalStudent();
+
+        InvalidOperationException exception = assertThrows(InvalidOperationException.class,
+                () -> frLogic.submitFeedbackResponsesFromStudent(question, giver, new FeedbackResponsesRequest()));
+
+        assertEquals("Feedback question is not answerable for students", exception.getMessage());
+        verify(frDb, never()).getFeedbackResponsesFromGiverForQuestion(any(UUID.class), any(UUID.class), any());
+    }
+
+    @Test
+    public void testSubmitFeedbackResponsesFromInstructor_nonInstructorGiverType_throwsInvalidOperationException() {
+        Course course = getTypicalCourse();
+        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
+        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
+        question.setId(UUID.randomUUID());
+        question.setGiverType(QuestionGiverType.STUDENTS);
+        Instructor giver = getTypicalInstructor();
+
+        InvalidOperationException exception = assertThrows(InvalidOperationException.class,
+                () -> frLogic.submitFeedbackResponsesFromInstructor(question, giver, new FeedbackResponsesRequest()));
+
+        assertEquals("Feedback question is not answerable for instructors", exception.getMessage());
+        verify(frDb, never()).getFeedbackResponsesFromGiverForQuestion(any(UUID.class), any(UUID.class), any());
+    }
+
+    @Test
     public void testHasGiverRespondedForSession_hasResponded() {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -402,76 +401,6 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
     }
 
     @Test
-    void testSpecificAccessControl_notAnswerableForStudent_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
-        stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
-
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
-                .thenReturn(stubFeedbackSession);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(stubStudent);
-        when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-        };
-        for (QuestionGiverType type : QuestionGiverType.values()) {
-            if (type == QuestionGiverType.STUDENTS || type == QuestionGiverType.TEAMS) {
-                continue;
-            }
-            stubFeedbackQuestion.setGiverType(type);
-            GetFeedbackResponsesAction action = getAction(params);
-            UnauthorizedAccessException uae = assertThrows(UnauthorizedAccessException.class,
-                    action::checkAccessControl);
-            assertEquals("Feedback question is not answerable for students", uae.getMessage());
-        }
-        verify(mockLogic, times(QuestionGiverType.values().length - 2))
-                .getFeedbackQuestion(stubFeedbackQuestion.getId());
-
-        // verify only QuestionGiverType.STUDENTS and TEAMS are accessible
-        for (QuestionGiverType type : new QuestionGiverType[] { QuestionGiverType.STUDENTS,
-                QuestionGiverType.TEAMS }) {
-            stubFeedbackQuestion.setGiverType(type);
-            verifyCanAccess(params);
-        }
-    }
-
-    @Test
-    void testSpecificAccessControl_notAnswerableForInstructor_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
-
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
-                .thenReturn(stubFeedbackSession);
-        when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId()))
-                .thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(stubInstructor);
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-        };
-        for (QuestionGiverType type : QuestionGiverType.values()) {
-            if (type == QuestionGiverType.INSTRUCTORS || type == QuestionGiverType.SESSION_CREATOR) {
-                continue;
-            }
-            stubFeedbackQuestion.setGiverType(type);
-            GetFeedbackResponsesAction action = getAction(params);
-            UnauthorizedAccessException uae = assertThrows(UnauthorizedAccessException.class,
-                    action::checkAccessControl);
-            assertEquals("Feedback question is not answerable for instructors", uae.getMessage());
-        }
-        verify(mockLogic, times(QuestionGiverType.values().length - 2))
-                .getFeedbackQuestion(stubFeedbackQuestion.getId());
-
-        // verify only QuestionGiverType.INSTRUCTORS and SESSION_CREATOR are accessible
-        for (QuestionGiverType type : new QuestionGiverType[] { QuestionGiverType.INSTRUCTORS,
-                QuestionGiverType.SESSION_CREATOR }) {
-            stubFeedbackQuestion.setGiverType(type);
-            verifyCanAccess(params);
-        }
-    }
-
-    @Test
     void testSpecificAccessControl_invalidIntent_cannotAccess() {
         loginAsInstructor(stubInstructor.getGoogleId());
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
@@ -504,43 +433,6 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         InvalidHttpParameterException e3 = assertThrows(InvalidHttpParameterException.class,
                 action3::checkAccessControl);
         assertEquals("Unknown intent " + Intent.STUDENT_RESULT, e3.getMessage());
-    }
-
-    @Test
-    void testSpecificAccessControl_studentSubmissionAsInstructor_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
-        FeedbackQuestion questionAnswerableToStudent = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
-        stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
-        questionAnswerableToStudent.setGiverType(QuestionGiverType.STUDENTS);
-        when(mockLogic.getFeedbackQuestion(questionAnswerableToStudent.getId())).thenReturn(questionAnswerableToStudent);
-        when(mockLogic.getStudentByGoogleId(stubCourse.getId(), stubInstructor.getGoogleId())).thenReturn(null);
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
-                .thenReturn(stubFeedbackSession);
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, questionAnswerableToStudent.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-        };
-        GetFeedbackResponsesAction action = getAction(params);
-        UnauthorizedAccessException uae = assertThrows(UnauthorizedAccessException.class, action::checkAccessControl);
-        assertEquals("Trying to access system using a non-existent student entity", uae.getMessage());
-    }
-
-    @Test
-    void testSpecificAccessControl_instructorSubmissionAsStudent_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
-        when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
-                .thenReturn(stubFeedbackSession);
-        when(mockLogic.getFeedbackQuestion(stubFeedbackQuestion.getId())).thenReturn(stubFeedbackQuestion);
-        when(mockLogic.getInstructorByGoogleId(stubCourse.getId(), stubStudent.getGoogleId())).thenReturn(null);
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, stubFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-        };
-        GetFeedbackResponsesAction action = getAction(params);
-        UnauthorizedAccessException uae = assertThrows(UnauthorizedAccessException.class, action::checkAccessControl);
-        assertEquals("Trying to access system using a non-existent instructor entity", uae.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -621,43 +621,6 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
     }
 
     @Test
-    void testSpecificAccessControl_notAnswerableForStudent_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
-        stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-        };
-
-        for (QuestionGiverType type : QuestionGiverType.values()) {
-            if (type == QuestionGiverType.STUDENTS || type == QuestionGiverType.TEAMS) {
-                continue;
-            }
-            spyFeedbackQuestion.setGiverType(type);
-            verifyCannotAccess(params);
-        }
-    }
-
-    @Test
-    void testSpecificAccessControl_notAnswerableForInstructor_cannotAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-        };
-
-        for (QuestionGiverType type : QuestionGiverType.values()) {
-            if (type == QuestionGiverType.INSTRUCTORS || type == QuestionGiverType.SESSION_CREATOR) {
-                continue;
-            }
-            spyFeedbackQuestion.setGiverType(type);
-            verifyCannotAccess(params);
-        }
-    }
-
-    @Test
     void testSpecificAccessControl_instructorWithoutSubmitPrivilege_cannotAccess() {
         loginAsInstructor(stubInstructor.getGoogleId());
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now().minus(Duration.ofDays(2)));


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

This PR removes access control checks related to question answerability and treats them as validation/business-rule checks instead.

Previously, attempts to access or submit responses for questions that were not answerable by the current user type resulted in authorization failures. These cases now return either an appropriate error response or empty content, depending on the endpoint’s expected behavior.

This aligns answerability checks with resource state validation rather than access control. The biggest win here is a simpler access control mental model. Access control is no longer scoped to individual feedback questions.