### PR TITLE
[#13597] Migrate instructor results page away from angular animations package

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -322,9 +322,6 @@ public class InstructorFeedbackResultsPage extends AppPage {
                                   Collection<Student> students) {
         selectViewType(QUESTION_VIEW);
         WebElement questionPanel = getQuestionPanel(question.getQuestionNumber());
-        // re-expand question panel to reset sorting order
-        hideQuestionPanel(questionPanel);
-        expandQuestionPanel(questionPanel);
         verifyStatistics(questionPanel, question, responses, instructors, students);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -419,7 +420,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
                     }
                 }
                 return true;
-            } catch (NoSuchElementException e) {
+            } catch (NoSuchElementException | StaleElementReferenceException | IndexOutOfBoundsException e) {
                 return false;
             }
         });
@@ -434,24 +435,28 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     private WebElement findMatchingRow(WebElement table, String[] expectedRowValues) {
-        List<WebElement> rows = table.findElement(By.tagName("tbody")).findElements(By.tagName("tr"));
-        for (WebElement row : rows) {
-            List<WebElement> cells = row.findElements(By.tagName("td"));
-            if (cells.size() < expectedRowValues.length) {
-                continue;
-            }
-            boolean isMatch = true;
-            for (int i = 0; i < expectedRowValues.length; i++) {
-                if (!expectedRowValues[i].equals(cells.get(i).getText())) {
-                    isMatch = false;
-                    break;
+        try {
+            List<WebElement> rows = table.findElement(By.tagName("tbody")).findElements(By.tagName("tr"));
+            for (WebElement row : rows) {
+                List<WebElement> cells = row.findElements(By.tagName("td"));
+                if (cells.size() < expectedRowValues.length) {
+                    continue;
+                }
+                boolean isMatch = true;
+                for (int i = 0; i < expectedRowValues.length; i++) {
+                    if (!expectedRowValues[i].equals(cells.get(i).getText())) {
+                        isMatch = false;
+                        break;
+                    }
+                }
+                if (isMatch) {
+                    return row;
                 }
             }
-            if (isMatch) {
-                return row;
-            }
+            return null;
+        } catch (NoSuchElementException | StaleElementReferenceException | IndexOutOfBoundsException e) {
+            return null;
         }
-        return null;
     }
 
     public void verifyQnViewStatsHidden(FeedbackQuestion question) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1030,31 +1030,6 @@ public class InstructorFeedbackResultsPage extends AppPage {
         return parentPanel;
     }
 
-    private void expandQuestionPanel(WebElement questionPanel) {
-        if (!isQuestionPanelExpanded(questionPanel)) {
-            click(questionPanel.findElement(By.className("card-header")));
-            waitUntilAnimationFinish();
-        }
-    }
-
-    private void hideQuestionPanel(WebElement questionPanel) {
-        if (isQuestionPanelExpanded(questionPanel)) {
-            click(questionPanel.findElement(By.className("card-header")));
-            waitUntilAnimationFinish();
-        }
-    }
-
-    private boolean isQuestionPanelExpanded(WebElement questionPanel) {
-        if (!questionPanel.findElements(By.cssSelector("div.collapse.show")).isEmpty()) {
-            return true;
-        }
-        if (!questionPanel.findElements(By.cssSelector("div.collapse")).isEmpty()) {
-            return false;
-        }
-
-        throw new RuntimeException("Question panel does not have expected collapse structure.");
-    }
-
     private String getQuestionText(WebElement questionPanel) {
         return questionPanel.findElement(By.className("question-text")).getText().trim();
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1,6 +1,7 @@
 package teammates.e2e.pageobjects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -404,10 +405,56 @@ public class InstructorFeedbackResultsPage extends AppPage {
         List<FeedbackResponse> responsesToUse = filterMissingResponses(responses);
         List<WebElement> statisticsTables = questionPanel.findElements(By.cssSelector("#mcq-statistics table"));
         verifyTableBodyValues(statisticsTables.get(0), getMcqResponseSummary(question));
-        // sort per recipient statistics
-        click(statisticsTables.get(1).findElements(By.tagName("th")).get(1));
-        verifyTableBodyValues(statisticsTables.get(1), getMcqPerRecipientStatistics(question, responsesToUse, students,
-                instructors));
+        verifyTableBodyValuesIgnoreOrder(statisticsTables.get(1), getMcqPerRecipientStatistics(
+                question, responsesToUse, students, instructors));
+    }
+
+    private void verifyTableBodyValuesIgnoreOrder(WebElement table, String[][] expectedTableBodyValues) {
+        waitFor(driver -> {
+            try {
+                List<WebElement> rows = table.findElement(By.tagName("tbody")).findElements(By.tagName("tr"));
+                if (rows.size() < expectedTableBodyValues.length) {
+                    return false;
+                }
+                for (String[] expectedRow : expectedTableBodyValues) {
+                    if (findMatchingRow(table, expectedRow) == null) {
+                        return false;
+                    }
+                }
+                return true;
+            } catch (NoSuchElementException e) {
+                return false;
+            }
+        });
+
+        List<WebElement> rows = table.findElement(By.tagName("tbody")).findElements(By.tagName("tr"));
+        assertTrue(expectedTableBodyValues.length <= rows.size());
+        for (String[] expectedRow : expectedTableBodyValues) {
+            WebElement matchingRow = findMatchingRow(table, expectedRow);
+            assertNull(matchingRow, "Expected row not found");
+            verifyTableRowValues(matchingRow, expectedRow);
+        }
+    }
+
+    private WebElement findMatchingRow(WebElement table, String[] expectedRowValues) {
+        List<WebElement> rows = table.findElement(By.tagName("tbody")).findElements(By.tagName("tr"));
+        for (WebElement row : rows) {
+            List<WebElement> cells = row.findElements(By.tagName("td"));
+            if (cells.size() < expectedRowValues.length) {
+                continue;
+            }
+            boolean isMatch = true;
+            for (int i = 0; i < expectedRowValues.length; i++) {
+                if (!expectedRowValues[i].equals(cells.get(i).getText())) {
+                    isMatch = false;
+                    break;
+                }
+            }
+            if (isMatch) {
+                return row;
+            }
+        }
+        return null;
     }
 
     public void verifyQnViewStatsHidden(FeedbackQuestion question) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1,7 +1,7 @@
 package teammates.e2e.pageobjects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -428,7 +428,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         assertTrue(expectedTableBodyValues.length <= rows.size());
         for (String[] expectedRow : expectedTableBodyValues) {
             WebElement matchingRow = findMatchingRow(table, expectedRow);
-            assertNull(matchingRow, "Expected row not found");
+            assertNotNull(matchingRow, "Expected row not found");
             verifyTableRowValues(matchingRow, expectedRow);
         }
     }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1001,8 +1001,14 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     private boolean isQuestionPanelExpanded(WebElement questionPanel) {
-        return questionPanel.findElements(By.id("response-table")).size()
-                + questionPanel.findElements(By.id("no-responses")).size() > 0;
+        if (!questionPanel.findElements(By.cssSelector("div.collapse.show")).isEmpty()) {
+            return true;
+        }
+        if (!questionPanel.findElements(By.cssSelector("div.collapse")).isEmpty()) {
+            return false;
+        }
+
+        throw new RuntimeException("Question panel does not have expected collapse structure.");
     }
 
     private String getQuestionText(WebElement questionPanel) {

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -14,43 +14,42 @@
               <tm-panel-chevron [isExpanded]="teamExpanded[teamInfo.key]"></tm-panel-chevron>
             </div>
           </h6>
-          @if (teamExpanded[teamInfo.key]) {
-            <div @collapseAnim>
-              <div class="card-body background-color-warning">
-                @if (teamsToQuestions[teamInfo.key] && teamsToQuestions[teamInfo.key].length && showStatistics) {
-                  <div>
-                    <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
-                    @for (question of teamsToQuestions[teamInfo.key]; track question) {
-                      <div id="team-statistics" class="card top-padded alert-primary-border">
-                        <div class="card-header alert alert-primary alert-no-bottom">
-                          <tm-question-text-with-info
-                            [questionNumber]="question.feedbackQuestion.questionNumber"
-                            [questionDetails]="question.feedbackQuestion.questionDetails"
-                          ></tm-question-text-with-info>
-                        </div>
-                        <div class="card-body top-padded-small">
-                          <tm-single-statistics
-                            [responses]="question.allResponses"
-                            [question]="question.feedbackQuestion.questionDetails"
-                            [statistics]="question.questionStatistics"
-                            [recipientType]="question.feedbackQuestion.recipientType"
-                            [displayContributionStats]="false"
-                          ></tm-single-statistics>
-                        </div>
+
+          <div [ngbCollapse]="!teamExpanded[teamInfo.key]">
+            <div class="card-body background-color-warning">
+              @if (teamsToQuestions[teamInfo.key] && teamsToQuestions[teamInfo.key].length && showStatistics) {
+                <div>
+                  <h3>{{ teamInfo.key }} Statistics for {{ isGqr ? 'Given' : 'Received' }} Responses</h3>
+                  @for (question of teamsToQuestions[teamInfo.key]; track question) {
+                    <div id="team-statistics" class="card top-padded alert-primary-border">
+                      <div class="card-header alert alert-primary alert-no-bottom">
+                        <tm-question-text-with-info
+                          [questionNumber]="question.feedbackQuestion.questionNumber"
+                          [questionDetails]="question.feedbackQuestion.questionDetails"
+                        ></tm-question-text-with-info>
                       </div>
-                    }
-                  </div>
-                }
-                <h3 class="top-padded">{{ teamInfo.key }} Detailed Responses</h3>
-                @for (userInfo of teamInfo.value; track userInfo) {
-                  <div>
-                    <ng-container [ngTemplateOutlet]="userTab" [ngTemplateOutletContext]="{ userInfo: userInfo }">
-                    </ng-container>
-                  </div>
-                }
-              </div>
+                      <div class="card-body top-padded-small">
+                        <tm-single-statistics
+                          [responses]="question.allResponses"
+                          [question]="question.feedbackQuestion.questionDetails"
+                          [statistics]="question.questionStatistics"
+                          [recipientType]="question.feedbackQuestion.recipientType"
+                          [displayContributionStats]="false"
+                        ></tm-single-statistics>
+                      </div>
+                    </div>
+                  }
+                </div>
+              }
+              <h3 class="top-padded">{{ teamInfo.key }} Detailed Responses</h3>
+              @for (userInfo of teamInfo.value; track userInfo) {
+                <div>
+                  <ng-container [ngTemplateOutlet]="userTab" [ngTemplateOutletContext]="{ userInfo: userInfo }">
+                  </ng-container>
+                </div>
+              }
             </div>
-          }
+          </div>
         </div>
       </div>
     }
@@ -102,61 +101,59 @@
         <tm-panel-chevron [isExpanded]="userExpanded[userInfo]"></tm-panel-chevron>
       </div>
     </h6>
-    @if (userExpanded[userInfo]) {
-      <div @collapseAnim>
-        <div class="card-body top-padded-0">
-          @for (question of responsesToShow[userInfo]; track question) {
+
+    <div [ngbCollapse]="!userExpanded[userInfo]">
+      <div class="card-body top-padded-0">
+        @for (question of responsesToShow[userInfo]; track question) {
+          <div
+            id="question-panel-{{ question.questionOutput.feedbackQuestion.questionNumber }}"
+            class="card top-padded alert-primary-border"
+          >
             <div
-              id="question-panel-{{ question.questionOutput.feedbackQuestion.questionNumber }}"
-              class="card top-padded alert-primary-border"
+              class="card-header alert alert-primary alert-no-bottom cursor-pointer"
+              (click)="question.isTabExpanded = !question.isTabExpanded"
             >
-              <div
-                class="card-header alert alert-primary alert-no-bottom cursor-pointer"
-                (click)="question.isTabExpanded = !question.isTabExpanded"
-              >
-                <tm-question-text-with-info
-                  [questionNumber]="question.questionOutput.feedbackQuestion.questionNumber"
-                  [questionDetails]="question.questionOutput.feedbackQuestion.questionDetails"
-                ></tm-question-text-with-info>
-                <div class="card-header-btn-toolbar">
-                  <tm-panel-chevron [isExpanded]="question.isTabExpanded"></tm-panel-chevron>
-                </div>
+              <tm-question-text-with-info
+                [questionNumber]="question.questionOutput.feedbackQuestion.questionNumber"
+                [questionDetails]="question.questionOutput.feedbackQuestion.questionDetails"
+              ></tm-question-text-with-info>
+              <div class="card-header-btn-toolbar">
+                <tm-panel-chevron [isExpanded]="question.isTabExpanded"></tm-panel-chevron>
               </div>
-              @if (question.isTabExpanded) {
-                <div @collapseAnim>
-                  <div class="card-body top-padded-small table-responsive">
-                    @if (showStatistics) {
-                      <tm-single-statistics
-                        [responses]="question.questionOutput.allResponses"
-                        [question]="question.questionOutput.feedbackQuestion.questionDetails"
-                        [statistics]="question.questionOutput.questionStatistics"
-                        [recipientType]="question.questionOutput.feedbackQuestion.recipientType"
-                        [displayContributionStats]="false"
-                      ></tm-single-statistics>
-                    }
-                    <tm-per-question-view-responses
-                      [responses]="question.questionOutput.allResponses"
-                      [section]="section"
-                      [sectionType]="sectionType"
-                      [session]="session"
-                      [statistics]="question.questionOutput.questionStatistics"
-                      [indicateMissingResponses]="indicateMissingResponses"
-                      [showGiver]="!isGqr"
-                      [showRecipient]="isGqr"
-                      [question]="question.questionOutput.feedbackQuestion"
-                      [instructorCommentTableModel]="instructorCommentTableModel"
-                      (instructorCommentTableModelChange)="triggerModelChange($event)"
-                      (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                      (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
-                      (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
-                    ></tm-per-question-view-responses>
-                  </div>
-                </div>
-              }
             </div>
-          }
-        </div>
+
+            <div [ngbCollapse]="!question.isTabExpanded">
+              <div class="card-body top-padded-small table-responsive">
+                @if (showStatistics) {
+                  <tm-single-statistics
+                    [responses]="question.questionOutput.allResponses"
+                    [question]="question.questionOutput.feedbackQuestion.questionDetails"
+                    [statistics]="question.questionOutput.questionStatistics"
+                    [recipientType]="question.questionOutput.feedbackQuestion.recipientType"
+                    [displayContributionStats]="false"
+                  ></tm-single-statistics>
+                }
+                <tm-per-question-view-responses
+                  [responses]="question.questionOutput.allResponses"
+                  [section]="section"
+                  [sectionType]="sectionType"
+                  [session]="session"
+                  [statistics]="question.questionOutput.questionStatistics"
+                  [indicateMissingResponses]="indicateMissingResponses"
+                  [showGiver]="!isGqr"
+                  [showRecipient]="isGqr"
+                  [question]="question.questionOutput.feedbackQuestion"
+                  [instructorCommentTableModel]="instructorCommentTableModel"
+                  (instructorCommentTableModelChange)="triggerModelChange($event)"
+                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                  (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
+                  (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
+                ></tm-per-question-view-responses>
+              </div>
+            </div>
+          </div>
+        }
       </div>
-    }
+    </div>
   </div>
 </ng-template>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -16,10 +16,10 @@ import { InstructorSessionResultSectionType } from '../../../pages-instructor/in
 import { ResponseModerationButtonComponent } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component';
 import { PanelChevronComponent } from '../../panel-chevron/panel-chevron.component';
 import { QuestionTextWithInfoComponent } from '../../question-text-with-info/question-text-with-info.component';
-import { collapseAnim } from '../../teammates-common/collapse-anim';
 import { InstructorResponsesViewBase } from '../instructor-responses-view-base';
 import { PerQuestionViewResponsesComponent } from '../per-question-view-responses/per-question-view-responses.component';
 import { SingleStatisticsComponent } from '../single-statistics/single-statistics.component';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 interface QuestionTab {
   questionOutput: QuestionOutput;
@@ -34,8 +34,8 @@ interface QuestionTab {
   selector: 'tm-gqr-rqg-view-responses',
   templateUrl: './gqr-rqg-view-responses.component.html',
   styleUrls: ['./gqr-rqg-view-responses.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     PanelChevronComponent,
     QuestionTextWithInfoComponent,
     SingleStatisticsComponent,

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -14,18 +14,17 @@
               <tm-panel-chevron [isExpanded]="teamExpanded[teamInfo.key]"></tm-panel-chevron>
             </div>
           </h6>
-          @if (teamExpanded[teamInfo.key]) {
-            <div @collapseAnim class="background-color-warning">
-              <div class="card-body">
-                @for (userInfo of teamInfo.value; track userInfo) {
-                  <div>
-                    <ng-container [ngTemplateOutlet]="userTab" [ngTemplateOutletContext]="{ userInfo: userInfo }">
-                    </ng-container>
-                  </div>
-                }
-              </div>
+
+          <div class="background-color-warning" [ngbCollapse]="!teamExpanded[teamInfo.key]">
+            <div class="card-body">
+              @for (userInfo of teamInfo.value; track userInfo) {
+                <div>
+                  <ng-container [ngTemplateOutlet]="userTab" [ngTemplateOutletContext]="{ userInfo: userInfo }">
+                  </ng-container>
+                </div>
+              }
             </div>
-          }
+          </div>
         </div>
       </div>
     }
@@ -83,37 +82,36 @@
         <tm-panel-chevron [isExpanded]="userExpanded[userInfo]"></tm-panel-chevron>
       </div>
     </h6>
-    @if (userExpanded[userInfo]) {
-      <div @collapseAnim>
-        <div class="card-body">
-          @if (userHasRealResponses[userInfo]) {
-            @for (other of responsesToShow[userInfo] | keyvalue; track other.key; let isLast = $last) {
-              <div id="grouped-responses" class="top-padded">
-                <tm-grouped-responses
-                  [responses]="other.value"
-                  [isGrq]="isGrq"
-                  [session]="session"
-                  [instructorCommentTableModel]="instructorCommentTableModel"
-                  [userToEmail]="userToEmail"
-                  (instructorCommentTableModelChange)="triggerModelChange($event)"
-                  (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
-                  (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
-                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                  [isLastGroupedResponses]="isLast"
-                ></tm-grouped-responses>
-              </div>
-            }
-          }
-          @if (!userHasRealResponses[userInfo]) {
-            <div id="no-responses" class="top-padded">
-              <i>
-                There are no responses {{ isGrq ? 'given' : 'received' }} by this user or you may not have the
-                permission to see the responses.
-              </i>
+
+    <div [ngbCollapse]="!userExpanded[userInfo]">
+      <div class="card-body">
+        @if (userHasRealResponses[userInfo]) {
+          @for (other of responsesToShow[userInfo] | keyvalue; track other.key; let isLast = $last) {
+            <div id="grouped-responses" class="top-padded">
+              <tm-grouped-responses
+                [responses]="other.value"
+                [isGrq]="isGrq"
+                [session]="session"
+                [instructorCommentTableModel]="instructorCommentTableModel"
+                [userToEmail]="userToEmail"
+                (instructorCommentTableModelChange)="triggerModelChange($event)"
+                (updateCommentEvent)="triggerUpdateCommentEvent($event.responseId, $event.index)"
+                (deleteCommentEvent)="triggerDeleteCommentEvent($event.responseId, $event.index)"
+                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                [isLastGroupedResponses]="isLast"
+              ></tm-grouped-responses>
             </div>
           }
-        </div>
+        }
+        @if (!userHasRealResponses[userInfo]) {
+          <div id="no-responses" class="top-padded">
+            <i>
+              There are no responses {{ isGrq ? 'given' : 'received' }} by this user or you may not have the permission
+              to see the responses.
+            </i>
+          </div>
+        }
       </div>
-    }
+    </div>
   </div>
 </ng-template>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -14,9 +14,9 @@ import {
 import { InstructorSessionResultSectionType } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
 import { ResponseModerationButtonComponent } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component';
 import { PanelChevronComponent } from '../../panel-chevron/panel-chevron.component';
-import { collapseAnim } from '../../teammates-common/collapse-anim';
 import { GroupedResponsesComponent } from '../grouped-responses/grouped-responses.component';
 import { InstructorResponsesViewBase } from '../instructor-responses-view-base';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 /**
  * Component to display list of responses in GRQ/RGQ view.
@@ -25,8 +25,8 @@ import { InstructorResponsesViewBase } from '../instructor-responses-view-base';
   selector: 'tm-grq-rgq-view-responses',
   templateUrl: './grq-rgq-view-responses.component.html',
   styleUrls: ['./grq-rgq-view-responses.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     PanelChevronComponent,
     NgTemplateOutlet,
     ResponseModerationButtonComponent,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -11,40 +11,39 @@
           <tm-panel-chevron [isExpanded]="sectionInfo.value.isTabExpanded"></tm-panel-chevron>
         </div>
       </div>
-      @if (sectionInfo.value.isTabExpanded) {
-        <div @collapseAnim>
-          <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
-          <tm-loading-retry
-            class="m-3"
-            [shouldShowRetry]="!!sectionInfo.value.errorMessage"
-            [message]="sectionInfo.value.errorMessage"
-            (retryEvent)="loadSection.emit(sectionInfo.key)"
-          >
-            @if (sectionInfo.value.hasPopulated) {
-              <div class="card-body">
-                <tm-gqr-rqg-view-responses
-                  [responses]="sectionInfo.value.questions || []"
-                  [sectionOfView]="sectionInfo.key"
-                  [section]="section"
-                  [sectionType]="sectionType"
-                  [indicateMissingResponses]="indicateMissingResponses"
-                  [groupByTeam]="groupByTeam"
-                  [showStatistics]="showStatistics"
-                  [isGqr]="true"
-                  [session]="session"
-                  [instructorCommentTableModel]="instructorCommentTableModel"
-                  [isExpandAll]="isExpandAll"
-                  (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                  (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                  (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                  style="margin-bottom: 20px"
-                ></tm-gqr-rqg-view-responses>
-              </div>
-            }
-          </tm-loading-retry>
-        </div>
-      }
+
+      <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+        <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
+        <tm-loading-retry
+          class="m-3"
+          [shouldShowRetry]="!!sectionInfo.value.errorMessage"
+          [message]="sectionInfo.value.errorMessage"
+          (retryEvent)="loadSection.emit(sectionInfo.key)"
+        >
+          @if (sectionInfo.value.hasPopulated) {
+            <div class="card-body">
+              <tm-gqr-rqg-view-responses
+                [responses]="sectionInfo.value.questions || []"
+                [sectionOfView]="sectionInfo.key"
+                [section]="section"
+                [sectionType]="sectionType"
+                [indicateMissingResponses]="indicateMissingResponses"
+                [groupByTeam]="groupByTeam"
+                [showStatistics]="showStatistics"
+                [isGqr]="true"
+                [session]="session"
+                [instructorCommentTableModel]="instructorCommentTableModel"
+                [isExpandAll]="isExpandAll"
+                (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                style="margin-bottom: 20px"
+              ></tm-gqr-rqg-view-responses>
+            </div>
+          }
+        </tm-loading-retry>
+      </div>
     </div>
   </div>
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.ts
@@ -6,7 +6,7 @@ import { LoadingRetryComponent } from '../../components/loading-retry/loading-re
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
 import { PanelChevronComponent } from '../../components/panel-chevron/panel-chevron.component';
 import { GqrRqgViewResponsesComponent } from '../../components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component';
-import { collapseAnim } from '../../components/teammates-common/collapse-anim';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 /**
  * Instructor sessions results page GQR view.
@@ -15,8 +15,8 @@ import { collapseAnim } from '../../components/teammates-common/collapse-anim';
   selector: 'tm-instructor-session-result-gqr-view',
   templateUrl: './instructor-session-result-gqr-view.component.html',
   styleUrls: ['./instructor-session-result-gqr-view.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     PanelChevronComponent,
     LoadingSpinnerDirective,
     LoadingRetryComponent,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -11,40 +11,39 @@
           <tm-panel-chevron [isExpanded]="sectionInfo.value.isTabExpanded"></tm-panel-chevron>
         </div>
       </div>
-      @if (sectionInfo.value.isTabExpanded) {
-        <div @collapseAnim>
-          <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
-          <tm-loading-retry
-            class="m-3"
-            [shouldShowRetry]="!!sectionInfo.value.errorMessage"
-            [message]="sectionInfo.value.errorMessage"
-            (retryEvent)="loadSection.emit(sectionInfo.key)"
-          >
-            @if (sectionInfo.value.hasPopulated) {
-              <div class="card-body">
-                <tm-grq-rgq-view-responses
-                  [responses]="sectionInfo.value.questions || []"
-                  [sectionOfView]="sectionInfo.key"
-                  [section]="section"
-                  [sectionType]="sectionType"
-                  [indicateMissingResponses]="indicateMissingResponses"
-                  [groupByTeam]="groupByTeam"
-                  [showStatistics]="showStatistics"
-                  [isGrq]="true"
-                  [session]="session"
-                  [isExpandAll]="isExpandAll"
-                  [instructorCommentTableModel]="instructorCommentTableModel"
-                  (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                  (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                  (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                  style="margin-bottom: 20px"
-                ></tm-grq-rgq-view-responses>
-              </div>
-            }
-          </tm-loading-retry>
-        </div>
-      }
+
+      <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+        <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
+        <tm-loading-retry
+          class="m-3"
+          [shouldShowRetry]="!!sectionInfo.value.errorMessage"
+          [message]="sectionInfo.value.errorMessage"
+          (retryEvent)="loadSection.emit(sectionInfo.key)"
+        >
+          @if (sectionInfo.value.hasPopulated) {
+            <div class="card-body">
+              <tm-grq-rgq-view-responses
+                [responses]="sectionInfo.value.questions || []"
+                [sectionOfView]="sectionInfo.key"
+                [section]="section"
+                [sectionType]="sectionType"
+                [indicateMissingResponses]="indicateMissingResponses"
+                [groupByTeam]="groupByTeam"
+                [showStatistics]="showStatistics"
+                [isGrq]="true"
+                [session]="session"
+                [isExpandAll]="isExpandAll"
+                [instructorCommentTableModel]="instructorCommentTableModel"
+                (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                style="margin-bottom: 20px"
+              ></tm-grq-rgq-view-responses>
+            </div>
+          }
+        </tm-loading-retry>
+      </div>
     </div>
   </div>
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.ts
@@ -6,7 +6,7 @@ import { LoadingRetryComponent } from '../../components/loading-retry/loading-re
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
 import { PanelChevronComponent } from '../../components/panel-chevron/panel-chevron.component';
 import { GrqRgqViewResponsesComponent } from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component';
-import { collapseAnim } from '../../components/teammates-common/collapse-anim';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 /**
  * Instructor sessions results page GRQ view.
@@ -15,8 +15,8 @@ import { collapseAnim } from '../../components/teammates-common/collapse-anim';
   selector: 'tm-instructor-session-result-grq-view',
   templateUrl: './instructor-session-result-grq-view.component.html',
   styleUrls: ['./instructor-session-result-grq-view.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     PanelChevronComponent,
     LoadingSpinnerDirective,
     LoadingRetryComponent,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -31,50 +31,48 @@
         <tm-panel-chevron chevronColor="black" [isExpanded]="question.isTabExpanded"></tm-panel-chevron>
       </div>
     </div>
-    @if (question.isTabExpanded) {
-      <div @collapseAnim>
-        <div *tmIsLoading="!question.hasPopulated && !question.errorMessage"></div>
-        <tm-loading-retry
-          class="m-3"
-          [shouldShowRetry]="!!question.errorMessage"
-          [message]="question.errorMessage"
-          (retryEvent)="loadTab.emit(question.question.feedbackQuestionId)"
-        >
-          @if (question.hasPopulated) {
-            <div class="card-body">
-              <div class="stats-table">
-                @if (showStatistics) {
-                  <tm-single-statistics
-                    [question]="question.question.questionDetails"
-                    [statistics]="question.statistics"
-                    [responses]="question.responses"
-                    [recipientType]="question.question.recipientType"
-                    [section]="section"
-                    [sectionType]="sectionType"
-                  ></tm-single-statistics>
-                }
-              </div>
-              <div class="stats-table">
-                <tm-per-question-view-responses
+    <div [ngbCollapse]="!question.isTabExpanded">
+      <div *tmIsLoading="!question.hasPopulated && !question.errorMessage"></div>
+      <tm-loading-retry
+        class="m-3"
+        [shouldShowRetry]="!!question.errorMessage"
+        [message]="question.errorMessage"
+        (retryEvent)="loadTab.emit(question.question.feedbackQuestionId)"
+      >
+        @if (question.hasPopulated) {
+          <div class="card-body">
+            <div class="stats-table">
+              @if (showStatistics) {
+                <tm-single-statistics
+                  [question]="question.question.questionDetails"
+                  [statistics]="question.statistics"
                   [responses]="question.responses"
+                  [recipientType]="question.question.recipientType"
                   [section]="section"
                   [sectionType]="sectionType"
-                  [session]="session"
-                  [statistics]="question.statistics"
-                  [indicateMissingResponses]="indicateMissingResponses"
-                  [question]="question.question"
-                  [isDisplayOnly]="isDisplayOnly"
-                  [instructorCommentTableModel]="instructorCommentTableModel"
-                  (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                  (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                  (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                ></tm-per-question-view-responses>
-              </div>
+                ></tm-single-statistics>
+              }
             </div>
-          }
-        </tm-loading-retry>
-      </div>
-    }
+            <div class="stats-table">
+              <tm-per-question-view-responses
+                [responses]="question.responses"
+                [section]="section"
+                [sectionType]="sectionType"
+                [session]="session"
+                [statistics]="question.statistics"
+                [indicateMissingResponses]="indicateMissingResponses"
+                [question]="question.question"
+                [isDisplayOnly]="isDisplayOnly"
+                [instructorCommentTableModel]="instructorCommentTableModel"
+                (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+              ></tm-per-question-view-responses>
+            </div>
+          </div>
+        }
+      </tm-loading-retry>
+    </div>
   </div>
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.ts
@@ -8,7 +8,7 @@ import { PanelChevronComponent } from '../../components/panel-chevron/panel-chev
 import { PerQuestionViewResponsesComponent } from '../../components/question-responses/per-question-view-responses/per-question-view-responses.component';
 import { SingleStatisticsComponent } from '../../components/question-responses/single-statistics/single-statistics.component';
 import { QuestionTextWithInfoComponent } from '../../components/question-text-with-info/question-text-with-info.component';
-import { collapseAnim } from '../../components/teammates-common/collapse-anim';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 /**
  * Instructor sessions results page question view.
@@ -17,8 +17,8 @@ import { collapseAnim } from '../../components/teammates-common/collapse-anim';
   selector: 'tm-instructor-session-result-question-view',
   templateUrl: './instructor-session-result-question-view.component.html',
   styleUrls: ['./instructor-session-result-question-view.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     QuestionTextWithInfoComponent,
     PanelChevronComponent,
     LoadingSpinnerDirective,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -11,40 +11,39 @@
           <tm-panel-chevron [isExpanded]="sectionInfo.value.isTabExpanded"></tm-panel-chevron>
         </div>
       </div>
-      @if (sectionInfo.value.isTabExpanded) {
-        <div @collapseAnim>
-          <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
-          <tm-loading-retry
-            class="m-3"
-            [shouldShowRetry]="!!sectionInfo.value.errorMessage"
-            [message]="sectionInfo.value.errorMessage"
-            (retryEvent)="loadSection.emit(sectionInfo.key)"
-          >
-            @if (sectionInfo.value.hasPopulated) {
-              <div class="card-body">
-                <tm-grq-rgq-view-responses
-                  [responses]="sectionInfo.value.questions || []"
-                  [sectionOfView]="sectionInfo.key"
-                  [section]="section"
-                  [sectionType]="sectionType"
-                  [indicateMissingResponses]="indicateMissingResponses"
-                  [groupByTeam]="groupByTeam"
-                  [showStatistics]="showStatistics"
-                  [isGrq]="false"
-                  [session]="session"
-                  [instructorCommentTableModel]="instructorCommentTableModel"
-                  [isExpandAll]="isExpandAll"
-                  (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                  (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                  (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                  style="margin-bottom: 20px"
-                ></tm-grq-rgq-view-responses>
-              </div>
-            }
-          </tm-loading-retry>
-        </div>
-      }
+
+      <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+        <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
+        <tm-loading-retry
+          class="m-3"
+          [shouldShowRetry]="!!sectionInfo.value.errorMessage"
+          [message]="sectionInfo.value.errorMessage"
+          (retryEvent)="loadSection.emit(sectionInfo.key)"
+        >
+          @if (sectionInfo.value.hasPopulated) {
+            <div class="card-body">
+              <tm-grq-rgq-view-responses
+                [responses]="sectionInfo.value.questions || []"
+                [sectionOfView]="sectionInfo.key"
+                [section]="section"
+                [sectionType]="sectionType"
+                [indicateMissingResponses]="indicateMissingResponses"
+                [groupByTeam]="groupByTeam"
+                [showStatistics]="showStatistics"
+                [isGrq]="false"
+                [session]="session"
+                [instructorCommentTableModel]="instructorCommentTableModel"
+                [isExpandAll]="isExpandAll"
+                (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                style="margin-bottom: 20px"
+              ></tm-grq-rgq-view-responses>
+            </div>
+          }
+        </tm-loading-retry>
+      </div>
     </div>
   </div>
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.ts
@@ -6,7 +6,7 @@ import { LoadingRetryComponent } from '../../components/loading-retry/loading-re
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
 import { PanelChevronComponent } from '../../components/panel-chevron/panel-chevron.component';
 import { GrqRgqViewResponsesComponent } from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component';
-import { collapseAnim } from '../../components/teammates-common/collapse-anim';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 /**
  * Instructor sessions results page RGQ view.
@@ -15,8 +15,8 @@ import { collapseAnim } from '../../components/teammates-common/collapse-anim';
   selector: 'tm-instructor-session-result-rgq-view',
   templateUrl: './instructor-session-result-rgq-view.component.html',
   styleUrls: ['./instructor-session-result-rgq-view.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     PanelChevronComponent,
     LoadingSpinnerDirective,
     LoadingRetryComponent,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -11,40 +11,38 @@
           <tm-panel-chevron [isExpanded]="sectionInfo.value.isTabExpanded"></tm-panel-chevron>
         </div>
       </div>
-      @if (sectionInfo.value.isTabExpanded) {
-        <div @collapseAnim>
-          <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
-          <tm-loading-retry
-            class="m-3"
-            [shouldShowRetry]="!!sectionInfo.value.errorMessage"
-            [message]="sectionInfo.value.errorMessage"
-            (retryEvent)="loadSection.emit(sectionInfo.key)"
-          >
-            @if (sectionInfo.value.hasPopulated) {
-              <div class="card-body">
-                <tm-gqr-rqg-view-responses
-                  [responses]="sectionInfo.value.questions || []"
-                  [sectionOfView]="sectionInfo.key"
-                  [section]="section"
-                  [sectionType]="sectionType"
-                  [indicateMissingResponses]="indicateMissingResponses"
-                  [groupByTeam]="groupByTeam"
-                  [showStatistics]="showStatistics"
-                  [isGqr]="false"
-                  [session]="session"
-                  [instructorCommentTableModel]="instructorCommentTableModel"
-                  [isExpandAll]="isExpandAll"
-                  (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
-                  (updateCommentEvent)="triggerUpdateCommentEvent($event)"
-                  (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
-                  (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
-                  style="margin-bottom: 20px"
-                ></tm-gqr-rqg-view-responses>
-              </div>
-            }
-          </tm-loading-retry>
-        </div>
-      }
+      <div [ngbCollapse]="!sectionInfo.value.isTabExpanded">
+        <div *tmIsLoading="!sectionInfo.value.hasPopulated && !sectionInfo.value.errorMessage"></div>
+        <tm-loading-retry
+          class="m-3"
+          [shouldShowRetry]="!!sectionInfo.value.errorMessage"
+          [message]="sectionInfo.value.errorMessage"
+          (retryEvent)="loadSection.emit(sectionInfo.key)"
+        >
+          @if (sectionInfo.value.hasPopulated) {
+            <div class="card-body">
+              <tm-gqr-rqg-view-responses
+                [responses]="sectionInfo.value.questions || []"
+                [sectionOfView]="sectionInfo.key"
+                [section]="section"
+                [sectionType]="sectionType"
+                [indicateMissingResponses]="indicateMissingResponses"
+                [groupByTeam]="groupByTeam"
+                [showStatistics]="showStatistics"
+                [isGqr]="false"
+                [session]="session"
+                [instructorCommentTableModel]="instructorCommentTableModel"
+                [isExpandAll]="isExpandAll"
+                (instructorCommentTableModelChange)="triggerInstructorCommentTableModelChange($event)"
+                (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                (saveNewCommentEvent)="triggerSaveNewCommentEvent($event)"
+                style="margin-bottom: 20px"
+              ></tm-gqr-rqg-view-responses>
+            </div>
+          }
+        </tm-loading-retry>
+      </div>
     </div>
   </div>
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.ts
@@ -6,7 +6,7 @@ import { LoadingRetryComponent } from '../../components/loading-retry/loading-re
 import { LoadingSpinnerDirective } from '../../components/loading-spinner/loading-spinner.directive';
 import { PanelChevronComponent } from '../../components/panel-chevron/panel-chevron.component';
 import { GqrRqgViewResponsesComponent } from '../../components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component';
-import { collapseAnim } from '../../components/teammates-common/collapse-anim';
+import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 /**
  * Instructor sessions results page RQG view.
@@ -15,8 +15,8 @@ import { collapseAnim } from '../../components/teammates-common/collapse-anim';
   selector: 'tm-instructor-session-result-rqg-view',
   templateUrl: './instructor-session-result-rqg-view.component.html',
   styleUrls: ['./instructor-session-result-rqg-view.component.scss'],
-  animations: [collapseAnim],
   imports: [
+    NgbCollapse,
     PanelChevronComponent,
     LoadingSpinnerDirective,
     LoadingRetryComponent,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #13597

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

As per title, e2e tests had to be updated to ignore ordering as opening and closing the panel no longer "resets" the sort order.
