### PR TITLE
[#14064] Fix ESLint rule disabled

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,7 +64,6 @@ module.exports = defineConfig(
       '@typescript-eslint/no-deprecated': 'warn',
       // The rules below are mostly stylistic rules that are deemed reasonable to be disabled.
       // They can be re-enabled in the future if desired.
-      '@typescript-eslint/prefer-for-of': 'off',
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/consistent-generic-constructors': 'off',

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -403,7 +403,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       (value: string | EnrollStatus) => typeof value === 'string',
     );
 
-    for (let i = 0; i < statuses.length; i += 1) {
+    for (const _status of statuses) {
       studentLists.push([]);
     }
 

--- a/src/web/app/pipes/search-terms-highlighter.pipe.spec.ts
+++ b/src/web/app/pipes/search-terms-highlighter.pipe.spec.ts
@@ -39,10 +39,10 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: '<span class="highlighted-text">Student</span>',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
+    for (const sample of consolidatedSamples) {
       expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch),
-      ).toEqual(consolidatedSamples[i].expected);
+        highlighterPipe.transform(sample.sampleValue, sample.sampleSearch),
+      ).toEqual(sample.expected);
     }
   });
 
@@ -61,10 +61,10 @@ describe('SearchTermsHighlighterPipe', () => {
         sampleValue: 'Student',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
+    for (const sample of consolidatedSamples) {
       expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch),
-      ).toEqual(consolidatedSamples[i].sampleValue);
+        highlighterPipe.transform(sample.sampleValue, sample.sampleSearch),
+      ).toEqual(sample.sampleValue);
     }
   });
 
@@ -117,10 +117,10 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: '<span class="highlighted-text">new student</span>' + ' <span class="highlighted-text">team</span> a',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
+    for (const sample of consolidatedSamples) {
       expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch),
-      ).toEqual(consolidatedSamples[i].expected);
+        highlighterPipe.transform(sample.sampleValue, sample.sampleSearch),
+      ).toEqual(sample.expected);
     }
   });
 
@@ -159,10 +159,10 @@ describe('SearchTermsHighlighterPipe', () => {
           'r</span>s<span class="highlighted-text">e</span>',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
+    for (const sample of consolidatedSamples) {
       expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-      ).toEqual(consolidatedSamples[i].expected);
+        highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true),
+      ).toEqual(sample.expected);
     }
   });
 
@@ -194,10 +194,10 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: '',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
+    for (const sample of consolidatedSamples) {
       expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-      ).toEqual(consolidatedSamples[i].expected);
+        highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true),
+      ).toEqual(sample.expected);
     }
   });
 
@@ -252,10 +252,10 @@ describe('SearchTermsHighlighterPipe', () => {
           expected: 'Test<span class="highlighted-text"> Course</span>',
         },
       ];
-      for (let i = 0; i < consolidatedSamples.length; i += 1) {
+      for (const sample of consolidatedSamples) {
         expect(
-          highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-        ).toEqual(consolidatedSamples[i].expected);
+          highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true),
+        ).toEqual(sample.expected);
       }
     },
   );
@@ -273,10 +273,10 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: 'Test Course',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
+    for (const sample of consolidatedSamples) {
       expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-      ).toEqual(consolidatedSamples[i].expected);
+        highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true),
+      ).toEqual(sample.expected);
     }
   });
 });

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -721,9 +721,9 @@ export function calculateRubricQuestionStatistics(
   stats.isWeightStatsVisible = stats.hasWeights && stats.weights.length > 0 && stats.weights[0].length > 0;
 
   const emptyAnswers: number[][] = [];
-  for (let i = 0; i < question.rubricSubQuestions.length; i += 1) {
+  for (const _subQuestion of question.rubricSubQuestions) {
     const subQuestionAnswers: number[] = [];
-    for (let j = 0; j < question.rubricChoices.length; j += 1) {
+    for (const _choice of question.rubricChoices) {
       subQuestionAnswers.push(0);
     }
     emptyAnswers.push(subQuestionAnswers);
@@ -877,8 +877,8 @@ function sumValidValuesByColumn(matrix: number[][]): number[] {
   const sums: number[] = [];
   for (let c = 0; c < matrix[0].length; c += 1) {
     let sum = 0;
-    for (let r = 0; r < matrix.length; r += 1) {
-      sum += matrix[r][c] === null ? 0 : matrix[r][c];
+    for (const row of matrix) {
+      sum += row[c] === null ? 0 : row[c];
     }
     sums[c] = sum;
   }
@@ -890,8 +890,8 @@ function countValidValuesByColumn(matrix: number[][]): number[] {
   const counts: number[] = [];
   for (let c = 0; c < matrix[0].length; c += 1) {
     let count = 0;
-    for (let r = 0; r < matrix.length; r += 1) {
-      count += matrix[r][c] === null ? 0 : 1;
+    for (const row of matrix) {
+      count += row[c] === null ? 0 : 1;
     }
     counts[c] = count;
   }


### PR DESCRIPTION
Fixes #14064 

**Outline of Solution**

What I changed:
- Removed the disabled `@typescript-eslint/prefer-for-of` override from `eslint.config.js`.
- Updated ESLint-reported simple index-based loops to use `for...of` where the index was not needed.
- Re-ran ESLint and confirmed all files pass linting.

Why I changed it:
- Re-enables the `@typescript-eslint/prefer-for-of` rule so the codebase consistently prefers clearer `for...of` iteration where appropriate.
- Keeps loop style aligned with the TypeScript ESLint recommended stylistic rules.
- Fixes all violations surfaced after re-enabling the rule.