### PR TITLE
[#13597] Migrate question edit form away from angular animations package

### DIFF
--- a/src/web/app/components/account-requests-table/admin-reject-with-reason-modal/__snapshots__/admin-reject-with-reason-modal.component.spec.ts.snap
+++ b/src/web/app/components/account-requests-table/admin-reject-with-reason-modal/__snapshots__/admin-reject-with-reason-modal.component.spec.ts.snap
@@ -63,9 +63,16 @@ exports[`RejectWithReasonModal > should show empty title and body 1`] = `
         <tm-rich-text-editor
           id="rejection-reason-body"
         >
-          <div
-            inviewport=""
-          >
+          <div>
+            <editor
+              class="editor ng-untouched ng-pristine ng-valid"
+              placeholder=""
+            >
+              <textarea
+                id="tiny-angular_31630362021780208347404"
+                style="visibility: hidden;"
+              />
+            </editor>
           </div>
         </tm-rich-text-editor>
       </div>

--- a/src/web/app/components/account-requests-table/admin-reject-with-reason-modal/__snapshots__/admin-reject-with-reason-modal.component.spec.ts.snap
+++ b/src/web/app/components/account-requests-table/admin-reject-with-reason-modal/__snapshots__/admin-reject-with-reason-modal.component.spec.ts.snap
@@ -69,7 +69,7 @@ exports[`RejectWithReasonModal > should show empty title and body 1`] = `
               placeholder=""
             >
               <textarea
-                id="tiny-angular_31630362021780208347404"
+                id="tinymce-editor-id-1"
                 style="visibility: hidden;"
               />
             </editor>

--- a/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.html
+++ b/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.html
@@ -22,14 +22,16 @@
       </pre>
     </div>
     <div class="col-md-10">
-      <tm-rich-text-editor
-        [richText]="description"
-        (richTextChange)="triggerDescriptionChange($event)"
-        [hasCharacterLimit]="true"
-        [isDisabled]="isDescriptionDisabled"
-        [minHeightInPx]="100"
-        [placeholderText]="'More details about the question e.g. &quot;In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.&quot;'"
-      ></tm-rich-text-editor>
+      @if (shouldRenderDescriptionEditor) {
+        <tm-rich-text-editor
+          [richText]="description"
+          (richTextChange)="triggerDescriptionChange($event)"
+          [hasCharacterLimit]="true"
+          [isDisabled]="isDescriptionDisabled"
+          [minHeightInPx]="100"
+          [placeholderText]="'More details about the question e.g. &quot;In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.&quot;'"
+        ></tm-rich-text-editor>
+      }
     </div>
   </div>
 </div>

--- a/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.ts
+++ b/src/web/app/components/question-edit-brief-description-form/question-edit-brief-description-form.component.ts
@@ -13,6 +13,9 @@ import { RichTextEditorComponent } from '../rich-text-editor/rich-text-editor.co
 })
 export class QuestionEditBriefDescriptionFormComponent {
   @Input()
+  shouldRenderDescriptionEditor = true;
+
+  @Input()
   isBriefDisabled = false;
 
   @Input()

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -118,7 +118,7 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
       </div>
     </button>
     <div
-      class="ng-trigger ng-trigger-collapseAnim ng-animate-queued"
+      class="collapse show"
     >
       <div
         class="card-body"
@@ -180,9 +180,7 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
                         <div
                           inviewport=""
                         >
-                          <div
-                            style=""
-                          >
+                          <div>
                              2000 characters left 
                           </div>
                         </div>
@@ -194,9 +192,7 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
               <div
                 class="padding-15px"
               >
-                <tm-text-question-edit-details-form
-                  style=""
-                >
+                <tm-text-question-edit-details-form>
                   <div
                     class="row padding-15px"
                   >
@@ -267,7 +263,6 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
               >
                 <span
                   class="text-wrap"
-                  style=""
                 >
                    Students in this course will give feedback on 
                   <i
@@ -302,7 +297,6 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
             </div>
             <div
               class="row margin-top-15px align-items-center"
-              style=""
             >
               <div
                 class="offset-1 col-md-4 text-md-end"
@@ -379,9 +373,7 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
                 id="btn-question-visibility"
                 ngbdropdowntoggle=""
               >
-                <span
-                  style=""
-                >
+                <span>
                 </span>
               </button>
               <ul
@@ -397,11 +389,9 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
                 <li
                   aria-hidden="true"
                   class="dropdown-divider"
-                  style=""
                 />
                 <li
                   class="text-wrap dropdown-item"
-                  style=""
                 >
                   <button
                     class="dropdown-button"
@@ -422,9 +412,7 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
               <ul
                 class="text-muted background-color-warning"
               >
-                <li
-                  style=""
-                >
+                <li>
                   No-one can see your responses
                 </li>
               </ul>
@@ -433,7 +421,6 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
         </tm-visibility-panel>
         <div
           class="row margin-top-15px"
-          style=""
         >
           <div
             class="col-12 text-end"

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -177,9 +177,16 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
                       class="col-md-10"
                     >
                       <tm-rich-text-editor>
-                        <div
-                          inviewport=""
-                        >
+                        <div>
+                          <editor
+                            class="editor editor-disabled ng-untouched ng-pristine ng-valid"
+                            placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
+                          >
+                            <textarea
+                              id="tiny-angular_11780460841780208347422"
+                              style="visibility: hidden;"
+                            />
+                          </editor>
                           <div>
                              2000 characters left 
                           </div>

--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -183,7 +183,7 @@ exports[`QuestionEditFormComponent > should snap with default view 1`] = `
                             placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
                           >
                             <textarea
-                              id="tiny-angular_11780460841780208347422"
+                              id="tinymce-editor-id-1"
                               style="visibility: hidden;"
                             />
                           </editor>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -130,6 +130,7 @@
               [description]="model.questionDescription"
               (descriptionChange)="triggerModelChange('questionDescription', $event)"
               [isDescriptionDisabled]="!model.isEditable"
+              [shouldRenderDescriptionEditor]="!model.isCollapsed"
             ></tm-question-edit-brief-description-form>
             <div class="padding-15px">
               @if (model.questionType === FeedbackQuestionType.TEXT) {

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -117,150 +117,147 @@
       </div>
     </div>
   </button>
-  @if (!model.isCollapsed) {
-    <div @collapseAnim>
-      <div class="card-body">
-        <div class="background-color-light-blue">
-          <div class="row">
-            <div class="col-12">
-              <tm-question-edit-brief-description-form
-                [brief]="model.questionBrief"
-                (briefChange)="triggerModelChange('questionBrief', $event)"
-                [isBriefDisabled]="!model.isEditable"
-                [description]="model.questionDescription"
-                (descriptionChange)="triggerModelChange('questionDescription', $event)"
-                [isDescriptionDisabled]="!model.isEditable"
-              ></tm-question-edit-brief-description-form>
-              <div class="padding-15px">
-                @if (model.questionType === FeedbackQuestionType.TEXT) {
-                  <tm-text-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-text-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.CONTRIB) {
-                  <tm-contribution-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-contribution-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.MCQ) {
-                  <tm-mcq-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-mcq-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.MSQ) {
-                  <tm-msq-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-msq-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.NUMSCALE) {
-                  <tm-num-scale-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-num-scale-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.RANK_OPTIONS) {
-                  <tm-rank-options-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-rank-options-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.RANK_RECIPIENTS) {
-                  <tm-rank-recipients-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-rank-recipients-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.RUBRIC) {
-                  <tm-rubric-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                  ></tm-rubric-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS) {
-                  <tm-constsum-options-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                    [questionNumber]="model.questionNumber"
-                  ></tm-constsum-options-question-edit-details-form>
-                }
-                @if (model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS) {
-                  <tm-constsum-recipients-question-edit-details-form
-                    [details]="model.questionDetails"
-                    (detailsChange)="triggerModelChange('questionDetails', $event)"
-                    [isEditable]="model.isEditable"
-                    [questionNumber]="model.questionNumber"
-                  ></tm-constsum-recipients-question-edit-details-form>
-                }
-              </div>
+
+  <div [ngbCollapse]="model.isCollapsed">
+    <div class="card-body">
+      <div class="background-color-light-blue">
+        <div class="row">
+          <div class="col-12">
+            <tm-question-edit-brief-description-form
+              [brief]="model.questionBrief"
+              (briefChange)="triggerModelChange('questionBrief', $event)"
+              [isBriefDisabled]="!model.isEditable"
+              [description]="model.questionDescription"
+              (descriptionChange)="triggerModelChange('questionDescription', $event)"
+              [isDescriptionDisabled]="!model.isEditable"
+            ></tm-question-edit-brief-description-form>
+            <div class="padding-15px">
+              @if (model.questionType === FeedbackQuestionType.TEXT) {
+                <tm-text-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-text-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.CONTRIB) {
+                <tm-contribution-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-contribution-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.MCQ) {
+                <tm-mcq-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-mcq-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.MSQ) {
+                <tm-msq-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-msq-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.NUMSCALE) {
+                <tm-num-scale-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-num-scale-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.RANK_OPTIONS) {
+                <tm-rank-options-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-rank-options-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.RANK_RECIPIENTS) {
+                <tm-rank-recipients-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-rank-recipients-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.RUBRIC) {
+                <tm-rubric-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                ></tm-rubric-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.CONSTSUM_OPTIONS) {
+                <tm-constsum-options-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                  [questionNumber]="model.questionNumber"
+                ></tm-constsum-options-question-edit-details-form>
+              }
+              @if (model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS) {
+                <tm-constsum-recipients-question-edit-details-form
+                  [details]="model.questionDetails"
+                  (detailsChange)="triggerModelChange('questionDetails', $event)"
+                  [isEditable]="model.isEditable"
+                  [questionNumber]="model.questionNumber"
+                ></tm-constsum-recipients-question-edit-details-form>
+              }
             </div>
           </div>
         </div>
-        <tm-feedback-path-panel
-          [model]="model"
-          [commonFeedbackPaths]="commonFeedbackPaths"
-          [allowedFeedbackPaths]="allowedFeedbackPaths"
-          (customFeedbackPath)="triggerModelChange('isUsingOtherFeedbackPath', $event)"
-          (customNumberOfEntitiesToGiveFeedbackTo)="
-            triggerModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)
-          "
-          (numberOfEntitiesToGiveFeedbackToSetting)="
-            triggerModelChange('numberOfEntitiesToGiveFeedbackToSetting', $event)
-          "
-          (triggerModelChangeBatch)="triggerModelChangeBatch($event)"
-        ></tm-feedback-path-panel>
-        <tm-visibility-panel
-          [model]="model"
-          [isCustomFeedbackVisibilitySettingAllowed]="isCustomFeedbackVisibilitySettingAllowed"
-          [commonFeedbackVisibilitySettings]="commonFeedbackVisibilitySettings"
-          (customVisibilitySetting)="triggerModelChange('isUsingOtherVisibilitySetting', $event)"
-          (triggerModelChangeBatch)="triggerModelChangeBatch($event)"
-          [visibilityStateMachine]="visibilityStateMachine"
-        ></tm-visibility-panel>
-        @if (!isDisplayOnly) {
-          <div class="row margin-top-15px">
-            <div class="col-12 text-end">
-              @if (model.isEditable) {
-                <button
-                  type="button"
-                  class="btn btn-light btn-margin-right"
-                  (click)="discardChangesHandler(false)"
-                  [disabled]="model.isSaving || model.isDeleting || model.isDuplicating"
-                >
-                  <i class="fas fa-ban"></i> Cancel
-                </button>
-              }
-              <button
-                class="btn btn-success"
-                [disabled]="!model.isEditable || model.isSaving || model.isDeleting || model.isDuplicating"
-                (click)="saveQuestionHandler()"
-              >
-                @if (model.isSaving) {
-                  <tm-ajax-loading></tm-ajax-loading>
-                }
-                @if (formMode === QuestionEditFormMode.EDIT) {
-                  <span><i class="fas fa-check"></i> Save Changes</span>
-                }
-                @if (formMode === QuestionEditFormMode.ADD) {
-                  <span id="btn-save-new"><i class="fas fa-check"></i> Save Question</span>
-                }
-              </button>
-            </div>
-          </div>
-        }
       </div>
+      <tm-feedback-path-panel
+        [model]="model"
+        [commonFeedbackPaths]="commonFeedbackPaths"
+        [allowedFeedbackPaths]="allowedFeedbackPaths"
+        (customFeedbackPath)="triggerModelChange('isUsingOtherFeedbackPath', $event)"
+        (customNumberOfEntitiesToGiveFeedbackTo)="triggerModelChange('customNumberOfEntitiesToGiveFeedbackTo', $event)"
+        (numberOfEntitiesToGiveFeedbackToSetting)="
+          triggerModelChange('numberOfEntitiesToGiveFeedbackToSetting', $event)
+        "
+        (triggerModelChangeBatch)="triggerModelChangeBatch($event)"
+      ></tm-feedback-path-panel>
+      <tm-visibility-panel
+        [model]="model"
+        [isCustomFeedbackVisibilitySettingAllowed]="isCustomFeedbackVisibilitySettingAllowed"
+        [commonFeedbackVisibilitySettings]="commonFeedbackVisibilitySettings"
+        (customVisibilitySetting)="triggerModelChange('isUsingOtherVisibilitySetting', $event)"
+        (triggerModelChangeBatch)="triggerModelChangeBatch($event)"
+        [visibilityStateMachine]="visibilityStateMachine"
+      ></tm-visibility-panel>
+      @if (!isDisplayOnly) {
+        <div class="row margin-top-15px">
+          <div class="col-12 text-end">
+            @if (model.isEditable) {
+              <button
+                type="button"
+                class="btn btn-light btn-margin-right"
+                (click)="discardChangesHandler(false)"
+                [disabled]="model.isSaving || model.isDeleting || model.isDuplicating"
+              >
+                <i class="fas fa-ban"></i> Cancel
+              </button>
+            }
+            <button
+              class="btn btn-success"
+              [disabled]="!model.isEditable || model.isSaving || model.isDeleting || model.isDuplicating"
+              (click)="saveQuestionHandler()"
+            >
+              @if (model.isSaving) {
+                <tm-ajax-loading></tm-ajax-loading>
+              }
+              @if (formMode === QuestionEditFormMode.EDIT) {
+                <span><i class="fas fa-check"></i> Save Changes</span>
+              }
+              @if (formMode === QuestionEditFormMode.ADD) {
+                <span id="btn-save-new"><i class="fas fa-check"></i> Save Question</span>
+              }
+            </button>
+          </div>
+        </div>
+      }
     </div>
-  }
+  </div>
 </div>

--- a/src/web/app/components/question-edit-form/question-edit-form.component.spec.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.spec.ts
@@ -1,7 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { QuestionEditFormModel } from './question-edit-form-model';
 import { QuestionEditFormComponent } from './question-edit-form.component';
 import { EXAMPLE_ESSAY_QUESTION_MODEL } from '../../pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data';
@@ -12,7 +11,6 @@ describe('QuestionEditFormComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule],
       providers: [provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 

--- a/src/web/app/components/question-edit-form/question-edit-form.component.ts
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.ts
@@ -29,9 +29,9 @@ import { RankRecipientsQuestionEditDetailsFormComponent } from '../question-type
 import { RubricQuestionEditDetailsFormComponent } from '../question-types/question-edit-details-form/rubric-question-edit-details-form.component';
 import { TextQuestionEditDetailsFormComponent } from '../question-types/question-edit-details-form/text-question-edit-details-form.component';
 import { SimpleModalType } from '../simple-modal/simple-modal-type';
-import { collapseAnim } from '../teammates-common/collapse-anim';
 import { QuestionTypeNamePipe } from '../teammates-common/question-type-name.pipe';
 import { VisibilityPanelComponent } from '../visibility-panel/visibility-panel.component';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 const FEEDBACK_PATH_PROPERTIES: Set<string> = new Set<string>([
   'giverType',
@@ -61,12 +61,12 @@ const QUESTION_DETAIL_PROPERTIES: Set<string> = new Set<string>([
   selector: 'tm-question-edit-form',
   templateUrl: './question-edit-form.component.html',
   styleUrls: ['./question-edit-form.component.scss'],
-  animations: [collapseAnim],
   imports: [
     PanelChevronComponent,
     FormsModule,
     AjaxLoadingComponent,
     NgbTooltip,
+    NgbCollapse,
     QuestionEditBriefDescriptionFormComponent,
     TextQuestionEditDetailsFormComponent,
     ContributionQuestionEditDetailsFormComponent,

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.html
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.html
@@ -2,6 +2,7 @@
   <editor
     class="editor"
     [ngClass]="{ 'editor-disabled': isDisabled }"
+    [readonly]="isDisabled"
     [init]="init"
     [ngModel]="richText"
     (ngModelChange)="richTextChange.emit($event)"

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.html
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.html
@@ -1,15 +1,12 @@
-<div inViewport (inViewportAction)="renderEditor($event)">
-  @if (render()) {
-    <editor
-      class="editor"
-      [ngClass]="{ 'editor-disabled': isDisabled }"
-      [init]="init"
-      [ngModel]="richText"
-      (ngModelChange)="richTextChange.emit($event)"
-      [attr.placeholder]="placeholderText"
-    >
-    </editor>
-  }
+<div>
+  <editor
+    class="editor"
+    [ngClass]="{ 'editor-disabled': isDisabled }"
+    [init]="init"
+    [ngModel]="richText"
+    (ngModelChange)="richTextChange.emit($event)"
+    [attr.placeholder]="placeholderText"
+  />
   @if (hasCharacterLimit) {
     <div>
       {{

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.spec.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.spec.ts
@@ -52,18 +52,6 @@ describe('RichTextEditorComponent', () => {
     expect(component.getCurrentCharacterCount(mockEditor)).toBe(123);
   });
 
-  it('should render editor when visible', () => {
-    component.render.set(false);
-    component.renderEditor({ visible: true });
-    expect(component.render()).toBe(true);
-  });
-
-  it('should not render editor when not visible', () => {
-    component.render.set(false);
-    component.renderEditor({ visible: false });
-    expect(component.render()).toBe(false);
-  });
-
   it('should define setup function when character limit is enabled', () => {
     component.hasCharacterLimit = true;
     component.ngOnInit();

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -12,7 +12,6 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { EditorComponent, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
-import { DestroyableDirective, InViewportDirective } from 'ng-in-viewport';
 import { Editor, EditorEvent, RawEditorOptions } from 'tinymce';
 
 const RICH_TEXT_EDITOR_MAX_CHARACTER_LENGTH = 2000;
@@ -24,7 +23,7 @@ const RICH_TEXT_EDITOR_MAX_CHARACTER_LENGTH = 2000;
   selector: 'tm-rich-text-editor',
   templateUrl: './rich-text-editor.component.html',
   styleUrls: ['./rich-text-editor.component.scss'],
-  imports: [DestroyableDirective, InViewportDirective, EditorComponent, NgClass, FormsModule],
+  imports: [EditorComponent, NgClass, FormsModule],
   providers: [{ provide: TINYMCE_SCRIPT_SRC, useValue: '/tinymce/tinymce.min.js' }],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -55,7 +54,6 @@ export class RichTextEditorComponent implements OnInit, OnChanges {
   // the argument passed to tinymce.init() in native JavaScript
   init: RawEditorOptions = {};
 
-  render = signal(false);
   private editorInstance?: Editor;
 
   defaultToolbar: string =
@@ -174,13 +172,5 @@ export class RichTextEditorComponent implements OnInit, OnChanges {
     const wordCountApi = editor.plugins['wordcount'];
     const currentCharacterCount = wordCountApi['body'].getCharacterCount();
     return currentCharacterCount;
-  }
-
-  renderEditor(event: any): void {
-    // If the editor has not been rendered before, render it once it gets into the viewport
-    // However, do not destroy it when it gets out of the viewport
-    if (event.visible && !this.render()) {
-      this.render.set(true);
-    }
   }
 }

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -4,10 +4,8 @@ import {
   Component,
   EventEmitter,
   Input,
-  OnChanges,
   OnInit,
   Output,
-  SimpleChanges,
   signal,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -27,7 +25,7 @@ const RICH_TEXT_EDITOR_MAX_CHARACTER_LENGTH = 2000;
   providers: [{ provide: TINYMCE_SCRIPT_SRC, useValue: '/tinymce/tinymce.min.js' }],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RichTextEditorComponent implements OnInit, OnChanges {
+export class RichTextEditorComponent implements OnInit {
   // const
   RICH_TEXT_EDITOR_MAX_CHARACTER_LENGTH: number = RICH_TEXT_EDITOR_MAX_CHARACTER_LENGTH;
 
@@ -54,8 +52,6 @@ export class RichTextEditorComponent implements OnInit, OnChanges {
   // the argument passed to tinymce.init() in native JavaScript
   init: RawEditorOptions = {};
 
-  private editorInstance?: Editor;
-
   defaultToolbar: string =
     'styles | forecolor backcolor ' +
     '| bold italic underline strikethrough subscript superscript ' +
@@ -64,12 +60,6 @@ export class RichTextEditorComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.init = this.getEditorSettings();
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['isDisabled']) {
-      this.editorInstance?.mode.set(this.isDisabled ? 'readonly' : 'design');
-    }
   }
 
   private getEditorSettings(): RawEditorOptions {
@@ -112,11 +102,6 @@ export class RichTextEditorComponent implements OnInit, OnChanges {
 
       toolbar1: this.defaultToolbar,
       setup: (editor: Editor) => {
-        this.editorInstance = editor;
-        editor.on('init', () => {
-          this.editorInstance?.mode.set(this.isDisabled ? 'readonly' : 'design');
-        });
-
         if (this.hasCharacterLimit) {
           editor.on('GetContent', () => {
             queueMicrotask(() => {

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -1,13 +1,5 @@
 import { NgClass } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { EditorComponent, TINYMCE_SCRIPT_SRC } from '@tinymce/tinymce-angular';
 import { Editor, EditorEvent, RawEditorOptions } from 'tinymce';

--- a/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
@@ -233,7 +233,7 @@ exports[`AdminNotificationsPageComponent > should snap when notification edit fo
                         placeholder=""
                       >
                         <textarea
-                          id="tiny-angular_6687151751780208347613"
+                          id="tinymce-editor-id-1"
                           style="visibility: hidden;"
                         />
                       </editor>
@@ -914,7 +914,7 @@ exports[`AdminNotificationsPageComponent > should snap when notifications are lo
                         placeholder=""
                       >
                         <textarea
-                          id="tiny-angular_78325958331780208347518"
+                          id="tinymce-editor-id-1"
                           style="visibility: hidden;"
                         />
                       </editor>
@@ -1602,7 +1602,7 @@ exports[`AdminNotificationsPageComponent > should snap when notifications failed
                         placeholder=""
                       >
                         <textarea
-                          id="tiny-angular_27988381741780208347569"
+                          id="tinymce-editor-id-1"
                           style="visibility: hidden;"
                         />
                       </editor>
@@ -2288,7 +2288,7 @@ exports[`AdminNotificationsPageComponent > should snap with default view 1`] = `
                         placeholder=""
                       >
                         <textarea
-                          id="tiny-angular_27405392421780208347462"
+                          id="tinymce-editor-id-1"
                           style="visibility: hidden;"
                         />
                       </editor>

--- a/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
@@ -227,9 +227,16 @@ exports[`AdminNotificationsPageComponent > should snap when notification edit fo
                   <tm-rich-text-editor
                     id="notification-message"
                   >
-                    <div
-                      inviewport=""
-                    >
+                    <div>
+                      <editor
+                        class="editor ng-untouched ng-pristine ng-valid"
+                        placeholder=""
+                      >
+                        <textarea
+                          id="tiny-angular_6687151751780208347613"
+                          style="visibility: hidden;"
+                        />
+                      </editor>
                     </div>
                   </tm-rich-text-editor>
                 </div>
@@ -901,9 +908,16 @@ exports[`AdminNotificationsPageComponent > should snap when notifications are lo
                   <tm-rich-text-editor
                     id="notification-message"
                   >
-                    <div
-                      inviewport=""
-                    >
+                    <div>
+                      <editor
+                        class="editor ng-untouched ng-pristine ng-valid"
+                        placeholder=""
+                      >
+                        <textarea
+                          id="tiny-angular_78325958331780208347518"
+                          style="visibility: hidden;"
+                        />
+                      </editor>
                     </div>
                   </tm-rich-text-editor>
                 </div>
@@ -1582,9 +1596,16 @@ exports[`AdminNotificationsPageComponent > should snap when notifications failed
                   <tm-rich-text-editor
                     id="notification-message"
                   >
-                    <div
-                      inviewport=""
-                    >
+                    <div>
+                      <editor
+                        class="editor ng-untouched ng-pristine ng-valid"
+                        placeholder=""
+                      >
+                        <textarea
+                          id="tiny-angular_27988381741780208347569"
+                          style="visibility: hidden;"
+                        />
+                      </editor>
                     </div>
                   </tm-rich-text-editor>
                 </div>
@@ -2261,9 +2282,16 @@ exports[`AdminNotificationsPageComponent > should snap with default view 1`] = `
                   <tm-rich-text-editor
                     id="notification-message"
                   >
-                    <div
-                      inviewport=""
-                    >
+                    <div>
+                      <editor
+                        class="editor ng-untouched ng-pristine ng-valid"
+                        placeholder=""
+                      >
+                        <textarea
+                          id="tiny-angular_27405392421780208347462"
+                          style="visibility: hidden;"
+                        />
+                      </editor>
                     </div>
                   </tm-rich-text-editor>
                 </div>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/__snapshots__/notification-edit-form.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/__snapshots__/notification-edit-form.component.spec.ts.snap
@@ -221,7 +221,7 @@ exports[`NotificationEditFormComponent > should snap with default view 1`] = `
                     placeholder=""
                   >
                     <textarea
-                      id="tiny-angular_91560566621780208347448"
+                      id="tinymce-editor-id-1"
                       style="visibility: hidden;"
                     />
                   </editor>
@@ -882,7 +882,7 @@ exports[`NotificationEditFormComponent > should snap with notification 1`] = `
                     placeholder=""
                   >
                     <textarea
-                      id="tiny-angular_13263393531780208347505"
+                      id="tinymce-editor-id-1"
                       style="visibility: hidden;"
                     />
                   </editor>
@@ -1543,7 +1543,7 @@ exports[`NotificationEditFormComponent > should snap with notification that has 
                     placeholder=""
                   >
                     <textarea
-                      id="tiny-angular_86760945941780208347550"
+                      id="tinymce-editor-id-1"
                       style="visibility: hidden;"
                     />
                   </editor>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/__snapshots__/notification-edit-form.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/__snapshots__/notification-edit-form.component.spec.ts.snap
@@ -215,9 +215,16 @@ exports[`NotificationEditFormComponent > should snap with default view 1`] = `
               <tm-rich-text-editor
                 id="notification-message"
               >
-                <div
-                  inviewport=""
-                >
+                <div>
+                  <editor
+                    class="editor ng-untouched ng-pristine ng-valid"
+                    placeholder=""
+                  >
+                    <textarea
+                      id="tiny-angular_91560566621780208347448"
+                      style="visibility: hidden;"
+                    />
+                  </editor>
                 </div>
               </tm-rich-text-editor>
             </div>
@@ -869,9 +876,16 @@ exports[`NotificationEditFormComponent > should snap with notification 1`] = `
               <tm-rich-text-editor
                 id="notification-message"
               >
-                <div
-                  inviewport=""
-                >
+                <div>
+                  <editor
+                    class="editor ng-untouched ng-pristine ng-valid"
+                    placeholder=""
+                  >
+                    <textarea
+                      id="tiny-angular_13263393531780208347505"
+                      style="visibility: hidden;"
+                    />
+                  </editor>
                 </div>
               </tm-rich-text-editor>
             </div>
@@ -1523,9 +1537,16 @@ exports[`NotificationEditFormComponent > should snap with notification that has 
               <tm-rich-text-editor
                 id="notification-message"
               >
-                <div
-                  inviewport=""
-                >
+                <div>
+                  <editor
+                    class="editor ng-untouched ng-pristine ng-valid"
+                    placeholder=""
+                  >
+                    <textarea
+                      id="tiny-angular_86760945941780208347550"
+                      style="visibility: hidden;"
+                    />
+                  </editor>
                 </div>
               </tm-rich-text-editor>
             </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -705,7 +705,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         placeholder=""
                       >
                         <textarea
-                          id="tiny-angular_65386273711780208347580"
+                          id="tinymce-editor-id-1"
                           style="visibility: hidden;"
                         />
                       </editor>
@@ -2079,7 +2079,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                                     placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
                                   >
                                     <textarea
-                                      id="tiny-angular_95694342821780208347599"
+                                      id="tinymce-editor-id-2"
                                       style="visibility: hidden;"
                                     />
                                   </editor>
@@ -2795,7 +2795,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                                     placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
                                   >
                                     <textarea
-                                      id="tiny-angular_31324994731780208347606"
+                                      id="tinymce-editor-id-1"
                                       style="visibility: hidden;"
                                     />
                                   </editor>
@@ -3941,7 +3941,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                         placeholder=""
                       >
                         <textarea
-                          id="tiny-angular_29806889541780208347757"
+                          id="tinymce-editor-id-1"
                           style="visibility: hidden;"
                         />
                       </editor>
@@ -5278,7 +5278,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                                 placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
                               >
                                 <textarea
-                                  id="tiny-angular_7799952851780208347763"
+                                  id="tinymce-editor-id-1"
                                   style="visibility: hidden;"
                                 />
                               </editor>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -699,9 +699,16 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                   <tm-rich-text-editor
                     id="instructions"
                   >
-                    <div
-                      inviewport=""
-                    >
+                    <div>
+                      <editor
+                        class="editor editor-disabled ng-untouched ng-pristine ng-valid"
+                        placeholder=""
+                      >
+                        <textarea
+                          id="tiny-angular_65386273711780208347580"
+                          style="visibility: hidden;"
+                        />
+                      </editor>
                       <div>
                          2000 characters left 
                       </div>
@@ -2066,9 +2073,16 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                               class="col-md-10"
                             >
                               <tm-rich-text-editor>
-                                <div
-                                  inviewport=""
-                                >
+                                <div>
+                                  <editor
+                                    class="editor ng-untouched ng-pristine ng-valid"
+                                    placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
+                                  >
+                                    <textarea
+                                      id="tiny-angular_95694342821780208347599"
+                                      style="visibility: hidden;"
+                                    />
+                                  </editor>
                                   <div>
                                      2000 characters left 
                                   </div>
@@ -2775,9 +2789,16 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                               class="col-md-10"
                             >
                               <tm-rich-text-editor>
-                                <div
-                                  inviewport=""
-                                >
+                                <div>
+                                  <editor
+                                    class="editor ng-untouched ng-pristine ng-valid"
+                                    placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
+                                  >
+                                    <textarea
+                                      id="tiny-angular_31324994731780208347606"
+                                      style="visibility: hidden;"
+                                    />
+                                  </editor>
                                   <div>
                                      2000 characters left 
                                   </div>
@@ -3914,9 +3935,16 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                   <tm-rich-text-editor
                     id="instructions"
                   >
-                    <div
-                      inviewport=""
-                    >
+                    <div>
+                      <editor
+                        class="editor editor-disabled ng-untouched ng-pristine ng-valid"
+                        placeholder=""
+                      >
+                        <textarea
+                          id="tiny-angular_29806889541780208347757"
+                          style="visibility: hidden;"
+                        />
+                      </editor>
                       <div>
                          2000 characters left 
                       </div>
@@ -5244,9 +5272,16 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                           class="col-md-10"
                         >
                           <tm-rich-text-editor>
-                            <div
-                              inviewport=""
-                            >
+                            <div>
+                              <editor
+                                class="editor ng-untouched ng-pristine ng-valid"
+                                placeholder="More details about the question e.g. "In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.""
+                              >
+                                <textarea
+                                  id="tiny-angular_7799952851780208347763"
+                                  style="visibility: hidden;"
+                                />
+                              </editor>
                               <div>
                                  2000 characters left 
                               </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/__snapshots__/instructor-session-edit-page.component.spec.ts.snap
@@ -2008,7 +2008,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
               </div>
             </button>
             <div
-              class="ng-trigger ng-trigger-collapseAnim ng-animate-queued"
+              class="collapse show"
             >
               <div
                 class="card-body"
@@ -2069,9 +2069,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                                 <div
                                   inviewport=""
                                 >
-                                  <div
-                                    style=""
-                                  >
+                                  <div>
                                      2000 characters left 
                                   </div>
                                 </div>
@@ -2083,9 +2081,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       <div
                         class="padding-15px"
                       >
-                        <tm-text-question-edit-details-form
-                          style=""
-                        >
+                        <tm-text-question-edit-details-form>
                           <div
                             class="row padding-15px"
                           >
@@ -2153,7 +2149,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       >
                         <span
                           class="text-wrap"
-                          style=""
                         >
                            Students in this course will give feedback on 
                           <i
@@ -2174,7 +2169,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           ngbdropdown=""
-                          style=""
                         >
                           <div
                             class="text-wrap dropdown-item"
@@ -2191,7 +2185,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           ngbdropdown=""
-                          style=""
                         >
                           <div
                             class="text-wrap dropdown-item"
@@ -2208,7 +2201,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           ngbdropdown=""
-                          style=""
                         >
                           <div
                             class="text-wrap dropdown-item"
@@ -2239,7 +2231,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                     </div>
                     <div
                       class="row margin-top-15px align-items-center"
-                      style=""
                     >
                       <div
                         class="offset-1 col-md-4 text-md-end"
@@ -2312,9 +2303,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         id="btn-question-visibility"
                         ngbdropdowntoggle=""
                       >
-                        <span
-                          style=""
-                        >
+                        <span>
                           Custom visibility options
                         </span>
                       </button>
@@ -2330,7 +2319,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -2340,7 +2328,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -2350,7 +2337,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -2360,7 +2346,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -2370,7 +2355,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -2381,11 +2365,9 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         <li
                           aria-hidden="true"
                           class="dropdown-divider"
-                          style=""
                         />
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -2401,7 +2383,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       <table
                         aria-label="Custom Visibility Options Table"
                         class="table margin-top-15px background-color-white table-striped"
-                        style=""
                       >
                         <thead>
                           <tr>
@@ -2581,14 +2562,10 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       <ul
                         class="text-muted background-color-warning"
                       >
-                        <li
-                          style=""
-                        >
+                        <li>
                            Your team members can see your response, but not the name of the recipient, or your name 
                         </li>
-                        <li
-                          style=""
-                        >
+                        <li>
                            Instructors in this course can see your response, but not the name of the recipient, or your name 
                         </li>
                       </ul>
@@ -2597,7 +2574,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                 </tm-visibility-panel>
                 <div
                   class="row margin-top-15px"
-                  style=""
                 >
                   <div
                     class="col-12 text-end"
@@ -2741,7 +2717,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
               </div>
             </button>
             <div
-              class="ng-trigger ng-trigger-collapseAnim ng-animate-queued"
+              class="collapse show"
             >
               <div
                 class="card-body"
@@ -2802,9 +2778,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                                 <div
                                   inviewport=""
                                 >
-                                  <div
-                                    style=""
-                                  >
+                                  <div>
                                      2000 characters left 
                                   </div>
                                 </div>
@@ -2816,9 +2790,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       <div
                         class="padding-15px"
                       >
-                        <tm-text-question-edit-details-form
-                          style=""
-                        >
+                        <tm-text-question-edit-details-form>
                           <div
                             class="row padding-15px"
                           >
@@ -2886,7 +2858,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       >
                         <span
                           class="text-wrap"
-                          style=""
                         >
                            Students in this course will give feedback on 
                           <i
@@ -2907,7 +2878,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           ngbdropdown=""
-                          style=""
                         >
                           <div
                             class="text-wrap dropdown-item"
@@ -2924,7 +2894,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           ngbdropdown=""
-                          style=""
                         >
                           <div
                             class="text-wrap dropdown-item"
@@ -2941,7 +2910,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           ngbdropdown=""
-                          style=""
                         >
                           <div
                             class="text-wrap dropdown-item"
@@ -2972,7 +2940,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                     </div>
                     <div
                       class="row margin-top-15px align-items-center"
-                      style=""
                     >
                       <div
                         class="offset-1 col-md-4 text-md-end"
@@ -3045,9 +3012,7 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         id="btn-question-visibility"
                         ngbdropdowntoggle=""
                       >
-                        <span
-                          style=""
-                        >
+                        <span>
                           Custom visibility options
                         </span>
                       </button>
@@ -3063,7 +3028,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -3073,7 +3037,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -3083,7 +3046,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -3093,7 +3055,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -3103,7 +3064,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         </li>
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -3114,11 +3074,9 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                         <li
                           aria-hidden="true"
                           class="dropdown-divider"
-                          style=""
                         />
                         <li
                           class="text-wrap dropdown-item"
-                          style=""
                         >
                           <button
                             class="dropdown-button"
@@ -3134,7 +3092,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       <table
                         aria-label="Custom Visibility Options Table"
                         class="table margin-top-15px background-color-white table-striped"
-                        style=""
                       >
                         <thead>
                           <tr>
@@ -3314,14 +3271,10 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                       <ul
                         class="text-muted background-color-warning"
                       >
-                        <li
-                          style=""
-                        >
+                        <li>
                            Your team members can see your response, but not the name of the recipient, or your name 
                         </li>
-                        <li
-                          style=""
-                        >
+                        <li>
                            Instructors in this course can see your response, but not the name of the recipient, or your name 
                         </li>
                       </ul>
@@ -3330,7 +3283,6 @@ exports[`InstructorSessionEditPageComponent > should snap with feedback session 
                 </tm-visibility-panel>
                 <div
                   class="row margin-top-15px"
-                  style=""
                 >
                   <div
                     class="col-12 text-end"
@@ -5234,7 +5186,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
           </div>
         </button>
         <div
-          class="ng-trigger ng-trigger-collapseAnim ng-animate-queued"
+          class="collapse show"
         >
           <div
             class="card-body"
@@ -5295,9 +5247,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                             <div
                               inviewport=""
                             >
-                              <div
-                                style=""
-                              >
+                              <div>
                                  2000 characters left 
                               </div>
                             </div>
@@ -5309,9 +5259,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                   <div
                     class="padding-15px"
                   >
-                    <tm-text-question-edit-details-form
-                      style=""
-                    >
+                    <tm-text-question-edit-details-form>
                       <div
                         class="row padding-15px"
                       >
@@ -5377,9 +5325,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     id="btn-feedback-path"
                     ngbdropdowntoggle=""
                   >
-                    <span
-                      style=""
-                    >
+                    <span>
                       Custom feedback path
                     </span>
                   </button>
@@ -5395,7 +5341,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       ngbdropdown=""
-                      style=""
                     >
                       <div
                         class="text-wrap dropdown-item"
@@ -5412,7 +5357,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       ngbdropdown=""
-                      style=""
                     >
                       <div
                         class="text-wrap dropdown-item"
@@ -5429,7 +5373,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       ngbdropdown=""
-                      style=""
                     >
                       <div
                         class="text-wrap dropdown-item"
@@ -5460,7 +5403,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                 </div>
                 <div
                   class="row margin-top-15px"
-                  style=""
                 >
                   <div
                     class="col-sm-6 mb-2 mb-sm-0"
@@ -5601,7 +5543,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                 </div>
                 <div
                   class="row margin-top-15px align-items-center"
-                  style=""
                 >
                   <div
                     class="offset-1 col-md-4 text-md-end"
@@ -5674,9 +5615,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     id="btn-question-visibility"
                     ngbdropdowntoggle=""
                   >
-                    <span
-                      style=""
-                    >
+                    <span>
                       Custom visibility options
                     </span>
                   </button>
@@ -5692,7 +5631,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5702,7 +5640,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5712,7 +5649,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5722,7 +5658,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5732,7 +5667,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5742,7 +5676,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     </li>
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5753,11 +5686,9 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                     <li
                       aria-hidden="true"
                       class="dropdown-divider"
-                      style=""
                     />
                     <li
                       class="text-wrap dropdown-item"
-                      style=""
                     >
                       <button
                         class="dropdown-button"
@@ -5773,7 +5704,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                   <table
                     aria-label="Custom Visibility Options Table"
                     class="table margin-top-15px background-color-white table-striped"
-                    style=""
                   >
                     <thead>
                       <tr>
@@ -5987,9 +5917,7 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
                   <ul
                     class="text-muted background-color-warning"
                   >
-                    <li
-                      style=""
-                    >
+                    <li>
                       No-one can see your responses
                     </li>
                   </ul>
@@ -5998,7 +5926,6 @@ exports[`InstructorSessionEditPageComponent > should snap with new question adde
             </tm-visibility-panel>
             <div
               class="row margin-top-15px"
-              style=""
             >
               <div
                 class="col-12 text-end"

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -311,7 +311,7 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_739336695151780208348152"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>
@@ -1844,7 +1844,7 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_781007650141780208348082"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>
@@ -3377,7 +3377,7 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_313902890161780208348220"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>
@@ -4891,7 +4891,7 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_593494531171780208348285"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>
@@ -6428,7 +6428,7 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_49422812181780208348369"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>
@@ -7961,7 +7961,7 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_134009715131780208348008"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>
@@ -9494,7 +9494,7 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
                           placeholder=""
                         >
                           <textarea
-                            id="tiny-angular_571941040121780208347930"
+                            id="tinymce-editor-id-1"
                             style="visibility: hidden;"
                           />
                         </editor>

--- a/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-sessions-page/__snapshots__/instructor-sessions-page.component.spec.ts.snap
@@ -305,9 +305,16 @@ exports[`InstructorSessionsPageComponent > should snap when courses are loading 
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_739336695151780208348152"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>
@@ -1831,9 +1838,16 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions ar
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_781007650141780208348082"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>
@@ -3357,9 +3371,16 @@ exports[`InstructorSessionsPageComponent > should snap when feedback sessions fa
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_313902890161780208348220"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>
@@ -4864,9 +4885,16 @@ exports[`InstructorSessionsPageComponent > should snap when new session form is 
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_593494531171780208348285"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>
@@ -6394,9 +6422,16 @@ exports[`InstructorSessionsPageComponent > should snap when recycle bin section 
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_49422812181780208348369"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>
@@ -7920,9 +7955,16 @@ exports[`InstructorSessionsPageComponent > should snap with active sessions 1`] 
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_134009715131780208348008"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>
@@ -9446,9 +9488,16 @@ exports[`InstructorSessionsPageComponent > should snap with default fields 1`] =
                     <tm-rich-text-editor
                       id="instructions"
                     >
-                      <div
-                        inviewport=""
-                      >
+                      <div>
+                        <editor
+                          class="editor ng-untouched ng-pristine ng-valid"
+                          placeholder=""
+                        >
+                          <textarea
+                            id="tiny-angular_571941040121780208347930"
+                            style="visibility: hidden;"
+                          />
+                        </editor>
                         <div>
                            2000 characters left 
                         </div>

--- a/src/web/test-helpers/serializers/tinymce-id-normalizer.serializer.ts
+++ b/src/web/test-helpers/serializers/tinymce-id-normalizer.serializer.ts
@@ -1,0 +1,49 @@
+import type { SnapshotSerializer } from 'vitest';
+
+const TINYMCE_ID_PREFIX = 'tiny-angular_';
+const NORMALIZED_ID_PREFIX = 'tinymce-editor-id-';
+
+function walkElements(root: Element, visitor: (element: Element) => void): void {
+  const stack: Element[] = [root];
+  while (stack.length > 0) {
+    const element = stack.pop()!;
+    visitor(element);
+    stack.push(...Array.from(element.children));
+  }
+}
+
+const serializer: SnapshotSerializer = {
+  test: (val): boolean => {
+    if (typeof Element === 'undefined' || !(val instanceof Element)) {
+      return false;
+    }
+
+    let foundTinyMceId = false;
+    walkElements(val, (element) => {
+      if (element.id.startsWith(TINYMCE_ID_PREFIX)) {
+        foundTinyMceId = true;
+      }
+    });
+    return foundTinyMceId;
+  },
+  serialize: (val, config, indentation, depth, refs, printer): string => {
+    const normalized = (val as Element).cloneNode(true) as Element;
+    const idMap = new Map<string, string>();
+    let nextId = 1;
+
+    walkElements(normalized, (element) => {
+      if (!element.id.startsWith(TINYMCE_ID_PREFIX)) {
+        return;
+      }
+      if (!idMap.has(element.id)) {
+        idMap.set(element.id, `${NORMALIZED_ID_PREFIX}${nextId}`);
+        nextId += 1;
+      }
+      element.id = idMap.get(element.id)!;
+    });
+
+    return printer(normalized, config, indentation, depth, refs);
+  },
+};
+
+export default serializer;

--- a/src/web/test-helpers/setup-vitest.ts
+++ b/src/web/test-helpers/setup-vitest.ts
@@ -1,3 +1,6 @@
+import { expect } from 'vitest';
+import tinyMceIdNormalizerSerializer from './serializers/tinymce-id-normalizer.serializer';
+
 class MockIntersectionObserver implements IntersectionObserver {
   readonly root: Element | Document | null = null;
   readonly rootMargin = '';
@@ -21,3 +24,5 @@ class MockResizeObserver implements ResizeObserver {
 }
 
 globalThis.ResizeObserver = MockResizeObserver;
+
+expect.addSnapshotSerializer(tinyMceIdNormalizerSerializer);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13597

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

As per title. Also removed lazy loading of rich text boxes, simplified rich text editor and hide it when collapsed. This fixes a few bugs around stale state of editor that causes it to be permanently disabled when question number is changed.