### PR TITLE
[#14075] Move InvalidHttpRequestBodyException to teammates.ui.exception

### DIFF
--- a/src/it/java/teammates/it/ui/webapi/BaseActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/BaseActionIT.java
@@ -47,7 +47,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.Action;
 import teammates.ui.webapi.ActionFactory;
 import teammates.ui.webapi.ActionResult;

--- a/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/CreateAccountRequestActionIT.java
@@ -15,7 +15,7 @@ import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.AccountRequest;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.CreateAccountRequestAction;
 import teammates.ui.webapi.JsonResult;
 

--- a/src/it/java/teammates/it/ui/webapi/RejectAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/RejectAccountRequestActionIT.java
@@ -24,7 +24,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestRejectionRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.RejectAccountRequestAction;
 

--- a/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateAccountRequestActionIT.java
@@ -21,7 +21,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.UpdateAccountRequestAction;
 

--- a/src/it/java/teammates/it/ui/webapi/UpdateInstructorActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateInstructorActionIT.java
@@ -16,7 +16,7 @@ import teammates.storage.entity.Instructor;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.UpdateInstructorAction;
 

--- a/src/it/java/teammates/it/ui/webapi/UpdateStudentActionIT.java
+++ b/src/it/java/teammates/it/ui/webapi/UpdateStudentActionIT.java
@@ -23,7 +23,7 @@ import teammates.storage.entity.Team;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.MessageOutput;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.StudentUpdateRequest;
 import teammates.ui.webapi.JsonResult;
 import teammates.ui.webapi.UpdateStudentAction;

--- a/src/main/java/teammates/ui/exception/InvalidHttpRequestBodyException.java
+++ b/src/main/java/teammates/ui/exception/InvalidHttpRequestBodyException.java
@@ -1,4 +1,4 @@
-package teammates.ui.request;
+package teammates.ui.exception;
 
 import teammates.common.exception.InvalidParametersException;
 

--- a/src/main/java/teammates/ui/request/AccountCreateRequest.java
+++ b/src/main/java/teammates/ui/request/AccountCreateRequest.java
@@ -1,11 +1,16 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.ArrayList;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.List;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.FieldValidator;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.StringHelper;
 
 /**

--- a/src/main/java/teammates/ui/request/AccountRequestRejectionRequest.java
+++ b/src/main/java/teammates/ui/request/AccountRequestRejectionRequest.java
@@ -1,9 +1,12 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Objects;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.SanitizationHelper;
 
 /**

--- a/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/AccountRequestUpdateRequest.java
@@ -1,8 +1,11 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.AccountRequestStatus;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.SanitizationHelper;
 
 /**

--- a/src/main/java/teammates/ui/request/BasicRequest.java
+++ b/src/main/java/teammates/ui/request/BasicRequest.java
@@ -1,5 +1,7 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
+
 /**
  * The request body of a HTTP request.
  */

--- a/src/main/java/teammates/ui/request/CourseBasicRequest.java
+++ b/src/main/java/teammates/ui/request/CourseBasicRequest.java
@@ -1,5 +1,7 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
+
 /**
  * The basic request of modifying a course.
  */

--- a/src/main/java/teammates/ui/request/CourseCreateRequest.java
+++ b/src/main/java/teammates/ui/request/CourseCreateRequest.java
@@ -1,5 +1,7 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
+
 /**
  * The create request for the course.
  */

--- a/src/main/java/teammates/ui/request/DeadlineExtensionsUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/DeadlineExtensionsUpdateRequest.java
@@ -1,8 +1,12 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.time.Instant;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Map;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.UUID;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/teammates/ui/request/ErrorReportRequest.java
+++ b/src/main/java/teammates/ui/request/ErrorReportRequest.java
@@ -1,5 +1,6 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**

--- a/src/main/java/teammates/ui/request/FeedbackQuestionBasicRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackQuestionBasicRequest.java
@@ -1,17 +1,29 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.List;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Map;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.stream.Collectors;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.participanttypes.ViewerType;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.Const;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.JsonUtils;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.output.FeedbackVisibilityType;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.output.NumberOfEntitiesToGiveFeedbackToSetting;
 
 /**

--- a/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackResponsesRequest.java
@@ -1,16 +1,25 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.HashSet;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.List;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Map;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Set;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.UUID;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.SanitizationHelper;
 
 /**

--- a/src/main/java/teammates/ui/request/FeedbackSessionBasicRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionBasicRequest.java
@@ -1,12 +1,18 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.time.Duration;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.time.Instant;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.Const;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.output.ResponseVisibleSetting;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.output.SessionVisibleSetting;
 
 /**

--- a/src/main/java/teammates/ui/request/FeedbackSessionCreateRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionCreateRequest.java
@@ -1,5 +1,6 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
 /**

--- a/src/main/java/teammates/ui/request/FeedbackSessionRemindRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionRemindRequest.java
@@ -1,5 +1,6 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**

--- a/src/main/java/teammates/ui/request/FeedbackSessionRespondentRemindRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionRespondentRemindRequest.java
@@ -1,5 +1,6 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.UUID;
 
 /**

--- a/src/main/java/teammates/ui/request/InstructorCreateRequest.java
+++ b/src/main/java/teammates/ui/request/InstructorCreateRequest.java
@@ -1,7 +1,9 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import jakarta.annotation.Nullable;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.InstructorPermissionRole;
 
 /**

--- a/src/main/java/teammates/ui/request/InstructorPrivilegeUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/InstructorPrivilegeUpdateRequest.java
@@ -1,5 +1,6 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.InstructorPrivileges;
 
 /**

--- a/src/main/java/teammates/ui/request/MarkNotificationAsReadRequest.java
+++ b/src/main/java/teammates/ui/request/MarkNotificationAsReadRequest.java
@@ -1,5 +1,6 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**

--- a/src/main/java/teammates/ui/request/NotificationBasicRequest.java
+++ b/src/main/java/teammates/ui/request/NotificationBasicRequest.java
@@ -1,6 +1,8 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.NotificationStyle;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.NotificationTargetUser;
 
 /**

--- a/src/main/java/teammates/ui/request/RegKeyRequest.java
+++ b/src/main/java/teammates/ui/request/RegKeyRequest.java
@@ -1,5 +1,7 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
+
 /**
  * The request that contains a registration key.
  */

--- a/src/main/java/teammates/ui/request/ResponseInstructorCommentBasicRequest.java
+++ b/src/main/java/teammates/ui/request/ResponseInstructorCommentBasicRequest.java
@@ -1,10 +1,14 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.List;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.datatransfer.participanttypes.ViewerType;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.output.CommentVisibilityType;
 
 /**

--- a/src/main/java/teammates/ui/request/SendEmailRequest.java
+++ b/src/main/java/teammates/ui/request/SendEmailRequest.java
@@ -1,7 +1,9 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.EmailWrapper;
 
 /**

--- a/src/main/java/teammates/ui/request/StudentEnrollRequest.java
+++ b/src/main/java/teammates/ui/request/StudentEnrollRequest.java
@@ -1,9 +1,12 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Locale;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.Const;
 
 /**

--- a/src/main/java/teammates/ui/request/StudentUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/StudentUpdateRequest.java
@@ -1,6 +1,8 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.Const;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.SanitizationHelper;
 
 /**

--- a/src/main/java/teammates/ui/request/StudentsEnrollRequest.java
+++ b/src/main/java/teammates/ui/request/StudentsEnrollRequest.java
@@ -1,9 +1,13 @@
 package teammates.ui.request;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.HashSet;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.List;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import java.util.Set;
 
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -11,7 +11,7 @@ import teammates.common.util.HibernateUtil;
 import teammates.common.util.Logger;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.Action;
 import teammates.ui.webapi.ActionFactory;
 import teammates.ui.webapi.ActionResult;

--- a/src/main/java/teammates/ui/servlets/WebApiServletExceptionHandler.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServletExceptionHandler.java
@@ -14,7 +14,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.JsonResult;
 
 /**

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -28,7 +28,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * An "action" to be performed by the system.

--- a/src/main/java/teammates/ui/webapi/ApproveAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/ApproveAccountRequestAction.java
@@ -10,7 +10,7 @@ import teammates.storage.entity.AccountRequest;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Approves an account request.

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -26,7 +26,7 @@ import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnexpectedServerException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Creates a new instructor account with sample courses.

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -7,7 +7,7 @@ import teammates.storage.entity.AccountRequest;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Creates a new account request.

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -12,7 +12,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.CourseData;
 import teammates.ui.request.CourseCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Create a new course for an instructor.

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -15,7 +15,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionData;
 import teammates.ui.request.FeedbackQuestionCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Creates a feedback question.

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -19,7 +19,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.request.FeedbackSessionCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Create a feedback session.

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -17,7 +17,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Action: adds another instructor to a course that already exists.

--- a/src/main/java/teammates/ui/webapi/CreateNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateNotificationAction.java
@@ -9,7 +9,7 @@ import teammates.storage.entity.Notification;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationCreateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -18,7 +18,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.ResponseInstructorCommentData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.ResponseInstructorCommentCreateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/DeleteDataBundleAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteDataBundleAction.java
@@ -5,7 +5,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Deletes a data bundle from the DB.

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -11,7 +11,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.EnrollStudentsData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.StudentEnrollRequest;
 import teammates.ui.request.StudentsEnrollRequest;
 

--- a/src/main/java/teammates/ui/webapi/GetNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationAction.java
@@ -6,7 +6,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Action: Gets a notification by ID.

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -8,7 +8,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.User;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.RegKeyRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.ReadNotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.MarkNotificationAsReadRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/PutDataBundleAction.java
+++ b/src/main/java/teammates/ui/webapi/PutDataBundleAction.java
@@ -6,7 +6,7 @@ import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Persists a data bundle into the DB.

--- a/src/main/java/teammates/ui/webapi/RejectAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/RejectAccountRequestAction.java
@@ -11,7 +11,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestRejectionRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Rejects an account request.

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -16,7 +16,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.FeedbackSessionRespondentRemindRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Remind the student about the published result of a feedback session.

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -15,7 +15,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.FeedbackSessionRespondentRemindRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Remind students about the feedback submission.

--- a/src/main/java/teammates/ui/webapi/SendEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/SendEmailWorkerAction.java
@@ -4,7 +4,7 @@ import org.apache.http.HttpStatus;
 
 import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailWrapper;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.SendEmailRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
+++ b/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
@@ -2,7 +2,7 @@ package teammates.ui.webapi;
 
 import teammates.common.util.Logger;
 import teammates.ui.request.ErrorReportRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Actions: sends an error report to the system admin.

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -19,7 +19,7 @@ import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionResponsesData;
 import teammates.ui.request.FeedbackResponsesRequest;
 import teammates.ui.request.Intent;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Submits feedback responses for one or more feedback questions in a feedback session.

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -9,7 +9,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates an account request.

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.CourseData;
 import teammates.ui.request.CourseUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates a course.

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -14,7 +14,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
 import teammates.ui.request.DeadlineExtensionsUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates the deadline extensions for a feedback session.

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionData;
 import teammates.ui.request.FeedbackQuestionUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates a feedback question.

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.request.FeedbackSessionUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates a feedback session.

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Edits an instructor in a course.

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.InstructorPrivilegeData;
 import teammates.ui.request.InstructorPrivilegeUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates an instructor's privileges.

--- a/src/main/java/teammates/ui/webapi/UpdateNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateNotificationAction.java
@@ -9,7 +9,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationUpdateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -13,7 +13,7 @@ import teammates.storage.entity.ResponseInstructorComment;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.ResponseInstructorCommentData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.ResponseInstructorCommentUpdateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -15,7 +15,7 @@ import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.StudentUpdateRequest;
 
 /**

--- a/src/test/java/teammates/ui/servlets/WebApiServletExceptionHandlerTest.java
+++ b/src/test/java/teammates/ui/servlets/WebApiServletExceptionHandlerTest.java
@@ -17,7 +17,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.exception.UnexpectedServerException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link WebApiServletExceptionHandler}.

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -46,7 +46,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Base class for all action tests.

--- a/src/test/java/teammates/ui/webapi/CreateAccountRequestActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateAccountRequestActionTest.java
@@ -16,7 +16,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.AccountRequest;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link CreateAccountRequestAction}.

--- a/src/test/java/teammates/ui/webapi/CreateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateNotificationActionTest.java
@@ -14,7 +14,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationCreateRequest;
 
 /**

--- a/src/test/java/teammates/ui/webapi/SendErrorReportActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SendErrorReportActionTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 import teammates.common.util.Const;
 import teammates.ui.output.MessageOutput;
 import teammates.ui.request.ErrorReportRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link SendErrorReportAction}.

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -16,7 +16,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationUpdateRequest;
 
 /**


### PR DESCRIPTION
## Proposed changes

Fixes #14075

`InvalidHttpRequestBodyException` represents an exception type, not a request DTO. Moving it from `teammates.ui.request` to `teammates.ui.exception` to match the project's package organization, consistent with the other exception classes already in that package (`ActionMappingException`, `EntityNotFoundException`, `InvalidHttpParameterException`, etc.).

## Changes

- Moved `InvalidHttpRequestBodyException.java` to `src/main/java/teammates/ui/exception/`
- Updated `package` declaration to `teammates.ui.exception`
- Updated `import` statements in all 46 referencing files (main source, test, and integration test)

## Type of change

- [x] Refactoring (no functional change)