### PR TITLE
[#13721] Support submitting feedback responses for multiple questions in a single request

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/FeedbackSubmitPage.java
@@ -111,6 +111,7 @@ public class FeedbackSubmitPage extends AppPage {
 
     public void verifyWarningMessageForPartialResponse(int[] unansweredQuestions) {
         click(getSubmitAllQuestionsButton());
+        waitForPageToLoad();
         StringBuilder expectedSb = new StringBuilder();
         for (int unansweredQuestion : unansweredQuestions) {
             expectedSb.append(unansweredQuestion).append(", ");

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -178,7 +178,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
     }
 
     private List<String> extractStudentTeams(List<Student> students) {
-        return students.stream().map(Student::getTeamName).toList();
+        return students.stream().map(Student::getTeamName).distinct().toList();
     }
 
     private FeedbackResponsesRequest buildRequestBodyWithStudentRecipientsEmail(
@@ -240,10 +240,9 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private void validateOutputForStudentRecipientsByTeam(List<FeedbackResponseData> responses, String giverTeam,
                                                           List<Student> recipients) {
-        int responsesSize = responses.size();
-        assertEquals(recipients.size(), responsesSize);
-
         List<String> recipientTeams = extractStudentTeams(recipients);
+        int responsesSize = responses.size();
+        assertEquals(recipientTeams.size(), responsesSize);
 
         validateOutput(responses, giverTeam, recipientTeams);
     }

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -152,7 +152,9 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private String[] buildSubmissionParams(FeedbackQuestion question, Intent intent) {
         currentQuestionForSubmission = question;
-        String sessionId = question != null ? question.getFeedbackSession().getId().toString() : UUID.randomUUID().toString();
+        String sessionId = question != null
+                ? question.getFeedbackSession().getId().toString()
+                : UUID.randomUUID().toString();
 
         return new String[] {Const.ParamsNames.FEEDBACK_SESSION_ID, sessionId, Const.ParamsNames.INTENT,
                 intent.toString()};

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -6,7 +6,9 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.testng.annotations.BeforeMethod;
@@ -42,6 +44,7 @@ import teammates.ui.webapi.SubmitFeedbackResponsesAction;
  */
 public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedbackResponsesAction> {
     private DataBundle typicalBundle;
+    private FeedbackQuestion currentQuestionForSubmission;
 
     @Override
     @BeforeMethod
@@ -148,9 +151,10 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
     }
 
     private String[] buildSubmissionParams(FeedbackQuestion question, Intent intent) {
-        String questionId = question != null ? question.getId().toString() : "";
+        currentQuestionForSubmission = question;
+        String sessionId = question != null ? question.getFeedbackSession().getId().toString() : UUID.randomUUID().toString();
 
-        return new String[] {Const.ParamsNames.FEEDBACK_QUESTION_ID, questionId, Const.ParamsNames.INTENT,
+        return new String[] {Const.ParamsNames.FEEDBACK_SESSION_ID, sessionId, Const.ParamsNames.INTENT,
                 intent.toString()};
     }
 
@@ -209,11 +213,12 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         }
 
         FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        requestBody.setQuestionResponses(Map.of(currentQuestionForSubmission.getId(), responses));
         return requestBody;
     }
 
-    private List<FeedbackResponseData> callExecute(FeedbackResponsesRequest requestBody, String[] submissionParams) {
+    private List<FeedbackResponseData> callExecute(FeedbackResponsesRequest requestBody,
+                                                   String[] submissionParams) {
         SubmitFeedbackResponsesAction action = getAction(requestBody, submissionParams);
         JsonResult result = getJsonResult(action);
 
@@ -356,24 +361,25 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
         verifyHttpParameterFailureAcl(submissionParams);
 
-        ______TS("Failure with instructors: feedback question does not exist");
+        ______TS("Failure with instructors: feedback session does not exist");
         setStartTime(session, -1);
         setEndTime(session, 3);
 
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000"};
+                Const.ParamsNames.FEEDBACK_SESSION_ID, "00000000-0000-0000-0000-000000000000"};
 
         verifyEntityNotFoundAcl(submissionParams);
 
-        ______TS("Failure with students: no feedback question parameter");
+        ______TS("Failure with students: no feedback session parameter");
         loginStudent("student1InCourse1");
         setStartTime(session, -1);
         setEndTime(session, 3);
 
         questionNumber = 2;
         FeedbackQuestion question = getQuestion(session, questionNumber);
-        submissionParams = new String[] {Const.ParamsNames.FEEDBACK_QUESTION_ID, question.getId().toString()};
+        submissionParams = new String[] {Const.ParamsNames.FEEDBACK_SESSION_ID,
+                question.getFeedbackSession().getId().toString()};
 
         verifyHttpParameterFailureAcl(submissionParams);
 
@@ -602,10 +608,10 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         String[] submissionParams = new String[] {Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString()};
         verifyHttpParameterFailure(submissionParams);
 
-        ______TS("Failure: feedback question does not exist");
+        ______TS("Failure: feedback session does not exist");
         submissionParams = new String[] {
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000"};
+                Const.ParamsNames.FEEDBACK_SESSION_ID, "00000000-0000-0000-0000-000000000000"};
         verifyEntityNotFound(submissionParams);
 
         ______TS("Failure: no request body");
@@ -624,11 +630,11 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         // Null recipient
         List<String> nullEmail = Collections.singletonList(null);
         FeedbackResponsesRequest requestBody = buildRequestBody(nullEmail);
-        verifyInvalidOperation(requestBody, submissionParams);
+        verifyHttpRequestBodyFailure(requestBody, submissionParams);
 
         // Empty String recipient
         requestBody = buildRequestBody(Collections.singletonList(""));
-        verifyInvalidOperation(requestBody, submissionParams);
+        verifyHttpRequestBodyFailure(requestBody, submissionParams);
 
         ______TS("Success: question has no existing responses");
         Instructor instructorGiver = loginInstructor("instructor1OfCourse1");

--- a/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -32,8 +32,8 @@ import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.User;
+import teammates.ui.output.FeedbackQuestionResponsesData;
 import teammates.ui.output.FeedbackResponseData;
-import teammates.ui.output.FeedbackResponsesData;
 import teammates.ui.request.FeedbackResponsesRequest;
 import teammates.ui.request.Intent;
 import teammates.ui.webapi.JsonResult;
@@ -224,8 +224,10 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         SubmitFeedbackResponsesAction action = getAction(requestBody, submissionParams);
         JsonResult result = getJsonResult(action);
 
-        FeedbackResponsesData output = (FeedbackResponsesData) result.getOutput();
-        return output.getResponses();
+        FeedbackQuestionResponsesData output = (FeedbackQuestionResponsesData) result.getOutput();
+        return output.getQuestionResponses().values().stream()
+                .flatMap(List::stream)
+                .toList();
     }
 
     private void validateOutputForStudentRecipientsByEmail(List<FeedbackResponseData> responses, String giverEmail,

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1342,21 +1342,21 @@ public class Logic {
     }
 
     /**
-     * Submits feedback responses from a student or the student's team for a feedback question.
+     * Submits feedback responses from a student or the student's team for one or more feedback questions.
      */
     public List<FeedbackResponse> submitFeedbackResponsesFromStudent(
-            FeedbackQuestion feedbackQuestion, Student student, FeedbackResponsesRequest submitRequest)
+            FeedbackSession feedbackSession, Student student, FeedbackResponsesRequest submitRequest)
             throws InvalidOperationException, InvalidParametersException {
-        return feedbackResponsesLogic.submitFeedbackResponsesFromStudent(feedbackQuestion, student, submitRequest);
+        return feedbackResponsesLogic.submitFeedbackResponsesFromStudent(feedbackSession, student, submitRequest);
     }
 
     /**
-     * Submits feedback responses from an instructor for a feedback question.
+     * Submits feedback responses from an instructor for one or more feedback questions.
      */
     public List<FeedbackResponse> submitFeedbackResponsesFromInstructor(
-            FeedbackQuestion feedbackQuestion, Instructor instructor, FeedbackResponsesRequest submitRequest)
+            FeedbackSession feedbackSession, Instructor instructor, FeedbackResponsesRequest submitRequest)
             throws InvalidOperationException, InvalidParametersException {
-        return feedbackResponsesLogic.submitFeedbackResponsesFromInstructor(feedbackQuestion, instructor, submitRequest);
+        return feedbackResponsesLogic.submitFeedbackResponsesFromInstructor(feedbackSession, instructor, submitRequest);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -47,6 +47,7 @@ import teammates.storage.entity.User;
 import teammates.storage.entity.responses.FeedbackRankRecipientsResponse;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.request.FeedbackResponsesRequest;
+import teammates.ui.request.FeedbackResponsesRequest.FeedbackResponseRequest;
 
 /**
  * Handles operations related to feedback responses.
@@ -205,7 +206,7 @@ public final class FeedbackResponsesLogic {
      * Submits feedback responses from a student or the student's team for a feedback question.
      */
     public List<FeedbackResponse> submitFeedbackResponsesFromStudent(
-            FeedbackQuestion feedbackQuestion, Student student, FeedbackResponsesRequest submitRequest)
+            FeedbackQuestion feedbackQuestion, Student student, List<FeedbackResponseRequest> submitResponses)
             throws InvalidOperationException, InvalidParametersException {
         if (feedbackQuestion.getGiverType() != QuestionGiverType.STUDENTS
                 && feedbackQuestion.getGiverType() != QuestionGiverType.TEAMS) {
@@ -218,14 +219,14 @@ public final class FeedbackResponsesLogic {
         List<FeedbackResponse> existingResponses = getFeedbackResponsesFromStudentOrTeamForQuestion(
                 feedbackQuestion, student);
 
-        return submitFeedbackResponses(feedbackQuestion, responseGiver, existingResponses, student, submitRequest);
+        return submitFeedbackResponses(feedbackQuestion, responseGiver, existingResponses, student, submitResponses);
     }
 
     /**
      * Submits feedback responses from an instructor for a feedback question.
      */
     public List<FeedbackResponse> submitFeedbackResponsesFromInstructor(
-            FeedbackQuestion feedbackQuestion, Instructor instructor, FeedbackResponsesRequest submitRequest)
+            FeedbackQuestion feedbackQuestion, Instructor instructor, List<FeedbackResponseRequest> submitResponses)
             throws InvalidOperationException, InvalidParametersException {
         if (feedbackQuestion.getGiverType() != QuestionGiverType.INSTRUCTORS
                 && feedbackQuestion.getGiverType() != QuestionGiverType.SESSION_CREATOR) {
@@ -236,12 +237,58 @@ public final class FeedbackResponsesLogic {
         List<FeedbackResponse> existingResponses = getFeedbackResponsesFromInstructorForQuestion(
                 feedbackQuestion, instructor);
 
-        return submitFeedbackResponses(feedbackQuestion, responseGiver, existingResponses, null, submitRequest);
+        return submitFeedbackResponses(feedbackQuestion, responseGiver, existingResponses, null, submitResponses);
+    }
+
+    /**
+     * Submits feedback responses from a student or the student's team for one or more feedback questions
+     * in the same feedback session.
+     */
+    public List<FeedbackResponse> submitFeedbackResponsesFromStudent(
+            FeedbackSession feedbackSession, Student student, FeedbackResponsesRequest submitRequest)
+            throws InvalidOperationException, InvalidParametersException {
+        List<FeedbackResponse> submittedResponses = new ArrayList<>();
+        for (Map.Entry<UUID, List<FeedbackResponseRequest>> entry : submitRequest.getQuestionResponses().entrySet()) {
+            FeedbackQuestion feedbackQuestion = fqLogic.getFeedbackQuestion(entry.getKey());
+            if (feedbackQuestion == null) {
+                throw new InvalidOperationException("The feedback question does not exist.");
+            }
+            if (!feedbackQuestion.getFeedbackSession().getId().equals(feedbackSession.getId())) {
+                throw new InvalidOperationException("The feedback question does not belong to the feedback session.");
+            }
+
+            submittedResponses.addAll(submitFeedbackResponsesFromStudent(feedbackQuestion, student, entry.getValue()));
+        }
+
+        return submittedResponses;
+    }
+
+    /**
+     * Submits feedback responses from an instructor for one or more feedback questions in the same feedback session.
+     */
+    public List<FeedbackResponse> submitFeedbackResponsesFromInstructor(
+            FeedbackSession feedbackSession, Instructor instructor, FeedbackResponsesRequest submitRequest)
+            throws InvalidOperationException, InvalidParametersException {
+        List<FeedbackResponse> submittedResponses = new ArrayList<>();
+        for (Map.Entry<UUID, List<FeedbackResponseRequest>> entry : submitRequest.getQuestionResponses().entrySet()) {
+            FeedbackQuestion feedbackQuestion = fqLogic.getFeedbackQuestion(entry.getKey());
+            if (feedbackQuestion == null) {
+                throw new InvalidOperationException("The feedback question does not exist.");
+            }
+            if (!feedbackQuestion.getFeedbackSession().getId().equals(feedbackSession.getId())) {
+                throw new InvalidOperationException("The feedback question does not belong to the feedback session.");
+            }
+
+            submittedResponses.addAll(submitFeedbackResponsesFromInstructor(
+                    feedbackQuestion, instructor, entry.getValue()));
+        }
+
+        return submittedResponses;
     }
 
     private List<FeedbackResponse> submitFeedbackResponses(FeedbackQuestion feedbackQuestion,
             ResponseGiver responseGiver, List<FeedbackResponse> existingResponses, @Nullable Student student,
-            FeedbackResponsesRequest submitRequest)
+            List<FeedbackResponseRequest> submitResponses)
             throws InvalidOperationException, InvalidParametersException {
         FeedbackQuestionDetails questionDetails = feedbackQuestion.getQuestionDetailsCopy();
         Optional<List<String>> dynamicallyGeneratedOptions = fqLogic.getDynamicallyGeneratedOptions(
@@ -264,7 +311,11 @@ public final class FeedbackResponsesLogic {
         Map<ResponseRecipient, FeedbackResponse> existingResponsesPerRecipient = new HashMap<>();
         existingResponses.forEach(response -> existingResponsesPerRecipient.put(response.getRecipient(), response));
 
-        for (String recipient : submitRequest.getRecipients()) {
+        List<String> recipients = submitResponses.stream()
+                .map(FeedbackResponseRequest::getRecipient)
+                .toList();
+
+        for (String recipient : recipients) {
             if (recipient == null || !recipientsByIdentifier.containsKey(recipient)) {
                 throw new InvalidOperationException(
                         "The recipient " + recipient + " is not a valid recipient of the question");
@@ -273,7 +324,7 @@ public final class FeedbackResponsesLogic {
 
         List<FeedbackResponse> feedbackResponses = new ArrayList<>();
 
-        for (var responseRequest : submitRequest.getResponses()) {
+        for (FeedbackResponseRequest responseRequest : submitResponses) {
             String recipient = responseRequest.getRecipient();
             ResponseRecipient responseRecipient = recipientsByIdentifier.get(recipient);
             FeedbackResponseDetails responseDetails = responseRequest.getResponseDetails();
@@ -320,7 +371,6 @@ public final class FeedbackResponsesLogic {
         }
 
         // Delete responses that are deleted by the user
-        List<String> recipients = submitRequest.getRecipients();
         List<FeedbackResponse> feedbackResponsesToDelete = existingResponsesPerRecipient.entrySet().stream()
                 .filter(entry -> !recipients.contains(entry.getKey().getIdentifier()))
                 .map(Entry::getValue)

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -203,44 +203,6 @@ public final class FeedbackResponsesLogic {
     }
 
     /**
-     * Submits feedback responses from a student or the student's team for a feedback question.
-     */
-    public List<FeedbackResponse> submitFeedbackResponsesFromStudent(
-            FeedbackQuestion feedbackQuestion, Student student, List<FeedbackResponseRequest> submitResponses)
-            throws InvalidOperationException, InvalidParametersException {
-        if (feedbackQuestion.getGiverType() != QuestionGiverType.STUDENTS
-                && feedbackQuestion.getGiverType() != QuestionGiverType.TEAMS) {
-            throw new InvalidOperationException("Feedback question is not answerable for students");
-        }
-
-        ResponseGiver responseGiver = feedbackQuestion.getGiverType() == QuestionGiverType.TEAMS
-                ? new ResponseGiver(student.getTeam())
-                : new ResponseGiver(student);
-        List<FeedbackResponse> existingResponses = getFeedbackResponsesFromStudentOrTeamForQuestion(
-                feedbackQuestion, student);
-
-        return submitFeedbackResponses(feedbackQuestion, responseGiver, existingResponses, student, submitResponses);
-    }
-
-    /**
-     * Submits feedback responses from an instructor for a feedback question.
-     */
-    public List<FeedbackResponse> submitFeedbackResponsesFromInstructor(
-            FeedbackQuestion feedbackQuestion, Instructor instructor, List<FeedbackResponseRequest> submitResponses)
-            throws InvalidOperationException, InvalidParametersException {
-        if (feedbackQuestion.getGiverType() != QuestionGiverType.INSTRUCTORS
-                && feedbackQuestion.getGiverType() != QuestionGiverType.SESSION_CREATOR) {
-            throw new InvalidOperationException("Feedback question is not answerable for instructors");
-        }
-
-        ResponseGiver responseGiver = new ResponseGiver(instructor);
-        List<FeedbackResponse> existingResponses = getFeedbackResponsesFromInstructorForQuestion(
-                feedbackQuestion, instructor);
-
-        return submitFeedbackResponses(feedbackQuestion, responseGiver, existingResponses, null, submitResponses);
-    }
-
-    /**
      * Submits feedback responses from a student or the student's team for one or more feedback questions
      * in the same feedback session.
      */
@@ -253,11 +215,26 @@ public final class FeedbackResponsesLogic {
             if (feedbackQuestion == null) {
                 throw new InvalidOperationException("The feedback question does not exist.");
             }
+
             if (!feedbackQuestion.getFeedbackSession().getId().equals(feedbackSession.getId())) {
                 throw new InvalidOperationException("The feedback question does not belong to the feedback session.");
             }
 
-            submittedResponses.addAll(submitFeedbackResponsesFromStudent(feedbackQuestion, student, entry.getValue()));
+            if (feedbackQuestion.getGiverType() != QuestionGiverType.STUDENTS
+                    && feedbackQuestion.getGiverType() != QuestionGiverType.TEAMS) {
+                throw new InvalidOperationException("Feedback question is not answerable for students");
+            }
+
+            ResponseGiver responseGiver = feedbackQuestion.getGiverType() == QuestionGiverType.TEAMS
+                    ? new ResponseGiver(student.getTeam())
+                    : new ResponseGiver(student);
+            List<FeedbackResponse> existingResponses = getFeedbackResponsesFromStudentOrTeamForQuestion(
+                    feedbackQuestion, student);
+
+            List<FeedbackResponse> responses = submitFeedbackResponses(
+                    feedbackQuestion, responseGiver, existingResponses, student, entry.getValue());
+
+            submittedResponses.addAll(responses);
         }
 
         return submittedResponses;
@@ -275,12 +252,24 @@ public final class FeedbackResponsesLogic {
             if (feedbackQuestion == null) {
                 throw new InvalidOperationException("The feedback question does not exist.");
             }
+
             if (!feedbackQuestion.getFeedbackSession().getId().equals(feedbackSession.getId())) {
                 throw new InvalidOperationException("The feedback question does not belong to the feedback session.");
             }
 
-            submittedResponses.addAll(submitFeedbackResponsesFromInstructor(
-                    feedbackQuestion, instructor, entry.getValue()));
+            if (feedbackQuestion.getGiverType() != QuestionGiverType.INSTRUCTORS
+                    && feedbackQuestion.getGiverType() != QuestionGiverType.SESSION_CREATOR) {
+                throw new InvalidOperationException("Feedback question is not answerable for instructors");
+            }
+
+            ResponseGiver responseGiver = new ResponseGiver(instructor);
+            List<FeedbackResponse> existingResponses = getFeedbackResponsesFromInstructorForQuestion(
+                    feedbackQuestion, instructor);
+
+            List<FeedbackResponse> responses = submitFeedbackResponses(
+                    feedbackQuestion, responseGiver, existingResponses, null, entry.getValue());
+
+            submittedResponses.addAll(responses);
         }
 
         return submittedResponses;

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -297,8 +297,8 @@ public final class FeedbackResponsesLogic {
         Map<String, ResponseRecipient> recipientsByIdentifier = recipientsOfTheQuestion.stream()
                 .collect(Collectors.toMap(ResponseRecipient::getIdentifier, recipient -> recipient));
 
-        Map<ResponseRecipient, FeedbackResponse> existingResponsesPerRecipient = new HashMap<>();
-        existingResponses.forEach(response -> existingResponsesPerRecipient.put(response.getRecipient(), response));
+        Map<UUID, FeedbackResponse> existingResponsesById = new HashMap<>();
+        existingResponses.forEach(response -> existingResponsesById.put(response.getId(), response));
 
         List<String> recipients = submitResponses.stream()
                 .map(FeedbackResponseRequest::getRecipient)
@@ -312,15 +312,21 @@ public final class FeedbackResponsesLogic {
         }
 
         List<FeedbackResponse> feedbackResponses = new ArrayList<>();
+        Set<UUID> submittedResponseIds = new HashSet<>();
 
         for (FeedbackResponseRequest responseRequest : submitResponses) {
             String recipient = responseRequest.getRecipient();
             ResponseRecipient responseRecipient = recipientsByIdentifier.get(recipient);
             FeedbackResponseDetails responseDetails = responseRequest.getResponseDetails();
+            UUID responseId = responseRequest.getResponseId();
 
-            if (existingResponsesPerRecipient.containsKey(responseRecipient)) {
+            if (responseId != null) {
+                FeedbackResponse existingFeedbackResponse = existingResponsesById.get(responseId);
+                if (existingFeedbackResponse == null) {
+                    throw new InvalidOperationException("The response " + responseId + " does not exist.");
+                }
                 // Update the existing response
-                FeedbackResponse existingFeedbackResponse = existingResponsesPerRecipient.get(responseRecipient);
+                submittedResponseIds.add(responseId);
                 existingFeedbackResponse.setGiver(responseGiver);
                 existingFeedbackResponse.setRecipient(responseRecipient);
                 existingFeedbackResponse.setFeedbackResponseDetails(responseDetails);
@@ -360,8 +366,8 @@ public final class FeedbackResponsesLogic {
         }
 
         // Delete responses that are deleted by the user
-        List<FeedbackResponse> feedbackResponsesToDelete = existingResponsesPerRecipient.entrySet().stream()
-                .filter(entry -> !recipients.contains(entry.getKey().getIdentifier()))
+        List<FeedbackResponse> feedbackResponsesToDelete = existingResponsesById.entrySet().stream()
+                .filter(entry -> !submittedResponseIds.contains(entry.getKey()))
                 .map(Entry::getValue)
                 .toList();
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -279,6 +279,7 @@ public final class FeedbackResponsesLogic {
             ResponseGiver responseGiver, List<FeedbackResponse> existingResponses, @Nullable Student student,
             List<FeedbackResponseRequest> submitResponses)
             throws InvalidOperationException, InvalidParametersException {
+        // TODO: Optimise logic to reduce the number of calls to the database.
         FeedbackQuestionDetails questionDetails = feedbackQuestion.getQuestionDetailsCopy();
         Optional<List<String>> dynamicallyGeneratedOptions = fqLogic.getDynamicallyGeneratedOptions(
                 feedbackQuestion, student);

--- a/src/main/java/teammates/ui/output/FeedbackQuestionResponsesData.java
+++ b/src/main/java/teammates/ui/output/FeedbackQuestionResponsesData.java
@@ -1,0 +1,46 @@
+package teammates.ui.output;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import teammates.storage.entity.FeedbackResponse;
+
+/**
+ * The API output format for submitted {@link FeedbackResponse}, grouped by question.
+ */
+public class FeedbackQuestionResponsesData extends ApiOutput {
+
+    private Map<UUID, List<FeedbackResponseData>> questionResponses;
+
+    private FeedbackQuestionResponsesData(Map<UUID, List<FeedbackResponseData>> questionResponses) {
+        this.questionResponses = questionResponses;
+    }
+
+    public FeedbackQuestionResponsesData() {
+        questionResponses = Collections.emptyMap();
+    }
+
+    /**
+     * Creates FeedbackQuestionResponsesData from a list of FeedbackResponse.
+     */
+    public static FeedbackQuestionResponsesData createFromEntity(List<FeedbackResponse> responses) {
+        Map<UUID, List<FeedbackResponseData>> groupedResponses = responses.stream()
+                .collect(Collectors.groupingBy(
+                        FeedbackResponse::getQuestionId,
+                        LinkedHashMap::new,
+                        Collectors.mapping(FeedbackResponseData::new, Collectors.toList())));
+        return new FeedbackQuestionResponsesData(groupedResponses);
+    }
+
+    public Map<UUID, List<FeedbackResponseData>> getQuestionResponses() {
+        return questionResponses;
+    }
+
+    public void setQuestionResponses(Map<UUID, List<FeedbackResponseData>> questionResponses) {
+        this.questionResponses = questionResponses;
+    }
+}

--- a/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
@@ -1,7 +1,8 @@
 package teammates.ui.request;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
@@ -13,23 +14,33 @@ import teammates.common.util.SanitizationHelper;
  */
 public class FeedbackResponsesRequest extends BasicRequest {
 
-    private List<FeedbackResponseRequest> responses = new ArrayList<>();
+    private Map<UUID, List<FeedbackResponseRequest>> questionResponses;
 
-    public List<FeedbackResponseRequest> getResponses() {
-        return responses;
+    public Map<UUID, List<FeedbackResponseRequest>> getQuestionResponses() {
+        return questionResponses;
     }
 
-    public void setResponses(List<FeedbackResponseRequest> responses) {
-        this.responses = responses;
-    }
-
-    public List<String> getRecipients() {
-        return responses.stream().map(FeedbackResponseRequest::getRecipient).toList();
+    public void setQuestionResponses(Map<UUID, List<FeedbackResponseRequest>> questionResponses) {
+        this.questionResponses = questionResponses;
     }
 
     @Override
-    public void validate() {
-        // No validation necessary; each response entities will be validated separately
+    public void validate() throws InvalidHttpRequestBodyException {
+        assertTrue(questionResponses != null, "Question responses cannot be null");
+        assertTrue(!questionResponses.isEmpty(), "Question responses cannot be empty");
+
+        for (Map.Entry<UUID, List<FeedbackResponseRequest>> entry : questionResponses.entrySet()) {
+            UUID questionId = entry.getKey();
+            List<FeedbackResponseRequest> responses = entry.getValue();
+
+            assertTrue(questionId != null, "Question ID cannot be null");
+            assertTrue(responses != null, "Responses cannot be null");
+
+            for (FeedbackResponseRequest response : responses) {
+                assertTrue(response != null, "Response cannot be null");
+                response.validate();
+            }
+        }
     }
 
     /**

--- a/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
@@ -1,11 +1,14 @@
 package teammates.ui.request;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import jakarta.annotation.Nullable;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.util.SanitizationHelper;
 
@@ -36,9 +39,17 @@ public class FeedbackResponsesRequest extends BasicRequest {
             assertTrue(questionId != null, "Question ID cannot be null");
             assertTrue(responses != null, "Responses cannot be null");
 
+            Set<UUID> submittedResponseIds = new HashSet<>();
+            Set<String> submittedRecipients = new HashSet<>();
+
             for (FeedbackResponseRequest response : responses) {
                 assertTrue(response != null, "Response cannot be null");
                 response.validate();
+                UUID responseId = response.getResponseId();
+                if (responseId != null) {
+                    assertTrue(submittedResponseIds.add(responseId), "Response IDs cannot be duplicated");
+                }
+                assertTrue(submittedRecipients.add(response.getRecipient()), "Recipients cannot be duplicated");
             }
         }
     }
@@ -48,16 +59,20 @@ public class FeedbackResponsesRequest extends BasicRequest {
      */
     public static class FeedbackResponseRequest extends BasicRequest {
 
+        @Nullable
+        private UUID responseId;
         private String recipient;
         private FeedbackResponseDetails responseDetails;
         private String giverComment;
 
         public FeedbackResponseRequest(String recipient, FeedbackResponseDetails responseDetails) {
-            this(recipient, responseDetails, null);
+            this(null, recipient, responseDetails, null);
         }
 
         @JsonCreator
-        public FeedbackResponseRequest(String recipient, FeedbackResponseDetails responseDetails, String giverComment) {
+        public FeedbackResponseRequest(
+                UUID responseId, String recipient, FeedbackResponseDetails responseDetails, String giverComment) {
+            this.responseId = responseId;
             this.recipient = recipient;
             this.responseDetails = responseDetails;
             this.giverComment = giverComment == null
@@ -69,6 +84,10 @@ public class FeedbackResponsesRequest extends BasicRequest {
         public void validate() throws InvalidHttpRequestBodyException {
             assertTrue(recipient != null && !recipient.isEmpty(), "Recipient cannot be empty");
             assertTrue(responseDetails != null, "Response details cannot be null");
+        }
+
+        public UUID getResponseId() {
+            return responseId;
         }
 
         public String getRecipient() {

--- a/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
@@ -6,9 +6,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import jakarta.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import jakarta.annotation.Nullable;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.util.SanitizationHelper;
 

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
+import teammates.common.util.StringHelper;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
@@ -21,10 +22,10 @@ import teammates.ui.request.Intent;
 import teammates.ui.request.InvalidHttpRequestBodyException;
 
 /**
- * Submits a list of feedback responses to a feedback question.
+ * Submits feedback responses for one or more feedback questions in a feedback session.
  *
- * <p>This action is meant to completely overwrite the feedback responses that are previously attached to the
- * same feedback question.
+ * <p>For each submitted question, the submitted responses are treated as the complete final set from the giver.
+ * Any existing responses not included in the submission will be removed.
  */
 public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
 
@@ -36,22 +37,22 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
     }
 
     @Override
-    void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-
-        final FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
-
-        if (feedbackQuestion == null) {
-            throw new EntityNotFoundException("The feedback question does not exist.");
+    void checkSpecificAccessControl() throws InvalidHttpRequestBodyException, UnauthorizedAccessException {
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
+        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("The feedback session does not exist.");
         }
 
-        FeedbackSession feedbackSession = feedbackQuestion.getFeedbackSession();
-        verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
+        if (!StringHelper.isEmpty(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON))) {
+            validateModerationVisibilityForSubmittedQuestions(feedbackSession,
+                    getAndValidateRequestBody(FeedbackResponsesRequest.class));
+        }
 
         Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
         switch (intent) {
         case STUDENT_SUBMISSION:
-            Student student = getStudentOfCourseForSubmission(feedbackQuestion.getCourseId(), false);
+            Student student = getStudentOfCourseForSubmission(feedbackSession.getCourseId(), false);
             if (student == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent student entity");
             }
@@ -59,7 +60,7 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:
-            Instructor instructor = getInstructorOfCourseForSubmission(feedbackQuestion.getCourseId(), false);
+            Instructor instructor = getInstructorOfCourseForSubmission(feedbackSession.getCourseId(), false);
             if (instructor == null) {
                 throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
             }
@@ -75,12 +76,10 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
 
     @Override
     public JsonResult execute() throws InvalidHttpRequestBodyException, InvalidOperationException {
-        UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-
-        final FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
-
-        if (feedbackQuestion == null) {
-            throw new EntityNotFoundException("The feedback question does not exist.");
+        UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
+        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
+        if (feedbackSession == null) {
+            throw new EntityNotFoundException("The feedback session does not exist.");
         }
 
         List<FeedbackResponse> output;
@@ -89,21 +88,23 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
 
         switch (intent) {
         case STUDENT_SUBMISSION:
-            Student student = getStudentOfCourseForSubmission(feedbackQuestion.getCourseId(), false);
-            log.info("Student " + student.getId() + " is submitting feedback responses for question "
-                    + feedbackQuestion.getId() + " in session " + feedbackQuestion.getFeedbackSession().getId());
+            Student student = getStudentOfCourseForSubmission(feedbackSession.getCourseId(), false);
+            log.info("Student " + student.getId() + " is submitting feedback responses for "
+                    + submitRequest.getQuestionResponses().size() + " question(s) in session "
+                    + feedbackSession.getId());
             try {
-                output = logic.submitFeedbackResponsesFromStudent(feedbackQuestion, student, submitRequest);
+                output = logic.submitFeedbackResponsesFromStudent(feedbackSession, student, submitRequest);
             } catch (InvalidParametersException e) {
                 throw new InvalidHttpRequestBodyException(e);
             }
             break;
         case INSTRUCTOR_SUBMISSION:
-            Instructor instructor = getInstructorOfCourseForSubmission(feedbackQuestion.getCourseId(), false);
-            log.info("Instructor " + instructor.getId() + " is submitting feedback responses for question "
-                    + feedbackQuestion.getId() + " in session " + feedbackQuestion.getFeedbackSession().getId());
+            Instructor instructor = getInstructorOfCourseForSubmission(feedbackSession.getCourseId(), false);
+            log.info("Instructor " + instructor.getId() + " is submitting feedback responses for "
+                    + submitRequest.getQuestionResponses().size() + " question(s) in session "
+                    + feedbackSession.getId());
             try {
-                output = logic.submitFeedbackResponsesFromInstructor(feedbackQuestion, instructor, submitRequest);
+                output = logic.submitFeedbackResponsesFromInstructor(feedbackSession, instructor, submitRequest);
             } catch (InvalidParametersException e) {
                 throw new InvalidHttpRequestBodyException(e);
             }
@@ -113,6 +114,21 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
         }
 
         return new JsonResult(FeedbackResponsesData.createFromEntity(output));
+    }
+
+    private void validateModerationVisibilityForSubmittedQuestions(
+            FeedbackSession feedbackSession, FeedbackResponsesRequest submitRequest)
+            throws UnauthorizedAccessException {
+        for (UUID questionId : submitRequest.getQuestionResponses().keySet()) {
+            FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(questionId);
+            if (feedbackQuestion == null) {
+                throw new EntityNotFoundException("The feedback question does not exist.");
+            }
+            if (!feedbackQuestion.getFeedbackSession().getId().equals(feedbackSession.getId())) {
+                throw new InvalidHttpParameterException("The feedback question does not belong to the feedback session.");
+            }
+            verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
+        }
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -16,7 +16,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.output.FeedbackResponsesData;
+import teammates.ui.output.FeedbackQuestionResponsesData;
 import teammates.ui.request.FeedbackResponsesRequest;
 import teammates.ui.request.Intent;
 import teammates.ui.request.InvalidHttpRequestBodyException;
@@ -113,7 +113,7 @@ public class SubmitFeedbackResponsesAction extends BasicFeedbackSubmissionAction
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }
 
-        return new JsonResult(FeedbackResponsesData.createFromEntity(output));
+        return new JsonResult(FeedbackQuestionResponsesData.createFromEntity(output));
     }
 
     private void validateModerationVisibilityForSubmittedQuestions(

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,7 +25,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
 import teammates.common.datatransfer.participanttypes.ViewerType;
-import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.storage.api.FeedbackResponsesDb;
 import teammates.storage.entity.Course;
@@ -35,12 +33,8 @@ import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.ResponseGiver;
-import teammates.storage.entity.ResponseRecipient;
 import teammates.storage.entity.Student;
 import teammates.test.BaseTestCase;
-import teammates.ui.exception.InvalidOperationException;
-import teammates.ui.request.FeedbackResponsesRequest;
-import teammates.ui.request.FeedbackResponsesRequest.FeedbackResponseRequest;
 
 /**
  * SUT: {@link FeedbackResponsesLogic}.
@@ -50,13 +44,12 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
     private final FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
 
     private FeedbackResponsesDb frDb;
-    private FeedbackQuestionsLogic fqLogic;
 
     @BeforeMethod
     public void setUpMethod() {
         frDb = mock(FeedbackResponsesDb.class);
         UsersLogic usersLogic = mock(UsersLogic.class);
-        fqLogic = mock(FeedbackQuestionsLogic.class);
+        FeedbackQuestionsLogic fqLogic = mock(FeedbackQuestionsLogic.class);
         ResponseInstructorCommentsLogic frcLogic = mock(ResponseInstructorCommentsLogic.class);
         frLogic.initLogicDependencies(frDb, usersLogic, fqLogic, frcLogic);
         when(fqLogic.getDynamicallyGeneratedOptions(any(FeedbackQuestion.class), any()))
@@ -324,131 +317,6 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
         assertEquals(1, result.size());
         assertEquals(response, result.get(0));
         verify(frDb, times(1)).getFeedbackResponsesFromGiverForQuestion(questionId, student.getId(), null);
-    }
-
-    @Test
-    public void testSubmitFeedbackResponsesFromStudent_noExistingResponses_createsResponse() throws Exception {
-        Course course = getTypicalCourse();
-        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
-        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
-        question.setId(UUID.randomUUID());
-        question.setGiverType(QuestionGiverType.STUDENTS);
-        Student giver = getTypicalStudent();
-        Student recipient = getTypicalStudent();
-        recipient.setEmail("recipient@email.com");
-        ResponseRecipient responseRecipient = new ResponseRecipient(recipient);
-        List<FeedbackResponseRequest> request = List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
-                recipient.getEmail(), new FeedbackTextResponseDetails("new response"), "new comment"));
-
-        when(frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), giver.getId(), null))
-                .thenReturn(List.of());
-        when(fqLogic.getRecipientsOfQuestion(any(FeedbackQuestion.class), any(ResponseGiver.class)))
-                .thenReturn(Set.of(responseRecipient));
-        when(frDb.createFeedbackResponse(any(FeedbackResponse.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        List<FeedbackResponse> result = frLogic.submitFeedbackResponsesFromStudent(question, giver, request);
-
-        assertEquals(1, result.size());
-        assertEquals(giver.getEmail(), result.get(0).getGiver().getIdentifier());
-        assertEquals(recipient.getEmail(), result.get(0).getRecipient().getIdentifier());
-        assertEquals("new comment", result.get(0).getGiverComment());
-        verify(frDb).createFeedbackResponse(any(FeedbackResponse.class));
-    }
-
-    @Test
-    public void testSubmitFeedbackResponsesFromStudent_existingResponses_updatesAndDeletes() throws Exception {
-        Course course = getTypicalCourse();
-        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
-        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
-        question.setId(UUID.randomUUID());
-        question.setGiverType(QuestionGiverType.STUDENTS);
-        Student giver = getTypicalStudent();
-        Student recipientToKeep = getTypicalStudent();
-        recipientToKeep.setEmail("keep@email.com");
-        Student recipientToDelete = getTypicalStudent();
-        recipientToDelete.setEmail("delete@email.com");
-        ResponseRecipient responseRecipientToKeep = new ResponseRecipient(recipientToKeep);
-        ResponseRecipient responseRecipientToDelete = new ResponseRecipient(recipientToDelete);
-        FeedbackResponse existingResponseToKeep = FeedbackResponse.makeResponse(
-                new ResponseGiver(giver), responseRecipientToKeep, new FeedbackTextResponseDetails("old response"),
-                "old comment");
-        FeedbackResponse existingResponseToDelete = FeedbackResponse.makeResponse(
-                new ResponseGiver(giver), responseRecipientToDelete, new FeedbackTextResponseDetails("deleted response"));
-        question.addFeedbackResponse(existingResponseToKeep);
-        question.addFeedbackResponse(existingResponseToDelete);
-        List<FeedbackResponseRequest> request = List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
-                recipientToKeep.getEmail(), new FeedbackTextResponseDetails("updated response"), "updated comment"));
-
-        when(frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), giver.getId(), null))
-                .thenReturn(List.of(existingResponseToKeep, existingResponseToDelete));
-        when(fqLogic.getRecipientsOfQuestion(any(FeedbackQuestion.class), any(ResponseGiver.class)))
-                .thenReturn(Set.of(responseRecipientToKeep, responseRecipientToDelete));
-
-        List<FeedbackResponse> result = frLogic.submitFeedbackResponsesFromStudent(question, giver, request);
-
-        assertEquals(1, result.size());
-        assertEquals("updated response", ((FeedbackTextResponseDetails) result.get(0).getFeedbackResponseDetailsCopy())
-                .getAnswer());
-        assertEquals("updated comment", result.get(0).getGiverComment());
-        verify(frDb, never()).createFeedbackResponse(any(FeedbackResponse.class));
-        verify(frDb).deleteFeedbackResponse(existingResponseToDelete);
-    }
-
-    @Test
-    public void testSubmitFeedbackResponsesFromStudent_invalidRecipient_throwsInvalidOperationException() {
-        Course course = getTypicalCourse();
-        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
-        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
-        question.setId(UUID.randomUUID());
-        question.setGiverType(QuestionGiverType.STUDENTS);
-        Student giver = getTypicalStudent();
-        List<FeedbackResponseRequest> request = List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
-                "invalid@email.com", new FeedbackTextResponseDetails("response")));
-
-        when(frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), giver.getId(), null))
-                .thenReturn(List.of());
-        when(fqLogic.getRecipientsOfQuestion(any(FeedbackQuestion.class), any(ResponseGiver.class)))
-                .thenReturn(Set.of());
-
-        InvalidOperationException exception = assertThrows(InvalidOperationException.class,
-                () -> frLogic.submitFeedbackResponsesFromStudent(question, giver, request));
-
-        assertEquals("The recipient invalid@email.com is not a valid recipient of the question", exception.getMessage());
-        verify(frDb, never()).createFeedbackResponse(any(FeedbackResponse.class));
-    }
-
-    @Test
-    public void testSubmitFeedbackResponsesFromStudent_nonStudentGiverType_throwsInvalidOperationException() {
-        Course course = getTypicalCourse();
-        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
-        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
-        question.setId(UUID.randomUUID());
-        question.setGiverType(QuestionGiverType.INSTRUCTORS);
-        Student giver = getTypicalStudent();
-
-        InvalidOperationException exception = assertThrows(InvalidOperationException.class,
-                () -> frLogic.submitFeedbackResponsesFromStudent(question, giver, List.of()));
-
-        assertEquals("Feedback question is not answerable for students", exception.getMessage());
-        verify(frDb, never()).getFeedbackResponsesFromGiverForQuestion(any(UUID.class), any(UUID.class), any());
-    }
-
-    @Test
-    public void testSubmitFeedbackResponsesFromInstructor_nonInstructorGiverType_throwsInvalidOperationException() {
-        Course course = getTypicalCourse();
-        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
-        FeedbackQuestion question = getTypicalFeedbackQuestionForSession(session);
-        question.setId(UUID.randomUUID());
-        question.setGiverType(QuestionGiverType.STUDENTS);
-        Instructor giver = getTypicalInstructor();
-
-        InvalidOperationException exception = assertThrows(InvalidOperationException.class,
-                () -> frLogic.submitFeedbackResponsesFromInstructor(
-                        question, giver, List.of()));
-
-        assertEquals("Feedback question is not answerable for instructors", exception.getMessage());
-        verify(frDb, never()).getFeedbackResponsesFromGiverForQuestion(any(UUID.class), any(UUID.class), any());
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -40,6 +40,7 @@ import teammates.storage.entity.Student;
 import teammates.test.BaseTestCase;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.request.FeedbackResponsesRequest;
+import teammates.ui.request.FeedbackResponsesRequest.FeedbackResponseRequest;
 
 /**
  * SUT: {@link FeedbackResponsesLogic}.
@@ -336,9 +337,8 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
         Student recipient = getTypicalStudent();
         recipient.setEmail("recipient@email.com");
         ResponseRecipient responseRecipient = new ResponseRecipient(recipient);
-        FeedbackResponsesRequest request = new FeedbackResponsesRequest();
-        request.setResponses(List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
-                recipient.getEmail(), new FeedbackTextResponseDetails("new response"), "new comment")));
+        List<FeedbackResponseRequest> request = List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                recipient.getEmail(), new FeedbackTextResponseDetails("new response"), "new comment"));
 
         when(frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), giver.getId(), null))
                 .thenReturn(List.of());
@@ -377,9 +377,8 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
                 new ResponseGiver(giver), responseRecipientToDelete, new FeedbackTextResponseDetails("deleted response"));
         question.addFeedbackResponse(existingResponseToKeep);
         question.addFeedbackResponse(existingResponseToDelete);
-        FeedbackResponsesRequest request = new FeedbackResponsesRequest();
-        request.setResponses(List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
-                recipientToKeep.getEmail(), new FeedbackTextResponseDetails("updated response"), "updated comment")));
+        List<FeedbackResponseRequest> request = List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                recipientToKeep.getEmail(), new FeedbackTextResponseDetails("updated response"), "updated comment"));
 
         when(frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), giver.getId(), null))
                 .thenReturn(List.of(existingResponseToKeep, existingResponseToDelete));
@@ -404,9 +403,8 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
         question.setId(UUID.randomUUID());
         question.setGiverType(QuestionGiverType.STUDENTS);
         Student giver = getTypicalStudent();
-        FeedbackResponsesRequest request = new FeedbackResponsesRequest();
-        request.setResponses(List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
-                "invalid@email.com", new FeedbackTextResponseDetails("response"))));
+        List<FeedbackResponseRequest> request = List.of(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                "invalid@email.com", new FeedbackTextResponseDetails("response")));
 
         when(frDb.getFeedbackResponsesFromGiverForQuestion(question.getId(), giver.getId(), null))
                 .thenReturn(List.of());
@@ -430,7 +428,7 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
         Student giver = getTypicalStudent();
 
         InvalidOperationException exception = assertThrows(InvalidOperationException.class,
-                () -> frLogic.submitFeedbackResponsesFromStudent(question, giver, new FeedbackResponsesRequest()));
+                () -> frLogic.submitFeedbackResponsesFromStudent(question, giver, List.of()));
 
         assertEquals("Feedback question is not answerable for students", exception.getMessage());
         verify(frDb, never()).getFeedbackResponsesFromGiverForQuestion(any(UUID.class), any(UUID.class), any());
@@ -446,7 +444,8 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
         Instructor giver = getTypicalInstructor();
 
         InvalidOperationException exception = assertThrows(InvalidOperationException.class,
-                () -> frLogic.submitFeedbackResponsesFromInstructor(question, giver, new FeedbackResponsesRequest()));
+                () -> frLogic.submitFeedbackResponsesFromInstructor(
+                        question, giver, List.of()));
 
         assertEquals("Feedback question is not answerable for instructors", exception.getMessage());
         verify(frDb, never()).getFeedbackResponsesFromGiverForQuestion(any(UUID.class), any(UUID.class), any());

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -250,6 +250,47 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
     }
 
     @Test
+    void testExecute_duplicateResponseId_throwsInvalidHttpRequestBodyException() {
+        loginAsStudent(stubStudent.getGoogleId());
+
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+        };
+
+        UUID duplicateResponseId = UUID.randomUUID();
+        List<FeedbackResponsesRequest.FeedbackResponseRequest> responses = new ArrayList<>();
+        responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                duplicateResponseId, recipientStudent1.getEmail(), new FeedbackTextResponseDetails("test"), null));
+        responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                duplicateResponseId, recipientStudent2.getEmail(), new FeedbackTextResponseDetails("test"), null));
+
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
+
+        verifyHttpRequestBodyFailure(requestBody, params);
+    }
+
+    @Test
+    void testExecute_duplicateRecipient_throwsInvalidHttpRequestBodyException() {
+        loginAsStudent(stubStudent.getGoogleId());
+
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+        };
+
+        List<FeedbackResponsesRequest.FeedbackResponseRequest> responses = new ArrayList<>();
+        responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                UUID.randomUUID(), recipientStudent1.getEmail(), new FeedbackTextResponseDetails("test"), null));
+        responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
+                UUID.randomUUID(), recipientStudent1.getEmail(), new FeedbackTextResponseDetails("test"), null));
+
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
+
+        verifyHttpRequestBodyFailure(requestBody, params);
+    }
+
+    @Test
     void testExecute_invalidRecipient_throwsInvalidOperationException() throws Exception {
         loginAsStudent(stubStudent.getGoogleId());
 

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -11,7 +11,9 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -104,6 +106,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 .thenReturn(stubInstructor);
         when(mockLogic.getFeedbackSession(stubFeedbackSession.getName(), stubFeedbackSession.getCourseId()))
                 .thenReturn(stubFeedbackSession);
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(stubFeedbackSession);
         when(mockLogic.getFeedbackQuestion(spyFeedbackQuestion.getId())).thenReturn(spyFeedbackQuestion);
         when(mockLogic.getStudentsForCourse(stubCourse.getId()))
                 .thenReturn(List.of(stubStudent, recipientStudent1, recipientStudent2));
@@ -112,14 +115,14 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         when(mockLogic.getDeadlineForUser(any(FeedbackSession.class), any()))
                 .thenAnswer(invocation -> ((FeedbackSession) invocation.getArgument(0)).getEndTime());
         when(mockLogic.submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class)))
+                any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class)))
                 .thenAnswer(invocation -> getSubmittedResponses(
-                        invocation.getArgument(0), getResponseGiver(invocation.getArgument(0), invocation.getArgument(1)),
+                        getResponseGiver(spyFeedbackQuestion, invocation.getArgument(1)),
                         invocation.getArgument(2)));
         when(mockLogic.submitFeedbackResponsesFromInstructor(
-                any(FeedbackQuestion.class), any(Instructor.class), any(FeedbackResponsesRequest.class)))
+                any(FeedbackSession.class), any(Instructor.class), any(FeedbackResponsesRequest.class)))
                 .thenAnswer(invocation -> getSubmittedResponses(
-                        invocation.getArgument(0), new ResponseGiver((Instructor) invocation.getArgument(1)),
+                        new ResponseGiver((Instructor) invocation.getArgument(1)),
                         invocation.getArgument(2)));
     }
 
@@ -129,16 +132,26 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 : new ResponseGiver(student);
     }
 
-    private List<FeedbackResponse> getSubmittedResponses(FeedbackQuestion feedbackQuestion, ResponseGiver responseGiver,
-            FeedbackResponsesRequest submitRequest) {
+    private FeedbackResponsesRequest getRequestBody(
+            List<FeedbackResponsesRequest.FeedbackResponseRequest> responses) {
+        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
+        requestBody.setQuestionResponses(Map.of(spyFeedbackQuestion.getId(), responses));
+        return requestBody;
+    }
+
+    private List<FeedbackResponse> getSubmittedResponses(
+            ResponseGiver responseGiver, FeedbackResponsesRequest submitRequest) {
         List<FeedbackResponse> responses = new ArrayList<>();
-        for (FeedbackResponsesRequest.FeedbackResponseRequest responseRequest : submitRequest.getResponses()) {
-            FeedbackResponse response = FeedbackResponse.makeResponse(
-                    responseGiver,
-                    getResponseRecipient(responseRequest.getRecipient()),
-                    responseRequest.getResponseDetails());
-            feedbackQuestion.addFeedbackResponse(response);
-            responses.add(response);
+        for (List<FeedbackResponsesRequest.FeedbackResponseRequest> responseRequests
+                : submitRequest.getQuestionResponses().values()) {
+            for (FeedbackResponsesRequest.FeedbackResponseRequest responseRequest : responseRequests) {
+                FeedbackResponse response = FeedbackResponse.makeResponse(
+                        responseGiver,
+                        getResponseRecipient(responseRequest.getRecipient()),
+                        responseRequest.getResponseDetails());
+                spyFeedbackQuestion.addFeedbackResponse(response);
+                responses.add(response);
+            }
         }
         return responses;
     }
@@ -177,7 +190,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -185,49 +198,56 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
     }
 
     @Test
-    void testExecute_nullRecipient_throwsInvalidOperationException() throws Exception {
+    void testExecute_nullResponsesForQuestion_throwsInvalidHttpRequestBodyException() {
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
-        when(mockLogic.submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class)))
-                .thenThrow(new InvalidOperationException("The recipient null is not a valid recipient of the question"));
+        Map<UUID, List<FeedbackResponsesRequest.FeedbackResponseRequest>> questionResponses = new HashMap<>();
+        questionResponses.put(spyFeedbackQuestion.getId(), null);
+        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
+        requestBody.setQuestionResponses(questionResponses);
+
+        verifyHttpRequestBodyFailure(requestBody, params);
+    }
+
+    @Test
+    void testExecute_nullRecipient_throwsInvalidHttpRequestBodyException() {
+        loginAsStudent(stubStudent.getGoogleId());
+
+        String[] params = {
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
+        };
 
         List<FeedbackResponsesRequest.FeedbackResponseRequest> responses = new ArrayList<>();
         responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
                 null, new FeedbackTextResponseDetails("test")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
-        verifyInvalidOperation(requestBody, params);
+        verifyHttpRequestBodyFailure(requestBody, params);
     }
 
     @Test
-    void testExecute_emptyRecipient_throwsInvalidOperationException() throws Exception {
+    void testExecute_emptyRecipient_throwsInvalidHttpRequestBodyException() {
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
-
-        when(mockLogic.submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class)))
-                .thenThrow(new InvalidOperationException("The recipient  is not a valid recipient of the question"));
 
         List<FeedbackResponsesRequest.FeedbackResponseRequest> responses = new ArrayList<>();
         responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
                 "", new FeedbackTextResponseDetails("test")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
-        verifyInvalidOperation(requestBody, params);
+        verifyHttpRequestBodyFailure(requestBody, params);
     }
 
     @Test
@@ -235,12 +255,12 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
         when(mockLogic.submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class)))
+                any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class)))
                 .thenThrow(new InvalidOperationException(
                         "The recipient invalid@email.com is not a valid recipient of the question"));
 
@@ -248,8 +268,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         responses.add(new FeedbackResponsesRequest.FeedbackResponseRequest(
                 "invalid@email.com", new FeedbackTextResponseDetails("test")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         verifyInvalidOperation(requestBody, params);
     }
@@ -259,7 +278,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -283,8 +302,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent1.getEmail(),
                 new FeedbackTextResponseDetails("Response for " + recipientStudent1.getEmail())));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -295,7 +313,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         assertEquals(recipientStudent1.getEmail(), responseData.getRecipientIdentifier());
 
         verify(mockLogic).submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class));
+                any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class));
     }
 
     @Test
@@ -303,7 +321,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsInstructor(stubInstructor.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
 
@@ -327,8 +345,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientInstructor1.getEmail(),
                 new FeedbackTextResponseDetails("Response for " + recipientInstructor1.getEmail())));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -339,7 +356,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         assertEquals(recipientInstructor1.getEmail(), responseData.getRecipientIdentifier());
 
         verify(mockLogic).submitFeedbackResponsesFromInstructor(
-                any(FeedbackQuestion.class), any(Instructor.class), any(FeedbackResponsesRequest.class));
+                any(FeedbackSession.class), any(Instructor.class), any(FeedbackResponsesRequest.class));
     }
 
     @Test
@@ -347,7 +364,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -387,15 +404,14 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent1.getEmail(),
                 new FeedbackTextResponseDetails("Updated response 1")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
 
         assertEquals(1, result.getResponses().size());
         verify(mockLogic).submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class));
+                any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class));
     }
 
     @Test
@@ -404,7 +420,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.TEAMS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -422,8 +438,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent1.getEmail(),
                 new FeedbackTextResponseDetails("Team response")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -431,7 +446,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         assertEquals(1, result.getResponses().size());
         assertEquals(stubStudent.getTeamName(), result.getResponses().get(0).getGiverIdentifier());
         verify(mockLogic).submitFeedbackResponsesFromStudent(
-                any(FeedbackQuestion.class), any(Student.class), any(FeedbackResponsesRequest.class));
+                any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class));
     }
 
     @Test
@@ -440,7 +455,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setNumOfEntitiesToGiveFeedbackTo(1);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -463,8 +478,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent2.getEmail(),
                 new FeedbackTextResponseDetails("Response 2")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -477,7 +491,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -500,8 +514,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent2.getEmail(),
                 new FeedbackTextResponseDetails("Response for " + recipientStudent2.getEmail())));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -515,7 +528,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setRecipientType(QuestionRecipientType.TEAMS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -534,8 +547,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 teamName,
                 new FeedbackTextResponseDetails("Team recipient response")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -549,7 +561,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         loginAsStudent(stubStudent.getGoogleId());
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, "invalid-uuid",
+                Const.ParamsNames.FEEDBACK_SESSION_ID, "invalid-uuid",
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -558,12 +570,11 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent1.getEmail(),
                 new FeedbackTextResponseDetails("test")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         InvalidHttpParameterException ihpe = assertThrows(InvalidHttpParameterException.class, action::execute);
-        assertEquals("Expected UUID value for questionid parameter, but found: [invalid-uuid]", ihpe.getMessage());
+        assertEquals("Expected UUID value for fsid parameter, but found: [invalid-uuid]", ihpe.getMessage());
     }
 
     @Test
@@ -572,7 +583,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setNumOfEntitiesToGiveFeedbackTo(Const.MAX_POSSIBLE_RECIPIENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -595,8 +606,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
                 recipientStudent2.getEmail(),
                 new FeedbackTextResponseDetails("Response 2")));
 
-        FeedbackResponsesRequest requestBody = new FeedbackResponsesRequest();
-        requestBody.setResponses(responses);
+        FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
         FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
@@ -605,19 +615,19 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
     }
 
     @Test
-    void testSpecificAccessControl_questionDoesNotExist_throwsEntityNotFoundException() {
+    void testSpecificAccessControl_sessionDoesNotExist_throwsEntityNotFoundException() {
         loginAsStudent(stubStudent.getGoogleId());
 
-        when(mockLogic.getFeedbackQuestion(spyFeedbackQuestion.getId())).thenReturn(null);
+        when(mockLogic.getFeedbackSession(stubFeedbackSession.getId())).thenReturn(null);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
         SubmitFeedbackResponsesAction action = getAction(params);
         EntityNotFoundException enfe = assertThrows(EntityNotFoundException.class, action::checkAccessControl);
-        assertEquals("The feedback question does not exist.", enfe.getMessage());
+        assertEquals("The feedback session does not exist.", enfe.getMessage());
     }
 
     @Test
@@ -635,7 +645,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.INSTRUCTORS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
 
@@ -652,7 +662,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -668,7 +678,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.INSTRUCTORS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
         };
 
@@ -688,7 +698,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -708,7 +718,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -729,7 +739,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -750,7 +760,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -764,7 +774,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.INSTRUCTORS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
                 Const.ParamsNames.PREVIEWAS, stubInstructor.getId().toString(),
         };
@@ -785,7 +795,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 
@@ -805,29 +815,8 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.INSTRUCTORS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-        };
-
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testSpecificAccessControl_instructorWithModeratorPrivilege_canAccess() {
-        loginAsInstructor(stubInstructor.getGoogleId());
-        spyFeedbackQuestion.setShowGiverNameTo(List.of(ViewerType.INSTRUCTORS));
-        spyFeedbackQuestion.setShowRecipientNameTo(List.of(ViewerType.INSTRUCTORS));
-        spyFeedbackQuestion.setShowResponsesTo(List.of(ViewerType.INSTRUCTORS));
-
-        when(mockLogic.getInstructorOfCourse(stubCourse.getId(), stubInstructor.getId()))
-                .thenReturn(stubInstructor);
-
-        spyFeedbackQuestion.setGiverType(QuestionGiverType.INSTRUCTORS);
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.INSTRUCTOR_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, stubInstructor.getId().toString(),
         };
 
         verifyCanAccess(params);
@@ -846,28 +835,12 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
                 Const.ParamsNames.USER, stubStudent.getGoogleId(),
         };
 
         verifyCanMasquerade(stubStudent.getGoogleId(), params);
-    }
-
-    @Test
-    void testSpecificAccessControl_studentModerationAttempt_cannotAccess() {
-        loginAsStudent(stubStudent.getGoogleId());
-        stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
-
-        spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
-
-        String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
-                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
-                Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, UUID.randomUUID().toString(),
-        };
-
-        verifyCannotAccess(params);
     }
 
     @Test
@@ -877,7 +850,7 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         spyFeedbackQuestion.setGiverType(QuestionGiverType.STUDENTS);
 
         String[] params = {
-                Const.ParamsNames.FEEDBACK_QUESTION_ID, spyFeedbackQuestion.getId().toString(),
+                Const.ParamsNames.FEEDBACK_SESSION_ID, stubFeedbackSession.getId().toString(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
 

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -37,8 +38,8 @@ import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
+import teammates.ui.output.FeedbackQuestionResponsesData;
 import teammates.ui.output.FeedbackResponseData;
-import teammates.ui.output.FeedbackResponsesData;
 import teammates.ui.request.FeedbackResponsesRequest;
 import teammates.ui.request.Intent;
 
@@ -169,6 +170,12 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
             return new ResponseRecipient(stubStudent.getTeam());
         }
         return new ResponseRecipient();
+    }
+
+    private List<FeedbackResponseData> flattenResponses(FeedbackQuestionResponsesData result) {
+        return result.getQuestionResponses().values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
     }
 
     @Test
@@ -345,10 +352,11 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(1, result.getResponses().size());
-        FeedbackResponseData responseData = result.getResponses().get(0);
+        assertEquals(1, submittedResponses.size());
+        FeedbackResponseData responseData = submittedResponses.get(0);
         assertEquals(stubStudent.getEmail(), responseData.getGiverIdentifier());
         assertEquals(recipientStudent1.getEmail(), responseData.getRecipientIdentifier());
 
@@ -388,10 +396,11 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(1, result.getResponses().size());
-        FeedbackResponseData responseData = result.getResponses().get(0);
+        assertEquals(1, submittedResponses.size());
+        FeedbackResponseData responseData = submittedResponses.get(0);
         assertEquals(stubInstructor.getEmail(), responseData.getGiverIdentifier());
         assertEquals(recipientInstructor1.getEmail(), responseData.getRecipientIdentifier());
 
@@ -447,9 +456,10 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(1, result.getResponses().size());
+        assertEquals(1, submittedResponses.size());
         verify(mockLogic).submitFeedbackResponsesFromStudent(
                 any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class));
     }
@@ -481,10 +491,11 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(1, result.getResponses().size());
-        assertEquals(stubStudent.getTeamName(), result.getResponses().get(0).getGiverIdentifier());
+        assertEquals(1, submittedResponses.size());
+        assertEquals(stubStudent.getTeamName(), submittedResponses.get(0).getGiverIdentifier());
         verify(mockLogic).submitFeedbackResponsesFromStudent(
                 any(FeedbackSession.class), any(Student.class), any(FeedbackResponsesRequest.class));
     }
@@ -521,9 +532,10 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(2, result.getResponses().size());
+        assertEquals(2, submittedResponses.size());
     }
 
     @Test
@@ -557,9 +569,10 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(2, result.getResponses().size());
+        assertEquals(2, submittedResponses.size());
     }
 
     @Test
@@ -590,10 +603,11 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(1, result.getResponses().size());
-        assertEquals(teamName, result.getResponses().get(0).getRecipientIdentifier());
+        assertEquals(1, submittedResponses.size());
+        assertEquals(teamName, submittedResponses.get(0).getRecipientIdentifier());
     }
 
     @Test
@@ -649,9 +663,10 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         FeedbackResponsesRequest requestBody = getRequestBody(responses);
 
         SubmitFeedbackResponsesAction action = getAction(requestBody, params);
-        FeedbackResponsesData result = (FeedbackResponsesData) getJsonResult(action).getOutput();
+        FeedbackQuestionResponsesData result = (FeedbackQuestionResponsesData) getJsonResult(action).getOutput();
+        List<FeedbackResponseData> submittedResponses = flattenResponses(result);
 
-        assertEquals(2, result.getResponses().size());
+        assertEquals(2, submittedResponses.size());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
-import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -397,7 +397,8 @@
                             class="btn-add-comment btn btn-light btn-sm"
                             (click)="addNewParticipantCommentToResponse(i)"
                             [disabled]="
-                              isFormsDisabled || recipientSubmissionFormModel.status === ResponseSubmissionStatus.NEW
+                              isFormsDisabled ||
+                              isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)
                             "
                           >
                             <i class="fas fa-comment"></i> [Optional] Comment on your response

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -397,8 +397,7 @@
                             class="btn-add-comment btn btn-light btn-sm"
                             (click)="addNewParticipantCommentToResponse(i)"
                             [disabled]="
-                              isFormsDisabled ||
-                              isFeedbackResponseDetailsEmpty(recipientSubmissionFormModel.responseDetails)
+                              isFormsDisabled || recipientSubmissionFormModel.status === ResponseSubmissionStatus.NEW
                             "
                           >
                             <i class="fas fa-comment"></i> [Optional] Comment on your response

--- a/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.spec.ts
@@ -300,7 +300,7 @@ describe('QuestionSubmissionFormComponent', () => {
     expect(model.recipientSubmissionForms).toEqual([formResponse3, formResponse4, formResponse2, formResponse1]);
   });
 
-  it('sets isSaved to false if some response has changed', () => {
+  it('sets isSaved to true if some response has changed', () => {
     component.model.recipientSubmissionForms.push(
       { ...recipientSubmissionFormBuilder.build(), status: ResponseSubmissionStatus.SAVED },
       { ...recipientSubmissionFormBuilder.build(), status: ResponseSubmissionStatus.MODIFIED },
@@ -308,7 +308,7 @@ describe('QuestionSubmissionFormComponent', () => {
 
     fixture.detectChanges();
 
-    expect(component.isSaved).toBeFalsy();
+    expect(component.isSaved).toBeTruthy();
   });
 
   it('sets isSaved to false if no response has changed and all responses are empty', () => {

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -397,9 +397,21 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
     this.model.recipientSubmissionForms[index] = {
       ...this.model.recipientSubmissionForms[index],
-      status: ResponseSubmissionStatus.MODIFIED,
       [field]: data,
     };
+
+    if (
+      this.model.recipientSubmissionForms[index].responseId ||
+      !this.feedbackResponseService.isFeedbackResponseDetailsEmpty(
+        this.model.questionType,
+        this.model.recipientSubmissionForms[index].responseDetails,
+      )
+    ) {
+      this.model.recipientSubmissionForms[index].status = ResponseSubmissionStatus.MODIFIED;
+    } else {
+      // Response details is empty and response has not been saved before
+      this.model.recipientSubmissionForms[index].status = ResponseSubmissionStatus.NEW;
+    }
 
     this.updateIsValidByQuestionConstraint();
     this.formModelChange.emit(this.model);

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -125,10 +125,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   ResponseSubmissionStatus!: typeof ResponseSubmissionStatus;
 
   get isSaved(): boolean {
-    return (
-      this.model.recipientSubmissionForms.length > 0 &&
-      this.model.recipientSubmissionForms.every((form) => form.status === ResponseSubmissionStatus.SAVED)
-    );
+    return this.model.recipientSubmissionForms.some((form) => form.status === ResponseSubmissionStatus.SAVED);
   }
 
   @Input()

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -188,7 +188,7 @@
                 [isSubmissionDisabled]="isSubmissionFormsDisabled"
                 [isFormsDisabled]="isSubmissionFormsDisabled && !this.previewAsPerson"
                 [isSavingResponses]="isSavingResponses"
-                (responsesSave)="saveFeedbackResponses([$event], entry.key)"
+                (responsesSave)="saveFeedbackResponses([$event])"
                 (deleteCommentEvent)="deleteParticipantComment(i, $event)"
                 [isQuestionCountOne]="isQuestionCountOne"
                 [currentSelectedSessionView]="currentSelectedSessionView"
@@ -236,7 +236,7 @@
             [isSubmissionDisabled]="isSubmissionFormsDisabled"
             [isFormsDisabled]="isSubmissionFormsDisabled && !this.previewAsPerson"
             [isSavingResponses]="isSavingResponses"
-            (responsesSave)="saveFeedbackResponses([$event], null)"
+            (responsesSave)="saveFeedbackResponses([$event])"
             (deleteCommentEvent)="deleteParticipantComment(i, $event)"
             [isQuestionCountOne]="isQuestionCountOne"
           ></tm-question-submission-form>
@@ -258,7 +258,7 @@
           [isSubmissionDisabled]="isSubmissionFormsDisabled"
           [isFormsDisabled]="isSubmissionFormsDisabled && !this.previewAsPerson"
           [isSavingResponses]="isSavingResponses"
-          (responsesSave)="saveFeedbackResponses([$event], null)"
+          (responsesSave)="saveFeedbackResponses([$event])"
           (deleteCommentEvent)="deleteParticipantComment(i, $event)"
           [isQuestionCountOne]="isQuestionCountOne"
           [currentSelectedSessionView]="currentSelectedSessionView"
@@ -294,7 +294,7 @@
               type="submit"
               class="btn btn-success"
               ngbTooltip="You can save your responses at any time and come back later to continue."
-              (click)="saveFeedbackResponses(questionSubmissionForms, null)"
+              (click)="saveFeedbackResponses(questionSubmissionForms)"
               [disabled]="isSavingResponses || isSubmissionFormsDisabled"
             >
               @if (isSavingResponses) {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1065,31 +1065,21 @@ describe('SessionSubmissionPageComponent', () => {
     testQuestionSubmissionForm2.recipientSubmissionForms[0].responseDetails = testResponseDetails2;
     component.questionSubmissionForms = [testQuestionSubmissionForm1, testQuestionSubmissionForm2];
 
-    const responseSpy = vi
-      .spyOn(feedbackResponsesService, 'submitFeedbackResponses')
-      .mockReturnValueOnce(
-        of({
-          questionResponses: {
-            'feedback-question-id-mcq': [testResponse1],
-          },
-          requestId: '10',
-        }),
-      )
-      .mockReturnValueOnce(
-        of({
-          questionResponses: {
-            'feedback-question-id-text': [testResponse2],
-          },
-          requestId: '20',
-        }),
-      );
+    const responseSpy = vi.spyOn(feedbackResponsesService, 'submitFeedbackResponses').mockReturnValueOnce(
+      of({
+        questionResponses: {
+          'feedback-question-id-mcq': [testResponse1],
+          'feedback-question-id-text': [testResponse2],
+        },
+        requestId: '10',
+      }),
+    );
     vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
 
     component.saveFeedbackResponses(component.questionSubmissionForms, null);
 
-    expect(responseSpy).toHaveBeenCalledTimes(2);
-    expect(responseSpy).toHaveBeenNthCalledWith(
-      1,
+    expect(responseSpy).toHaveBeenCalledTimes(1);
+    expect(responseSpy).toHaveBeenCalledWith(
       component.feedbackSessionId,
       {
         questionResponses: {
@@ -1101,19 +1091,6 @@ describe('SessionSubmissionPageComponent', () => {
               giverComment: 'comment text here',
             },
           ],
-        },
-      },
-      {
-        intent: 'STUDENT_SUBMISSION',
-        singlerecipientidforsubmission: '',
-        key: 'reg-key',
-        moderatedperson: '',
-      },
-    );
-    expect(responseSpy).toHaveBeenLastCalledWith(
-      component.feedbackSessionId,
-      {
-        questionResponses: {
           'feedback-question-id-text': [], // do not call for empty response details
         },
       },
@@ -1182,7 +1159,7 @@ describe('SessionSubmissionPageComponent', () => {
       },
     );
 
-    // only the valid response is saved
+    // valid questions are submitted; invalid ones are shown in the completion modal
     expect(mockModalRef.componentInstance.questions).toEqual([
       testQuestionSubmissionForm1,
       testQuestionSubmissionForm2,
@@ -1193,6 +1170,32 @@ describe('SessionSubmissionPageComponent', () => {
     expect(component.questionSubmissionForms[1].recipientSubmissionForms[0].status).toBe(
       ResponseSubmissionStatus.MODIFIED,
     );
+  });
+
+  it('should show one backend error modal when batch save fails', () => {
+    const testResponseDetails1: any = deepCopy(testMcqRecipientSubmissionForm.responseDetails);
+    const testQuestionSubmissionForm1: QuestionSubmissionFormModel = deepCopy(testMcqQuestionSubmissionForm);
+    testQuestionSubmissionForm1.recipientSubmissionForms[0].responseDetails = testResponseDetails1;
+    component.questionSubmissionForms = [testQuestionSubmissionForm1];
+
+    vi.spyOn(feedbackResponsesService, 'submitFeedbackResponses').mockReturnValue(
+      throwError(() => ({
+        error: {
+          message: 'backend error',
+        },
+      })),
+    );
+    const simpleModalSpy = vi.spyOn(simpleModalService, 'openInformationModal');
+    const ngbModalSpy = vi.spyOn(ngbModal, 'open');
+
+    component.saveFeedbackResponses(component.questionSubmissionForms, null);
+
+    expect(simpleModalSpy).toHaveBeenCalledWith(
+      'Saving Failed',
+      SimpleModalType.DANGER,
+      'An error occurred and your responses could not be saved. backend error',
+    );
+    expect(ngbModalSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should delete participant comment', () => {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1067,12 +1067,8 @@ describe('SessionSubmissionPageComponent', () => {
 
     const responseSpy = vi
       .spyOn(feedbackResponsesService, 'submitFeedbackResponses')
-      .mockImplementation((id: string) => {
-        if (id === testQuestionSubmissionForm1.feedbackQuestionId) {
-          return of({ responses: [testResponse1], requestId: '10' });
-        }
-        return of({ responses: [testResponse2], requestId: '20' });
-      });
+      .mockReturnValueOnce(of({ responses: [testResponse1], requestId: '10' }))
+      .mockReturnValueOnce(of({ responses: [testResponse2], requestId: '20' }));
     vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
 
     component.saveFeedbackResponses(component.questionSubmissionForms, null);
@@ -1080,15 +1076,17 @@ describe('SessionSubmissionPageComponent', () => {
     expect(responseSpy).toHaveBeenCalledTimes(2);
     expect(responseSpy).toHaveBeenNthCalledWith(
       1,
-      'feedback-question-id-mcq',
+      component.feedbackSessionId,
       {
-        responses: [
-          {
-            recipient: testMcqRecipientSubmissionForm.recipientIdentifier,
-            responseDetails: testResponseDetails1,
-            giverComment: 'comment text here',
-          },
-        ],
+        questionResponses: {
+          'feedback-question-id-mcq': [
+            {
+              recipient: testMcqRecipientSubmissionForm.recipientIdentifier,
+              responseDetails: testResponseDetails1,
+              giverComment: 'comment text here',
+            },
+          ],
+        },
       },
       {
         intent: 'STUDENT_SUBMISSION',
@@ -1098,9 +1096,11 @@ describe('SessionSubmissionPageComponent', () => {
       },
     );
     expect(responseSpy).toHaveBeenLastCalledWith(
-      'feedback-question-id-text',
+      component.feedbackSessionId,
       {
-        responses: [], // do not call for empty response details
+        questionResponses: {
+          'feedback-question-id-text': [], // do not call for empty response details
+        },
       },
       {
         intent: 'STUDENT_SUBMISSION',
@@ -1141,15 +1141,17 @@ describe('SessionSubmissionPageComponent', () => {
     expect(responseSpy).toHaveBeenCalledTimes(1);
     expect(responseSpy).toHaveBeenNthCalledWith(
       1,
-      testQuestionSubmissionForm1.feedbackQuestionId,
+      component.feedbackSessionId,
       {
-        responses: [
-          {
-            recipient: testMcqRecipientSubmissionForm.recipientIdentifier,
-            responseDetails: testResponseDetails1,
-            giverComment: 'comment text here',
-          },
-        ],
+        questionResponses: {
+          [testQuestionSubmissionForm1.feedbackQuestionId]: [
+            {
+              recipient: testMcqRecipientSubmissionForm.recipientIdentifier,
+              responseDetails: testResponseDetails1,
+              giverComment: 'comment text here',
+            },
+          ],
+        },
       },
       {
         intent: 'STUDENT_SUBMISSION',

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1193,7 +1193,7 @@ describe('SessionSubmissionPageComponent', () => {
     expect(simpleModalSpy).toHaveBeenCalledWith(
       'Saving Failed',
       SimpleModalType.DANGER,
-      'An error occurred and your responses could not be saved. backend error',
+      'An error occurred and your responses could not be saved. Error details: backend error',
     );
     expect(ngbModalSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1063,7 +1063,6 @@ describe('SessionSubmissionPageComponent', () => {
     testQuestionSubmissionForm1.recipientSubmissionForms[0].status = ResponseSubmissionStatus.MODIFIED;
     testQuestionSubmissionForm1.recipientSubmissionForms[0].responseDetails = testResponseDetails1;
     testQuestionSubmissionForm2.recipientSubmissionForms[0].responseDetails = testResponseDetails2;
-    testQuestionSubmissionForm2.recipientSubmissionForms[0].status = ResponseSubmissionStatus.NEW;
     testQuestionSubmissionForm2.recipientSubmissionForms[0].responseId = '';
     component.questionSubmissionForms = [testQuestionSubmissionForm1, testQuestionSubmissionForm2];
 
@@ -1093,7 +1092,7 @@ describe('SessionSubmissionPageComponent', () => {
               giverComment: 'comment text here',
             },
           ],
-          'feedback-question-id-text': [], // do not call if status is NEW (unanswered)
+          // do not call for testQuestionSubmissionForm2 since it is empty
         },
       },
       {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1063,6 +1063,8 @@ describe('SessionSubmissionPageComponent', () => {
     testQuestionSubmissionForm1.recipientSubmissionForms[0].status = ResponseSubmissionStatus.MODIFIED;
     testQuestionSubmissionForm1.recipientSubmissionForms[0].responseDetails = testResponseDetails1;
     testQuestionSubmissionForm2.recipientSubmissionForms[0].responseDetails = testResponseDetails2;
+    testQuestionSubmissionForm2.recipientSubmissionForms[0].status = ResponseSubmissionStatus.NEW;
+    testQuestionSubmissionForm2.recipientSubmissionForms[0].responseId = '';
     component.questionSubmissionForms = [testQuestionSubmissionForm1, testQuestionSubmissionForm2];
 
     const responseSpy = vi.spyOn(feedbackResponsesService, 'submitFeedbackResponses').mockReturnValueOnce(
@@ -1091,7 +1093,7 @@ describe('SessionSubmissionPageComponent', () => {
               giverComment: 'comment text here',
             },
           ],
-          'feedback-question-id-text': [], // do not call for empty response details
+          'feedback-question-id-text': [], // do not call if status is NEW (unanswered)
         },
       },
       {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1067,8 +1067,22 @@ describe('SessionSubmissionPageComponent', () => {
 
     const responseSpy = vi
       .spyOn(feedbackResponsesService, 'submitFeedbackResponses')
-      .mockReturnValueOnce(of({ responses: [testResponse1], requestId: '10' }))
-      .mockReturnValueOnce(of({ responses: [testResponse2], requestId: '20' }));
+      .mockReturnValueOnce(
+        of({
+          questionResponses: {
+            'feedback-question-id-mcq': [testResponse1],
+          },
+          requestId: '10',
+        }),
+      )
+      .mockReturnValueOnce(
+        of({
+          questionResponses: {
+            'feedback-question-id-text': [testResponse2],
+          },
+          requestId: '20',
+        }),
+      );
     vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
 
     component.saveFeedbackResponses(component.questionSubmissionForms, null);
@@ -1133,7 +1147,12 @@ describe('SessionSubmissionPageComponent', () => {
     component.questionSubmissionForms = [testQuestionSubmissionForm1, testQuestionSubmissionForm2];
 
     const responseSpy = vi.spyOn(feedbackResponsesService, 'submitFeedbackResponses').mockImplementation(() => {
-      return of({ responses: [testResponse1], requestId: '10' });
+      return of({
+        questionResponses: {
+          [testQuestionSubmissionForm1.feedbackQuestionId]: [testResponse1],
+        },
+        requestId: '10',
+      });
     });
     vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1076,7 +1076,7 @@ describe('SessionSubmissionPageComponent', () => {
     );
     vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
 
-    component.saveFeedbackResponses(component.questionSubmissionForms, null);
+    component.saveFeedbackResponses(component.questionSubmissionForms);
 
     expect(responseSpy).toHaveBeenCalledTimes(1);
     expect(responseSpy).toHaveBeenCalledWith(
@@ -1096,7 +1096,6 @@ describe('SessionSubmissionPageComponent', () => {
       },
       {
         intent: 'STUDENT_SUBMISSION',
-        singlerecipientidforsubmission: '',
         key: 'reg-key',
         moderatedperson: '',
       },
@@ -1133,7 +1132,7 @@ describe('SessionSubmissionPageComponent', () => {
     });
     vi.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
 
-    component.saveFeedbackResponses(component.questionSubmissionForms, null);
+    component.saveFeedbackResponses(component.questionSubmissionForms);
 
     expect(responseSpy).toHaveBeenCalledTimes(1);
     expect(responseSpy).toHaveBeenNthCalledWith(
@@ -1155,7 +1154,6 @@ describe('SessionSubmissionPageComponent', () => {
         intent: 'STUDENT_SUBMISSION',
         key: 'reg-key',
         moderatedperson: '',
-        singlerecipientidforsubmission: '',
       },
     );
 
@@ -1188,7 +1186,7 @@ describe('SessionSubmissionPageComponent', () => {
     const simpleModalSpy = vi.spyOn(simpleModalService, 'openInformationModal');
     const ngbModalSpy = vi.spyOn(ngbModal, 'open');
 
-    component.saveFeedbackResponses(component.questionSubmissionForms, null);
+    component.saveFeedbackResponses(component.questionSubmissionForms);
 
     expect(simpleModalSpy).toHaveBeenCalledWith(
       'Saving Failed',

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1081,6 +1081,7 @@ describe('SessionSubmissionPageComponent', () => {
         questionResponses: {
           'feedback-question-id-mcq': [
             {
+              responseId: testMcqRecipientSubmissionForm.responseId,
               recipient: testMcqRecipientSubmissionForm.recipientIdentifier,
               responseDetails: testResponseDetails1,
               giverComment: 'comment text here',
@@ -1146,6 +1147,7 @@ describe('SessionSubmissionPageComponent', () => {
         questionResponses: {
           [testQuestionSubmissionForm1.feedbackQuestionId]: [
             {
+              responseId: testMcqRecipientSubmissionForm.responseId,
               recipient: testMcqRecipientSubmissionForm.recipientIdentifier,
               responseDetails: testResponseDetails1,
               giverComment: 'comment text here',

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -5,8 +5,8 @@ import { ActivatedRoute } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 import { DestroyableDirective, InViewportDirective } from 'ng-in-viewport';
-import { forkJoin, Observable, of } from 'rxjs';
-import { catchError, finalize, switchMap, tap } from 'rxjs/operators';
+import { forkJoin, Observable } from 'rxjs';
+import { finalize, switchMap, tap } from 'rxjs/operators';
 import { SavingCompleteModalComponent } from './saving-complete-modal/saving-complete-modal.component';
 import { SessionView } from './session-view.enum';
 import { environment } from '../../../environments/environment';
@@ -799,16 +799,18 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   saveFeedbackResponses(questionSubmissionForms: QuestionSubmissionFormModel[], recipientId: string | null): void {
     const notYetAnsweredQuestions: Set<number> = new Set();
     const failToSaveQuestions: Record<number, string> = {}; // Map of question number to error message
-    const savingRequests: Observable<any>[] = [];
+    const questionResponses: Record<string, FeedbackResponseRequest[]> = {};
 
     questionSubmissionForms.forEach((questionSubmissionFormModel: QuestionSubmissionFormModel) => {
       const responses: FeedbackResponseRequest[] = [];
+      let hasValidationErrorInQuestion = false;
 
       questionSubmissionFormModel.recipientSubmissionForms.forEach(
         (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) => {
           if (!recipientSubmissionFormModel.isValid) {
             failToSaveQuestions[questionSubmissionFormModel.questionNumber] =
               'Invalid responses provided. Please check question constraints.';
+            hasValidationErrorInQuestion = true;
             return;
           }
           const isFeedbackResponseDetailsEmpty: boolean = this.feedbackResponsesService.isFeedbackResponseDetailsEmpty(
@@ -828,59 +830,8 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       );
 
       const isQuestionFullyAnswered = responses.length > 0;
-
-      if (!failToSaveQuestions[questionSubmissionFormModel.questionNumber]) {
-        savingRequests.push(
-          this.feedbackResponsesService
-            .submitFeedbackResponses(
-              this.feedbackSessionId,
-              {
-                questionResponses: {
-                  [questionSubmissionFormModel.feedbackQuestionId]: responses,
-                },
-              },
-              {
-                intent: this.intent,
-                key: this.regKey,
-                moderatedperson: this.moderatedPerson,
-                singlerecipientidforsubmission: recipientId?.toString() || '',
-              },
-            )
-            .pipe(
-              tap((resp: FeedbackQuestionResponses) => {
-                const submittedQuestionResponses: FeedbackResponse[] =
-                  resp.questionResponses[questionSubmissionFormModel.feedbackQuestionId] ?? [];
-                const responsesMap: Record<string, FeedbackResponse> = {};
-                submittedQuestionResponses.forEach((response: FeedbackResponse) => {
-                  responsesMap[response.recipientIdentifier] = response;
-                });
-
-                questionSubmissionFormModel.recipientSubmissionForms.forEach(
-                  (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) => {
-                    if (responsesMap[recipientSubmissionFormModel.recipientIdentifier]) {
-                      const correspondingResp: FeedbackResponse =
-                        responsesMap[recipientSubmissionFormModel.recipientIdentifier];
-                      recipientSubmissionFormModel.responseId = correspondingResp.feedbackResponseId;
-                      recipientSubmissionFormModel.status = ResponseSubmissionStatus.SAVED;
-                      recipientSubmissionFormModel.responseDetails = correspondingResp.responseDetails;
-                      recipientSubmissionFormModel.recipientIdentifier = correspondingResp.recipientIdentifier;
-                      recipientSubmissionFormModel.commentByGiver = correspondingResp.giverComment
-                        ? this.getGiverCommentModel(correspondingResp.giverComment)
-                        : undefined;
-                    } else {
-                      recipientSubmissionFormModel.responseId = '';
-                      recipientSubmissionFormModel.status = ResponseSubmissionStatus.NEW;
-                      recipientSubmissionFormModel.commentByGiver = undefined;
-                    }
-                  },
-                );
-              }),
-              catchError((error: ErrorMessageOutput) => {
-                failToSaveQuestions[questionSubmissionFormModel.questionNumber] = error.error.message;
-                return of(error);
-              }),
-            ),
-        );
+      if (!hasValidationErrorInQuestion) {
+        questionResponses[questionSubmissionFormModel.feedbackQuestionId] = responses;
       }
 
       if (!isQuestionFullyAnswered) {
@@ -888,19 +839,101 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       }
     });
 
+    if (Object.keys(questionResponses).length === 0) {
+      this.openSavingCompleteModal(questionSubmissionForms, notYetAnsweredQuestions, failToSaveQuestions);
+      return;
+    }
+
+    this.submitFeedbackResponses(
+      questionResponses,
+      recipientId,
+      questionSubmissionForms,
+      notYetAnsweredQuestions,
+      failToSaveQuestions,
+    );
+  }
+
+  private submitFeedbackResponses(
+    questionResponses: Record<string, FeedbackResponseRequest[]>,
+    recipientId: string | null,
+    questionSubmissionForms: QuestionSubmissionFormModel[],
+    notYetAnsweredQuestions: Set<number>,
+    failToSaveQuestions: Record<number, string>,
+  ) {
     this.isSavingResponses = true;
-    forkJoin(savingRequests)
+    this.feedbackResponsesService
+      .submitFeedbackResponses(
+        this.feedbackSessionId,
+        { questionResponses },
+        {
+          intent: this.intent,
+          key: this.regKey,
+          moderatedperson: this.moderatedPerson,
+          singlerecipientidforsubmission: recipientId?.toString() || '',
+        },
+      )
       .pipe(
         finalize(() => {
           this.isSavingResponses = false;
-
-          const modalRef: NgbModalRef = this.ngbModal.open(SavingCompleteModalComponent);
-          modalRef.componentInstance.questions = questionSubmissionForms;
-          modalRef.componentInstance.notYetAnsweredQuestions = Array.from(notYetAnsweredQuestions.values());
-          modalRef.componentInstance.failToSaveQuestions = failToSaveQuestions;
         }),
       )
-      .subscribe();
+      .subscribe({
+        next: (resp: FeedbackQuestionResponses) => {
+          questionSubmissionForms.forEach((questionSubmissionFormModel: QuestionSubmissionFormModel) => {
+            if (!(questionSubmissionFormModel.feedbackQuestionId in questionResponses)) {
+              return;
+            }
+
+            const submittedQuestionResponses: FeedbackResponse[] =
+              resp.questionResponses[questionSubmissionFormModel.feedbackQuestionId] ?? [];
+            const responsesMap: Record<string, FeedbackResponse> = {};
+            submittedQuestionResponses.forEach((response: FeedbackResponse) => {
+              responsesMap[response.recipientIdentifier] = response;
+            });
+
+            questionSubmissionFormModel.recipientSubmissionForms.forEach(
+              (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) => {
+                if (responsesMap[recipientSubmissionFormModel.recipientIdentifier]) {
+                  const correspondingResp: FeedbackResponse =
+                    responsesMap[recipientSubmissionFormModel.recipientIdentifier];
+                  recipientSubmissionFormModel.responseId = correspondingResp.feedbackResponseId;
+                  recipientSubmissionFormModel.status = ResponseSubmissionStatus.SAVED;
+                  recipientSubmissionFormModel.responseDetails = correspondingResp.responseDetails;
+                  recipientSubmissionFormModel.recipientIdentifier = correspondingResp.recipientIdentifier;
+                  recipientSubmissionFormModel.commentByGiver = correspondingResp.giverComment
+                    ? this.getGiverCommentModel(correspondingResp.giverComment)
+                    : undefined;
+                } else {
+                  recipientSubmissionFormModel.responseId = '';
+                  recipientSubmissionFormModel.status = ResponseSubmissionStatus.NEW;
+                  recipientSubmissionFormModel.commentByGiver = undefined;
+                }
+              },
+            );
+          });
+
+          this.openSavingCompleteModal(questionSubmissionForms, notYetAnsweredQuestions, failToSaveQuestions);
+        },
+        error: (resp: ErrorMessageOutput) => {
+          const contextMessage = resp.error?.message ?? 'An unknown error occurred.';
+          this.simpleModalService.openInformationModal(
+            'Saving Failed',
+            SimpleModalType.DANGER,
+            `An error occurred and your responses could not be saved. Error details: ${contextMessage}`,
+          );
+        },
+      });
+  }
+
+  private openSavingCompleteModal(
+    questionSubmissionForms: QuestionSubmissionFormModel[],
+    notYetAnsweredQuestions: Set<number>,
+    failToSaveQuestions: Record<number, string>,
+  ): void {
+    const modalRef: NgbModalRef = this.ngbModal.open(SavingCompleteModalComponent);
+    modalRef.componentInstance.questions = questionSubmissionForms;
+    modalRef.componentInstance.notYetAnsweredQuestions = Array.from(notYetAnsweredQuestions.values());
+    modalRef.componentInstance.failToSaveQuestions = failToSaveQuestions;
   }
 
   downloadSubmissionReceipt(): void {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -811,10 +811,9 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
             hasValidationErrorInQuestion = true;
             return;
           }
-          const isFeedbackResponseDetailsEmpty: boolean = this.feedbackResponsesService.isFeedbackResponseDetailsEmpty(
-            questionSubmissionFormModel.questionType,
-            recipientSubmissionFormModel.responseDetails,
-          );
+
+          const isFeedbackResponseDetailsEmpty: boolean =
+            recipientSubmissionFormModel.status === ResponseSubmissionStatus.NEW;
 
           if (!isFeedbackResponseDetailsEmpty) {
             responses.push({

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -805,17 +805,26 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
       questionSubmissionFormModel.recipientSubmissionForms.forEach(
         (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) => {
-          if (!recipientSubmissionFormModel.isValid) {
+          // Consider untouched questions to be valid
+          // Untouched questions are those that are not filled in and are not saved before
+          const isValid =
+            recipientSubmissionFormModel.status === ResponseSubmissionStatus.NEW ||
+            recipientSubmissionFormModel.isValid;
+
+          if (!isValid) {
             failToSaveQuestions[questionSubmissionFormModel.questionNumber] =
               'Invalid responses provided. Please check question constraints.';
             hasValidationErrorInQuestion = true;
             return;
           }
 
-          const isFeedbackResponseDetailsEmpty: boolean =
-            recipientSubmissionFormModel.status === ResponseSubmissionStatus.NEW;
-
-          if (!isFeedbackResponseDetailsEmpty) {
+          if (
+            !this.feedbackResponsesService.isFeedbackResponseDetailsEmpty(
+              questionSubmissionFormModel.questionType,
+              recipientSubmissionFormModel.responseDetails,
+            )
+          ) {
+            // Only include non-empty responses in the request, empty responses will be deleted in the backend
             responses.push({
               responseId: recipientSubmissionFormModel.responseId,
               recipient: recipientSubmissionFormModel.recipientIdentifier,
@@ -827,7 +836,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       );
 
       const isQuestionFullyAnswered = responses.length > 0;
-      if (!hasValidationErrorInQuestion) {
+      if (!hasValidationErrorInQuestion && isQuestionFullyAnswered) {
         questionResponses[questionSubmissionFormModel.feedbackQuestionId] = responses;
       }
 
@@ -898,6 +907,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                     ? this.getGiverCommentModel(correspondingResp.giverComment)
                     : undefined;
                 } else {
+                  // empty response is deleted in the backend, reset the form model to default state
                   recipientSubmissionFormModel.responseId = '';
                   recipientSubmissionFormModel.status = ResponseSubmissionStatus.NEW;
                   recipientSubmissionFormModel.commentByGiver = undefined;

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -793,10 +793,8 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
    * <p>All empty feedback response will be deleted; For non-empty responses, update/create them if necessary.
    *
    * @param questionSubmissionForms An array of question submission forms to be saved
-   * @param recipientId The recipient identifier of the selected recipient when saving responses for this recipient
-   * only. This parameter will be null when saving responses for all questions or saving responses for one question.
    */
-  saveFeedbackResponses(questionSubmissionForms: QuestionSubmissionFormModel[], recipientId: string | null): void {
+  saveFeedbackResponses(questionSubmissionForms: QuestionSubmissionFormModel[]): void {
     const notYetAnsweredQuestions: Set<number> = new Set();
     const failToSaveQuestions: Record<number, string> = {}; // Map of question number to error message
     const questionResponses: Record<string, FeedbackResponseRequest[]> = {};
@@ -846,7 +844,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
     this.submitFeedbackResponses(
       questionResponses,
-      recipientId,
       questionSubmissionForms,
       notYetAnsweredQuestions,
       failToSaveQuestions,
@@ -855,7 +852,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
   private submitFeedbackResponses(
     questionResponses: Record<string, FeedbackResponseRequest[]>,
-    recipientId: string | null,
     questionSubmissionForms: QuestionSubmissionFormModel[],
     notYetAnsweredQuestions: Set<number>,
     failToSaveQuestions: Record<number, string>,
@@ -869,7 +865,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
           intent: this.intent,
           key: this.regKey,
           moderatedperson: this.moderatedPerson,
-          singlerecipientidforsubmission: recipientId?.toString() || '',
         },
       )
       .pipe(
@@ -1062,7 +1057,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         questionsToRecipient.has(questionSubmissionFormModel.questionNumber),
     );
 
-    this.saveFeedbackResponses(recipientQSForms, recipientId);
+    this.saveFeedbackResponses(recipientQSForms);
   }
 
   private addQuestionForRecipient(recipientId: string, questionId: any): void {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -798,7 +798,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
    */
   saveFeedbackResponses(questionSubmissionForms: QuestionSubmissionFormModel[], recipientId: string | null): void {
     const notYetAnsweredQuestions: Set<number> = new Set();
-    const requestIds: Record<string, string> = {};
     const failToSaveQuestions: Record<number, string> = {}; // Map of question number to error message
     const savingRequests: Observable<any>[] = [];
 
@@ -855,7 +854,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                 submittedQuestionResponses.forEach((response: FeedbackResponse) => {
                   responsesMap[response.recipientIdentifier] = response;
                 });
-                requestIds[questionSubmissionFormModel.feedbackQuestionId] = resp.requestId || '';
 
                 questionSubmissionFormModel.recipientSubmissionForms.forEach(
                   (recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel) => {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -819,6 +819,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
 
           if (!isFeedbackResponseDetailsEmpty) {
             responses.push({
+              responseId: recipientSubmissionFormModel.responseId,
               recipient: recipientSubmissionFormModel.recipientIdentifier,
               responseDetails: recipientSubmissionFormModel.responseDetails,
               giverComment: recipientSubmissionFormModel.commentByGiver?.commentEditFormModel.commentText ?? '',

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -833,9 +833,11 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         savingRequests.push(
           this.feedbackResponsesService
             .submitFeedbackResponses(
-              questionSubmissionFormModel.feedbackQuestionId,
+              this.feedbackSessionId,
               {
-                responses,
+                questionResponses: {
+                  [questionSubmissionFormModel.feedbackQuestionId]: responses,
+                },
               },
               {
                 intent: this.intent,

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -32,7 +32,7 @@ import {
   FeedbackQuestionRecipients,
   FeedbackQuestionType,
   FeedbackResponse,
-  FeedbackResponses,
+  FeedbackQuestionResponses,
   FeedbackSession,
   FeedbackSessionLogType,
   FeedbackSessionSubmissionStatus,
@@ -848,9 +848,11 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               },
             )
             .pipe(
-              tap((resp: FeedbackResponses) => {
+              tap((resp: FeedbackQuestionResponses) => {
+                const submittedQuestionResponses: FeedbackResponse[] =
+                  resp.questionResponses[questionSubmissionFormModel.feedbackQuestionId] ?? [];
                 const responsesMap: Record<string, FeedbackResponse> = {};
-                resp.responses.forEach((response: FeedbackResponse) => {
+                submittedQuestionResponses.forEach((response: FeedbackResponse) => {
                   responsesMap[response.recipientIdentifier] = response;
                 });
                 requestIds[questionSubmissionFormModel.feedbackQuestionId] = resp.requestId || '';

--- a/src/web/services/feedback-responses.service.spec.ts
+++ b/src/web/services/feedback-responses.service.spec.ts
@@ -360,29 +360,29 @@ describe('FeedbackResponsesService', () => {
 
   it('should call put when submitting a feedback response', () => {
     const paramMap: Record<string, string> = {
-      questionid: '[dummy question ID]',
+      fsid: '[dummy session ID]',
     };
-    const dummyRequest: FeedbackResponsesRequest = { responses: [] };
+    const dummyRequest: FeedbackResponsesRequest = { questionResponses: {} };
     const dummyAdditionalParams: { [key: string]: string } = {};
-    service.submitFeedbackResponses(paramMap['questionid'], dummyRequest, dummyAdditionalParams);
+    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyAdditionalParams);
     expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.RESPONSES, paramMap, dummyRequest);
   });
 
   it('should include additional parameters when submitting a feedback response', () => {
     const dummyIntent: Intent = Intent.STUDENT_SUBMISSION;
     const paramMap: Record<string, string> = {
-      questionid: '[dummy question ID]',
+      fsid: '[dummy session ID]',
       intent: dummyIntent,
       key: '[dummy registration key]',
       moderatedperson: '',
     };
-    const dummyRequest: FeedbackResponsesRequest = { responses: [] };
+    const dummyRequest: FeedbackResponsesRequest = { questionResponses: {} };
     const dummyAdditionalParams: { [key: string]: string } = {
       intent: dummyIntent,
       key: paramMap['key'],
       moderatedperson: paramMap['moderatedperson'],
     };
-    service.submitFeedbackResponses(paramMap['questionid'], dummyRequest, dummyAdditionalParams);
+    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyAdditionalParams);
     expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.RESPONSES, paramMap, dummyRequest);
   });
 

--- a/src/web/services/feedback-responses.service.spec.ts
+++ b/src/web/services/feedback-responses.service.spec.ts
@@ -1,7 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { FeedbackResponsesService } from './feedback-responses.service';
+import { FeedbackResponsesService, SubmitFeedbackResponsesParams } from './feedback-responses.service';
 import { HttpRequestService } from './http-request.service';
 import { InstructorSessionResultSectionType } from '../app/pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
 import createSpyFromClass from '../test-helpers/create-spy-from-class';
@@ -363,8 +363,8 @@ describe('FeedbackResponsesService', () => {
       fsid: '[dummy session ID]',
     };
     const dummyRequest: FeedbackResponsesRequest = { questionResponses: {} };
-    const dummyAdditionalParams: { [key: string]: string } = {};
-    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyAdditionalParams);
+    const dummyParams: Partial<SubmitFeedbackResponsesParams> = {};
+    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyParams);
     expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.RESPONSES, paramMap, dummyRequest);
   });
 
@@ -377,12 +377,12 @@ describe('FeedbackResponsesService', () => {
       moderatedperson: '',
     };
     const dummyRequest: FeedbackResponsesRequest = { questionResponses: {} };
-    const dummyAdditionalParams: { [key: string]: string } = {
+    const dummyParams: Partial<SubmitFeedbackResponsesParams> = {
       intent: dummyIntent,
       key: paramMap['key'],
       moderatedperson: paramMap['moderatedperson'],
     };
-    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyAdditionalParams);
+    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyParams);
     expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.RESPONSES, paramMap, dummyRequest);
   });
 

--- a/src/web/services/feedback-responses.service.spec.ts
+++ b/src/web/services/feedback-responses.service.spec.ts
@@ -1,7 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { FeedbackResponsesService, SubmitFeedbackResponsesParams } from './feedback-responses.service';
+import { FeedbackResponsesService } from './feedback-responses.service';
 import { HttpRequestService } from './http-request.service';
 import { InstructorSessionResultSectionType } from '../app/pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
 import createSpyFromClass from '../test-helpers/create-spy-from-class';
@@ -359,16 +359,6 @@ describe('FeedbackResponsesService', () => {
   });
 
   it('should call put when submitting a feedback response', () => {
-    const paramMap: Record<string, string> = {
-      fsid: '[dummy session ID]',
-    };
-    const dummyRequest: FeedbackResponsesRequest = { questionResponses: {} };
-    const dummyParams: Partial<SubmitFeedbackResponsesParams> = {};
-    service.submitFeedbackResponses(paramMap['fsid'], dummyRequest, dummyParams);
-    expect(spyHttpRequestService.put).toHaveBeenCalledWith(ResourceEndpoints.RESPONSES, paramMap, dummyRequest);
-  });
-
-  it('should include additional parameters when submitting a feedback response', () => {
     const dummyIntent: Intent = Intent.STUDENT_SUBMISSION;
     const paramMap: Record<string, string> = {
       fsid: '[dummy session ID]',
@@ -377,7 +367,7 @@ describe('FeedbackResponsesService', () => {
       moderatedperson: '',
     };
     const dummyRequest: FeedbackResponsesRequest = { questionResponses: {} };
-    const dummyParams: Partial<SubmitFeedbackResponsesParams> = {
+    const dummyParams = {
       intent: dummyIntent,
       key: paramMap['key'],
       moderatedperson: paramMap['moderatedperson'],

--- a/src/web/services/feedback-responses.service.ts
+++ b/src/web/services/feedback-responses.service.ts
@@ -14,7 +14,7 @@ import {
   FeedbackRankRecipientsResponseDetails,
   FeedbackResponseDetails,
   FeedbackResponse,
-  FeedbackResponses,
+  FeedbackQuestionResponses,
   MessageOutput,
   FeedbackRubricResponseDetails,
   FeedbackTextResponseDetails,
@@ -202,7 +202,7 @@ export class FeedbackResponsesService {
     feedbackSessionId: string,
     request: FeedbackResponsesRequest,
     additionalParams: { [key: string]: string } = {},
-  ): Observable<FeedbackResponses> {
+  ): Observable<FeedbackQuestionResponses> {
     return this.httpRequestService.put(
       ResourceEndpoints.RESPONSES,
       {

--- a/src/web/services/feedback-responses.service.ts
+++ b/src/web/services/feedback-responses.service.ts
@@ -196,17 +196,17 @@ export class FeedbackResponsesService {
   }
 
   /**
-   * Submits a list of feedback responses for a feedback question by calling API.
+   * Submits feedback responses for one or more feedback questions in a feedback session by calling API.
    */
   submitFeedbackResponses(
-    questionId: string,
+    feedbackSessionId: string,
     request: FeedbackResponsesRequest,
     additionalParams: { [key: string]: string } = {},
   ): Observable<FeedbackResponses> {
     return this.httpRequestService.put(
       ResourceEndpoints.RESPONSES,
       {
-        questionid: questionId,
+        fsid: feedbackSessionId,
         ...additionalParams,
       },
       request,

--- a/src/web/services/feedback-responses.service.ts
+++ b/src/web/services/feedback-responses.service.ts
@@ -47,12 +47,6 @@ export interface FeedbackResponsesResponse {
   responses: FeedbackResponse[];
 }
 
-export interface SubmitFeedbackResponsesParams {
-  intent: Intent;
-  key: string;
-  moderatedperson: string;
-}
-
 /**
  * Handles feedback response settings provision.
  */
@@ -207,7 +201,11 @@ export class FeedbackResponsesService {
   submitFeedbackResponses(
     feedbackSessionId: string,
     request: FeedbackResponsesRequest,
-    params: Partial<SubmitFeedbackResponsesParams> = {},
+    params: {
+      intent: Intent;
+      key: string;
+      moderatedperson: string;
+    },
   ): Observable<FeedbackQuestionResponses> {
     return this.httpRequestService.put(
       ResourceEndpoints.RESPONSES,

--- a/src/web/services/feedback-responses.service.ts
+++ b/src/web/services/feedback-responses.service.ts
@@ -47,6 +47,12 @@ export interface FeedbackResponsesResponse {
   responses: FeedbackResponse[];
 }
 
+export interface SubmitFeedbackResponsesParams {
+  intent: Intent;
+  key: string;
+  moderatedperson: string;
+}
+
 /**
  * Handles feedback response settings provision.
  */
@@ -201,13 +207,13 @@ export class FeedbackResponsesService {
   submitFeedbackResponses(
     feedbackSessionId: string,
     request: FeedbackResponsesRequest,
-    additionalParams: { [key: string]: string } = {},
+    params: Partial<SubmitFeedbackResponsesParams> = {},
   ): Observable<FeedbackQuestionResponses> {
     return this.httpRequestService.put(
       ResourceEndpoints.RESPONSES,
       {
         fsid: feedbackSessionId,
-        ...additionalParams,
+        ...params,
       },
       request,
     );

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -212,6 +212,10 @@ export interface FeedbackQuestionRecipients extends ApiOutput {
   recipients: FeedbackQuestionRecipient[];
 }
 
+export interface FeedbackQuestionResponses extends ApiOutput {
+  questionResponses: { [index: string]: FeedbackResponse[] };
+}
+
 export interface FeedbackQuestions extends ApiOutput {
   questions: FeedbackQuestion[];
 }

--- a/src/web/types/api-request.ts
+++ b/src/web/types/api-request.ts
@@ -118,6 +118,7 @@ export interface FeedbackResponseDetails {
 }
 
 export interface FeedbackResponseRequest extends BasicRequest {
+  responseId?: string;
   recipient: string;
   responseDetails: FeedbackResponseDetails;
   giverComment: string;

--- a/src/web/types/api-request.ts
+++ b/src/web/types/api-request.ts
@@ -124,7 +124,7 @@ export interface FeedbackResponseRequest extends BasicRequest {
 }
 
 export interface FeedbackResponsesRequest extends BasicRequest {
-  responses: FeedbackResponseRequest[];
+  questionResponses: { [index: string]: FeedbackResponseRequest[] };
 }
 
 export interface FeedbackRubricResponseDetails extends FeedbackResponseDetails {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Currently, we only support submitting of responses for a single question. This PR changes the submission action to support submission of responses for multiple questions at once.

Another change is that backend errors now result in a single error message being shown (rather than question specific errors). Since the responses are pre-validated on the frontend, validation errors for specific questions are unlikely to happen (and if they do the frontend validator should be updated). Instead, the most likely errors are not question specific (e.g. feedback session closed).

This also unblocks #13590.

Next steps:
1. Optimisation of submission endpoint. There is a lot of room for optimisation by reducing the number of DB calls. 
2. UX work on saving complete modal. There is also a lot of room to make the status of the submission clear. It's very confusing at the moment. Apart from the verbosity, the main issue is that it does not clarify the main question - what exactly has been submitted?