### PR TITLE
[#13721] Replace creatorEmail in FeedbackSession entity with reference to instructor entity

### DIFF
--- a/src/client/resources/SeedingDatabundle.json
+++ b/src/client/resources/SeedingDatabundle.json
@@ -802,7 +802,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "CS1101S",
       "name": "Midterm Peer Review",
-      "creatorEmail": "alice@teammates.tmt",
       "instructions": "Please provide thoughtful and constructive feedback for each question below. Your responses will help your peers improve.",
       "startTime": "seed.d(-14)T08:00:00Z",
       "endTime": "seed.d(+30)T22:00:00Z",
@@ -815,13 +814,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "CS1101S",
       "name": "Team Project Milestone 1",
-      "creatorEmail": "alice@teammates.tmt",
       "instructions": "Evaluate your team members' contributions to Milestone 1. Be honest but respectful in your assessments.",
       "startTime": "seed.d(-30)T08:00:00Z",
       "endTime": "seed.d(+14)T22:00:00Z",
@@ -834,13 +833,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session3InCourse1": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "CS1101S",
       "name": "Final Peer Evaluation",
-      "creatorEmail": "alice@teammates.tmt",
       "instructions": "This is the final evaluation of the semester. Please rank and rate your teammates comprehensively.",
       "startTime": "seed.d(+45)T08:00:00Z",
       "endTime": "seed.d(+75)T22:00:00Z",
@@ -853,13 +852,13 @@
       "isOpenedEmailSent": false,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session4InCourse1": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "CS1101S",
       "name": "Instructor Feedback",
-      "creatorEmail": "alice@teammates.tmt",
       "instructions": "Please share your honest feedback about the instruction quality and course content.",
       "startTime": "seed.d(-60)T08:00:00Z",
       "endTime": "seed.d(-30)T22:00:00Z",
@@ -872,13 +871,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session1InCourse2": {
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "CS2103T",
       "name": "Sprint 1 Review",
-      "creatorEmail": "elena@teammates.tmt",
       "instructions": "Reflect on Sprint 1 and evaluate your teammates. Focus on concrete examples of contribution.",
       "startTime": "seed.d(-14)T08:00:00Z",
       "endTime": "seed.d(+30)T22:00:00Z",
@@ -891,13 +890,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     },
     "session2InCourse2": {
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "CS2103T",
       "name": "Sprint 2 Review",
-      "creatorEmail": "elena@teammates.tmt",
       "instructions": "Evaluate your team's performance during Sprint 2. Consider code quality, collaboration, and process adherence.",
       "startTime": "seed.d(-30)T08:00:00Z",
       "endTime": "seed.d(+14)T22:00:00Z",
@@ -910,13 +909,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     },
     "session3InCourse2": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "CS2103T",
       "name": "Final Team Assessment",
-      "creatorEmail": "elena@teammates.tmt",
       "instructions": "Provide your final assessment of all team members. This evaluation covers the entire project duration.",
       "startTime": "seed.d(+45)T08:00:00Z",
       "endTime": "seed.d(+75)T22:00:00Z",
@@ -929,13 +928,13 @@
       "isOpenedEmailSent": false,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     },
     "session1InCourse3": {
       "id": "00000000-0000-4000-8000-000000000708",
       "courseId": "CS2040DE",
       "name": "Lab Partner Evaluation",
-      "creatorEmail": "priya.sharma@teammates.tmt",
       "instructions": "Evaluate your lab partner's problem-solving skills and collaboration during the laboratory sessions.",
       "startTime": "seed.d(-14)T12:00:00Z",
       "endTime": "seed.d(+30)T22:00:00Z",
@@ -948,13 +947,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000505"
     },
     "session2InCourse3": {
       "id": "00000000-0000-4000-8000-000000000709",
       "courseId": "CS2040DE",
       "name": "Algorithm Design Review",
-      "creatorEmail": "priya.sharma@teammates.tmt",
       "instructions": "Evaluate your peer's algorithm design quality, correctness analysis, and presentation clarity.",
       "startTime": "seed.d(-60)T12:00:00Z",
       "endTime": "seed.d(-30)T12:00:00Z",
@@ -967,13 +966,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000505"
     },
     "session3InCourse3": {
       "id": "00000000-0000-4000-8000-000000000710",
       "courseId": "CS2040DE",
       "name": "End-of-Term Feedback",
-      "creatorEmail": "priya.sharma@teammates.tmt",
       "instructions": "Share your thoughts on the course, your team's work on the final project, and any suggestions for improvement.",
       "startTime": "seed.d(+45)T08:00:00Z",
       "endTime": "seed.d(+75)T22:00:00Z",
@@ -986,7 +985,8 @@
       "isOpenedEmailSent": false,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000505"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
@@ -73,7 +73,7 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
 
         copySession = new FeedbackSession(
                 "Second Session",
-                instructor.getEmail(),
+                instructor,
                 session.getInstructions(),
                 ZonedDateTime.now(ZoneId.of(copyCourse.getTimeZone()))
                     .plus(Duration.ofDays(2))
@@ -97,7 +97,7 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
 
         copySession2 = new FeedbackSession(
                 "Second Session",
-                instructor.getEmail(),
+                instructor,
                 copySession.getInstructions(),
                 copySession.getStartTime(),
                 copySession.getEndTime(),

--- a/src/e2e/java/teammates/e2e/util/EntityCopyUtil.java
+++ b/src/e2e/java/teammates/e2e/util/EntityCopyUtil.java
@@ -20,7 +20,7 @@ public final class EntityCopyUtil {
      */
     public static FeedbackSession copyFeedbackSession(FeedbackSession original) {
         FeedbackSession fs = new FeedbackSession(
-                original.getName(), original.getCreatorEmail(), original.getInstructions(),
+                original.getName(), original.getSessionCreator(), original.getInstructions(),
                 original.getStartTime(),
                 original.getEndTime(), original.getSessionVisibleFromTime(), original.getResultsVisibleFromTime(),
                 original.getGracePeriod(), original.isClosingSoonEmailEnabled(),

--- a/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
@@ -121,11 +121,6 @@ public class TestDataValidityTest extends BaseTestCase {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid session course ID: " + session.getCourseId());
                     }
-
-                    if (!isValidTestEmail(session.getCreatorEmail())) {
-                        errors.computeIfAbsent(pathString, k -> new ArrayList<>())
-                                .add("Invalid session creator email: " + session.getCreatorEmail());
-                    }
                 });
 
                 dataBundle.feedbackResponses.forEach((id, response) -> {

--- a/src/e2e/resources/data/AdminSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSessionsPageE2ETest.json
@@ -47,7 +47,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.ASess.idOfTypicalCourse1",
       "name": "Open feedback session",
-      "creatorEmail": "asess.instructor1@gmail.tmt",
       "instructions": "Please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-03-28T22:00:00Z",
@@ -61,13 +60,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.ASess.idOfTypicalCourse1",
       "name": "Awaiting feedback session",
-      "creatorEmail": "asess.instructor1@gmail.tmt",
       "instructions": "Please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-03-28T22:00:00Z",
@@ -81,13 +80,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session3InCourse1": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "tm.e2e.ASess.idOfTypicalCourse1",
       "name": "Future feedback session",
-      "creatorEmail": "asess.instructor1@gmail.tmt",
       "instructions": "Please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-03-28T22:00:00Z",
@@ -101,7 +100,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     }
   }
 }

--- a/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
+++ b/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
@@ -71,7 +71,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.AutSesRem.course",
       "name": "AutSesRem Opening Session",
-      "creatorEmail": "autsesrem.instructor@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-02T00:00:00Z",
@@ -84,13 +83,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "closingSoonSession": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.AutSesRem.course",
       "name": "AutSesRem Closing Session",
-      "creatorEmail": "autsesrem.instructor@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-02T00:00:00Z",
@@ -103,13 +102,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "closedSession": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "tm.e2e.AutSesRem.course",
       "name": "AutSesRem Closed Session",
-      "creatorEmail": "autsesrem.instructor@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-02T00:00:00Z",
@@ -122,13 +121,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "publishedSession": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "tm.e2e.AutSesRem.course",
       "name": "AutSesRem Published Session",
-      "creatorEmail": "autsesrem.instructor@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-02T00:00:00Z",
@@ -141,7 +140,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
@@ -145,7 +145,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FCSumOptQn.CS2104",
       "name": "First Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -158,13 +157,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.FCSumOptQn.CS1101",
       "name": "Second Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -177,7 +176,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
@@ -167,7 +167,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FCSumRcptQn.CS2104",
       "name": "First Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -180,13 +179,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.FCSumRcptQn.CS1101",
       "name": "Second Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -199,7 +198,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
@@ -67,7 +67,8 @@
         "sectionLevel": {},
         "sessionLevel": {}
       },
-      "accountId": "00000000-0000-4000-8000-000000000001"
+      "accountId": "00000000-0000-4000-8000-000000000001",
+      "id": "00000000-0000-4000-8000-000000000501"
     },
     "instructor2": {
       "courseId": "tm.e2e.FContrQn.CS1101",
@@ -90,7 +91,8 @@
         "sectionLevel": {},
         "sessionLevel": {}
       },
-      "accountId": "00000000-0000-4000-8000-000000000001"
+      "accountId": "00000000-0000-4000-8000-000000000001",
+      "id": "00000000-0000-4000-8000-000000000502"
     }
   },
   "students": {
@@ -173,7 +175,7 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "creatorId": "instructor"
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
@@ -192,7 +194,7 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "creatorId": "instructor2"
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
@@ -160,7 +160,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "name": "First Session",
       "courseId": "tm.e2e.FContrQn.CS2104",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -173,13 +172,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "instructor"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "name": "Second Session",
       "courseId": "tm.e2e.FContrQn.CS1101",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -192,7 +191,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "instructor2"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
@@ -122,7 +122,6 @@
     "openSession": {
       "id": "00000000-0000-4000-8000-000000000701",
       "name": "First Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -136,12 +135,12 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "courseId": "tm.e2e.FMcqQn.CS2104"
+      "courseId": "tm.e2e.FMcqQn.CS2104",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "name": "Second Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -155,7 +154,8 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "courseId": "tm.e2e.FMcqQn.CS1101"
+      "courseId": "tm.e2e.FMcqQn.CS1101",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
@@ -132,7 +132,6 @@
   },
   "feedbackSessions": {
     "openSession": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -148,10 +147,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FMsqQn.CS2104",
-      "name": "First Session"
+      "name": "First Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -167,7 +166,8 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.FMsqQn.CS1101",
-      "name": "Second Session"
+      "name": "Second Session",
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
@@ -109,7 +109,6 @@
   },
   "feedbackSessions": {
     "openSession": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -125,10 +124,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FNumScaleQn.CS2104",
-      "name": "First Session"
+      "name": "First Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -144,7 +143,8 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.FNumScaleQn.CS1101",
-      "name": "Second Session"
+      "name": "Second Session",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
@@ -157,7 +157,6 @@
     "openSession": {
       "id": "00000000-0000-4000-8000-000000000701",
       "name": "First Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -171,12 +170,12 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "courseId": "tm.e2e.FRankOptQn.CS2104"
+      "courseId": "tm.e2e.FRankOptQn.CS2104",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "name": "Second Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -190,7 +189,8 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "courseId": "tm.e2e.FRankOptQn.CS1101"
+      "courseId": "tm.e2e.FRankOptQn.CS1101",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
@@ -189,7 +189,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "name": "First Session",
       "courseId": "tm.e2e.FRankRcptQn.CS2104",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -202,13 +201,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "instructor"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "name": "Second Session",
       "courseId": "tm.e2e.FRankRcptQn.CS1101",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -221,7 +220,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "instructor3"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
@@ -73,7 +73,8 @@
         "sectionLevel": {},
         "sessionLevel": {}
       },
-      "accountId": "00000000-0000-4000-8000-000000000001"
+      "accountId": "00000000-0000-4000-8000-000000000001",
+      "id": "00000000-0000-4000-8000-000000000501"
     },
     "instructor2": {
       "courseId": "tm.e2e.FRankRcptQn.CS2104",
@@ -96,7 +97,8 @@
         "sectionLevel": {},
         "sessionLevel": {}
       },
-      "accountId": "00000000-0000-4000-8000-000000000002"
+      "accountId": "00000000-0000-4000-8000-000000000002",
+      "id": "00000000-0000-4000-8000-000000000502"
     },
     "instructor3": {
       "courseId": "tm.e2e.FRankRcptQn.CS1101",
@@ -119,7 +121,8 @@
         "sectionLevel": {},
         "sessionLevel": {}
       },
-      "accountId": "00000000-0000-4000-8000-000000000001"
+      "accountId": "00000000-0000-4000-8000-000000000001",
+      "id": "00000000-0000-4000-8000-000000000503"
     }
   },
   "students": {
@@ -202,7 +205,7 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "creatorId": "instructor"
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
@@ -221,7 +224,7 @@
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
       "isPublishedEmailEnabled": true,
-      "creatorId": "instructor3"
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
@@ -187,7 +187,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FRes.CS2104",
       "name": "First Session",
-      "creatorEmail": "fres.instr@gmail.tmt",
       "instructions": "Instructions for first session",
       "startTime": "2012-04-01T16:00:00Z",
       "endTime": "2026-04-30T16:00:00Z",
@@ -201,7 +200,8 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-04-01T23:59:00Z"
+      "createdAt": "2012-04-01T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     }
   },
   "feedbackQuestions": {
@@ -241,7 +241,7 @@
       "questionDetails": {
         "hasAssignedWeights": false,
         "mcqWeights": [],
-        "mcqOtherWeight": 0.0,
+        "mcqOtherWeight": 0,
         "mcqChoices": ["UI", "Algo"],
         "otherEnabled": true,
         "questionDropdownEnabled": false,
@@ -265,7 +265,7 @@
         "otherEnabled": false,
         "hasAssignedWeights": false,
         "msqWeights": [],
-        "msqOtherWeight": 0.0,
+        "msqOtherWeight": 0,
         "generateOptionsFor": "STUDENTS",
         "maxSelectableChoices": -2147483648,
         "minSelectableChoices": -2147483648,
@@ -380,9 +380,9 @@
       "questionDetails": {
         "hasAssignedWeights": true,
         "rubricWeightsForEachCell": [
-          [1.0, 2.0, 3.0, 4.0, 5.0],
+          [1, 2, 3, 4, 5],
           [0.01, 0.02, 0.03, 0.04, 0.05],
-          [2.0, 1.0, 0.0, -1.0, -2.0]
+          [2, 1, 0, -1, -2]
         ],
         "rubricChoices": ["Strongly Agree", "Agree", "Neutral", "Disagree", "Strongly Disagree"],
         "rubricSubQuestions": [

--- a/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
@@ -145,7 +145,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FRubricQn.CS2104",
       "name": "First Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2028-04-30T22:00:00Z",
@@ -159,13 +158,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-04-01T23:59:00Z"
+      "createdAt": "2012-04-01T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.FRubricQn.CS1101",
       "name": "Second Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2028-04-30T22:00:00Z",
@@ -179,7 +178,8 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-04-01T23:59:00Z"
+      "createdAt": "2012-04-01T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {
@@ -188,7 +188,7 @@
         "hasAssignedWeights": true,
         "rubricWeightsForEachCell": [
           [1.01, -0.99],
-          [100.0, -200.0]
+          [100, -200]
         ],
         "rubricChoices": ["Yes", "No"],
         "rubricSubQuestions": ["This student has done a good job.", "This student has tried his/her best."],

--- a/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
@@ -177,7 +177,6 @@
       "id": "00000000-0000-4000-8000-000000000501",
       "courseId": "tm.e2e.FSubmit.CS2104",
       "name": "First Session",
-      "creatorEmail": "fsubmit.instr@gmail.tmt",
       "instructions": "Instructions for first session",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -191,13 +190,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000101"
     },
     "Grace Period Session": {
       "id": "00000000-0000-4000-8000-000000000502",
       "courseId": "tm.e2e.FSubmit.CS2104",
       "name": "Grace Period Session",
-      "creatorEmail": "fsubmit.instr@gmail.tmt",
       "instructions": "This is going to be a grace period session",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -211,13 +210,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000101"
     },
     "Closed Session": {
       "id": "00000000-0000-4000-8000-000000000503",
       "courseId": "tm.e2e.FSubmit.CS2104",
       "name": "Closed Session",
-      "creatorEmail": "fsubmit.instr@gmail.tmt",
       "instructions": "This is going to be a closed session",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-02T16:00:00Z",
@@ -231,7 +230,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000101"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
@@ -117,7 +117,6 @@
   },
   "feedbackSessions": {
     "openSession": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -133,10 +132,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.FTextQn.CS2104",
-      "name": "First Session"
+      "name": "First Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "openSession2": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -152,7 +151,8 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.FTextQn.CS1101",
-      "name": "Second Session"
+      "name": "Second Session",
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
@@ -477,7 +477,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.ICEdit.CS2104",
       "name": "First feedback session",
-      "creatorEmail": "icedit.coowner.cs2104@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -490,7 +489,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     }
   },
   "feedbackQuestions": {},

--- a/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
@@ -206,7 +206,6 @@
       "id": "00000000-0000-4000-8000-000000000501",
       "courseId": "tm.e2e.ICs.CS1231",
       "name": "Second Session",
-      "creatorEmail": "backdoor@gmail.tmt",
       "instructions": "<p>Instructions for Second session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-02T00:00:00Z",
@@ -219,7 +218,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": null
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
@@ -135,7 +135,6 @@
   },
   "feedbackSessions": {
     "openSession": {
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -151,13 +150,13 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.InstFEP.CS2104",
-      "name": "First Session"
+      "name": "First Session",
+      "creatorId": null
     },
     "openSession2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.InstFEP.CS1101",
       "name": "First Session",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for First session</p>",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2026-04-30T22:00:00Z",
@@ -171,7 +170,8 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-04-01T23:59:00Z"
+      "createdAt": "2012-04-01T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
@@ -243,7 +243,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.IFRep.CS2104",
       "name": "First Session",
-      "creatorEmail": "ifrep.instr1@gmail.tmt",
       "instructions": "Instructions for first session",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -257,13 +256,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": true,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "Open Session 2": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.IFRep.CS2103",
       "name": "First Session",
-      "creatorEmail": "ifrep.instr1@gmail.tmt",
       "instructions": "Instructions for first session",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -277,7 +276,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": true,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000503"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
@@ -181,7 +181,6 @@
   },
   "feedbackSessions": {
     "openSession": {
-      "creatorEmail": "ifsessionpage.instr@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -197,10 +196,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.CS2104",
-      "name": "First Session"
+      "name": "First Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "closedSession": {
-      "creatorEmail": "ifsessionpage.instr2@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "createdAt": "2012-04-01T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -216,7 +215,8 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.CS1101",
-      "name": "Second Session"
+      "name": "Second Session",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorHomePageE2ETest.json
+++ b/src/e2e/resources/data/InstructorHomePageE2ETest.json
@@ -180,7 +180,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.IHome.CS2104",
       "name": "First Feedback Session",
-      "creatorEmail": "ihome.instructor.tmms@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T04:00:00Z",
       "endTime": "2027-04-30T16:00:00Z",
@@ -194,13 +193,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "Second Feedback Session": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.IHome.CS2104",
       "name": "Second Feedback Session",
-      "creatorEmail": "ihome.instructor.tmms@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-03-29T04:00:00Z",
       "endTime": "2012-05-01T04:00:00Z",
@@ -214,13 +213,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "Third Feedback Session": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "tm.e2e.IHome.CS2104",
       "name": "Third Feedback Session",
-      "creatorEmail": "ihome.instructor.tmms@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-10T16:00:00Z",
       "endTime": "2012-04-30T16:00:00Z",
@@ -234,13 +233,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "Fourth Feedback Session": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "tm.e2e.IHome.CS2104",
       "name": "Fourth Feedback Session",
-      "creatorEmail": "ihome.instructor.tmms@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-05T04:00:00Z",
       "endTime": "2012-04-20T04:00:00Z",
@@ -254,13 +253,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "CS1101 Session": {
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "tm.e2e.IHome.CS1101",
       "name": "CS1101 Session",
-      "creatorEmail": "ihome.instructor.tmms@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-05T04:00:00Z",
       "endTime": "2012-04-20T04:00:00Z",
@@ -274,7 +273,8 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorSessionIndividualExtensionPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorSessionIndividualExtensionPageE2ETest.json
@@ -172,7 +172,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "name": "First Session",
       "courseId": "tm.e2e.ISesIe.CS2104",
-      "creatorEmail": "instructor1.tmms@gmail.tmt",
       "instructions": "<p>Instructions for First Session</p>",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2032-04-30T16:00:00Z",
@@ -185,7 +184,8 @@
       "isOpenedEmailSent": false,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/InstructorStudentActivityLogsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorStudentActivityLogsPageE2ETest.json
@@ -92,7 +92,6 @@
       "id": "00000000-0000-4000-8000-000000000501",
       "name": "First Session",
       "courseId": "tm.e2e.ISActLogs.CS2104",
-      "creatorEmail": "tmms.test@gmail.tmt",
       "instructions": "<p>Instructions for first session</p>",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2026-04-30T22:00:00Z",
@@ -105,7 +104,8 @@
       "isOpenedEmailSent": false,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000301"
     }
   },
   "feedbackQuestions": {

--- a/src/e2e/resources/data/StudentHomePageE2ETest.json
+++ b/src/e2e/resources/data/StudentHomePageE2ETest.json
@@ -221,7 +221,6 @@
   },
   "feedbackSessions": {
     "SHome.CS2104:First Feedback Session": {
-      "creatorEmail": "shome.instr@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -236,10 +235,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "tm.e2e.SHome.CS2104",
-      "name": "First Feedback Session"
+      "name": "First Feedback Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "SHome.CS2104:Graced Feedback Session": {
-      "creatorEmail": "shome.instr@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -254,10 +253,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "tm.e2e.SHome.CS2104",
-      "name": "Graced Feedback Session"
+      "name": "Graced Feedback Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "SHome.CS2104:No Question Feedback Session": {
-      "creatorEmail": "shome.instr@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -272,10 +271,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "tm.e2e.SHome.CS2104",
-      "name": "No Question Feedback Session"
+      "name": "No Question Feedback Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "SHome.CS2104:Future Feedback Session": {
-      "creatorEmail": "shome.instr@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2034-04-01T16:00:00Z",
@@ -290,10 +289,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "tm.e2e.SHome.CS2104",
-      "name": "Future Feedback Session"
+      "name": "Future Feedback Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "SHome.CS2104:Closed Feedback Session": {
-      "creatorEmail": "shome.instr@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -308,10 +307,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "tm.e2e.SHome.CS2104",
-      "name": "Closed Feedback Session"
+      "name": "Closed Feedback Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "SHome.CS4221:Session with no Student Questions": {
-      "creatorEmail": "shome.instr@gmail.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -326,7 +325,8 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "tm.e2e.SHome.CS4221",
-      "name": "Session without Student Questions"
+      "name": "Session without Student Questions",
+      "creatorId": "00000000-0000-4000-8000-000000000504"
     }
   },
   "feedbackQuestions": {},

--- a/src/it/java/teammates/it/logic/core/DataBundleLogicIT.java
+++ b/src/it/java/teammates/it/logic/core/DataBundleLogicIT.java
@@ -181,7 +181,7 @@ public class DataBundleLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         FeedbackSession actualSession1 = dataBundle.feedbackSessions.get("session1InTypicalCourse");
         FeedbackSession expectedSession1 = new FeedbackSession("First feedback session",
-                "instr1@teammates.tmt", "Please please fill in the following questions.",
+                expectedInstructor1, "Please please fill in the following questions.",
                 Instant.parse("2012-04-01T22:00:00Z"), Instant.parse("2027-04-30T22:00:00Z"),
                 Instant.parse("2012-03-28T22:00:00Z"), Instant.parse("2027-05-01T22:00:00Z"), Duration.ofMinutes(10),
                 true, true);

--- a/src/it/java/teammates/it/storage/api/FeedbackSessionsDbIT.java
+++ b/src/it/java/teammates/it/storage/api/FeedbackSessionsDbIT.java
@@ -31,11 +31,11 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithDatabaseAccess {
         ______TS("success: get feedback session that exists");
         Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
         coursesDb.createCourse(course1);
-        FeedbackSession fs1 = new FeedbackSession("name1", "test1@test.com", "test-instruction",
+        FeedbackSession fs1 = new FeedbackSession("name1", null, "test-instruction",
                 Instant.now().plus(Duration.ofDays(1)), Instant.now().plus(Duration.ofDays(7)), Instant.now(),
                 Instant.now().plus(Duration.ofDays(7)), Duration.ofMinutes(10), true, true);
         course1.addFeedbackSession(fs1);
-        FeedbackSession fs2 = new FeedbackSession("name2", "test1@test.com", "test-instruction",
+        FeedbackSession fs2 = new FeedbackSession("name2", null, "test-instruction",
                 Instant.now().plus(Duration.ofDays(1)), Instant.now().plus(Duration.ofDays(7)), Instant.now(),
                 Instant.now().plus(Duration.ofDays(7)), Duration.ofMinutes(10), true, true);
         course1.addFeedbackSession(fs2);
@@ -53,13 +53,13 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithDatabaseAccess {
         Instant instantNow = Instant.now();
         Course course1 = new Course("test-id1", "test-name1", "UTC", "NUS");
         coursesDb.createCourse(course1);
-        FeedbackSession c1Fs1 = new FeedbackSession("name1-1", "test1@test.com", "test-instruction",
+        FeedbackSession c1Fs1 = new FeedbackSession("name1-1", null, "test-instruction",
                 instantNow.minus(Duration.ofDays(7L)), instantNow.minus(Duration.ofDays(1L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
         course1.addFeedbackSession(c1Fs1);
         fsDb.createFeedbackSession(c1Fs1);
-        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", "test2@test.com", "test-instruction",
+        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", null, "test-instruction",
                 instantNow, instantNow.plus(Duration.ofDays(7L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
@@ -67,13 +67,13 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithDatabaseAccess {
         fsDb.createFeedbackSession(c1Fs2);
         Course course2 = new Course("test-id2", "test-name2", "UTC", "MIT");
         coursesDb.createCourse(course2);
-        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", "test3@test.com", "test-instruction",
+        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", null, "test-instruction",
                 instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
         course2.addFeedbackSession(c2Fs1);
         fsDb.createFeedbackSession(c2Fs1);
-        FeedbackSession c2Fs2 = new FeedbackSession("name2-2", "test3@test.com", "test-instruction",
+        FeedbackSession c2Fs2 = new FeedbackSession("name2-2", null, "test-instruction",
                 instantNow.plus(Duration.ofDays(1L)), instantNow.plus(Duration.ofDays(7L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
@@ -81,7 +81,7 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithDatabaseAccess {
         fsDb.createFeedbackSession(c2Fs2);
         Course course3 = new Course("test-id3", "test-name3", "UTC", "UCL");
         coursesDb.createCourse(course3);
-        FeedbackSession c3Fs1 = new FeedbackSession("name3-1", "test4@test.com", "test-instruction",
+        FeedbackSession c3Fs1 = new FeedbackSession("name3-1", null, "test-instruction",
                 instantNow.minus(Duration.ofDays(7L)), instantNow,
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);

--- a/src/it/resources/data/DataBundleLogicIT.json
+++ b/src/it/resources/data/DataBundleLogicIT.json
@@ -135,7 +135,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "typical-course-id",
       "name": "First feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -148,13 +147,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "typical-course-id",
       "name": "Second feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -167,7 +166,8 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     }
   },
   "feedbackQuestions": {

--- a/src/it/resources/data/EmailGeneratorTest.json
+++ b/src/it/resources/data/EmailGeneratorTest.json
@@ -372,7 +372,6 @@
   },
   "feedbackSessions": {
     "session1InCourse1": {
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -387,10 +386,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "idOfTypicalCourse1",
-      "name": "First feedback session"
+      "name": "First feedback session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InCourse1": {
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2013-03-20T23:59:00Z",
       "startTime": "2013-06-01T22:00:00Z",
@@ -405,10 +404,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "idOfTypicalCourse1",
-      "name": "Second feedback session"
+      "name": "Second feedback session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "gracePeriodSession": {
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2013-03-20T23:59:00Z",
       "startTime": "2013-06-01T22:00:00Z",
@@ -423,10 +422,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "idOfTypicalCourse1",
-      "name": "Grace Period Session"
+      "name": "Grace Period Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "closedSession": {
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2013-03-20T23:59:00Z",
       "startTime": "2013-06-01T22:00:00Z",
@@ -441,10 +440,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "idOfTypicalCourse1",
-      "name": "Closed Session"
+      "name": "Closed Session",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "empty.session": {
-      "creatorEmail": "instructor2@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2013-01-20T23:57:00Z",
       "startTime": "2013-02-02T00:00:00Z",
@@ -461,10 +460,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "idOfTypicalCourse1",
-      "name": "Empty session"
+      "name": "Empty session",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     },
     "awaiting.session": {
-      "creatorEmail": "instructor2@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2013-01-20T23:00:00Z",
       "startTime": "2026-04-01T23:00:00Z",
@@ -481,10 +480,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "idOfTypicalCourse1",
-      "name": "non visible session"
+      "name": "non visible session",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     },
     "session2InCourse2": {
-      "creatorEmail": "instructor1@course2.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T16:00:00Z",
@@ -499,10 +498,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "idOfTypicalCourse2",
-      "name": "Not answerable feedback session"
+      "name": "Not answerable feedback session",
+      "creatorId": "00000000-0000-4000-8000-000000000505"
     },
     "session1InCourse3": {
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -517,10 +516,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000708",
       "courseId": "idOfTypicalCourse3",
-      "name": "First feedback session"
+      "name": "First feedback session",
+      "creatorId": null
     },
     "session2InCourse3": {
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -535,10 +534,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000709",
       "courseId": "idOfTypicalCourse3",
-      "name": "Second feedback session"
+      "name": "Second feedback session",
+      "creatorId": null
     },
     "session1InCourse4": {
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -553,10 +552,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000710",
       "courseId": "idOfTypicalCourse4",
-      "name": "First feedback session"
+      "name": "First feedback session",
+      "creatorId": null
     },
     "session2InCourse4": {
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -571,10 +570,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000711",
       "courseId": "idOfTypicalCourse4",
-      "name": "Second feedback session"
+      "name": "Second feedback session",
+      "creatorId": null
     },
     "session1InTestingNoEmailsSentCourse": {
-      "creatorEmail": "instructor1@noemailcourse.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -591,10 +590,10 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000712",
       "courseId": "idOfTestingNoEmailsSentCourse",
-      "name": "Feedback session with no emails sent"
+      "name": "Feedback session with no emails sent",
+      "creatorId": null
     },
     "session1InTestingSanitizationCourse": {
-      "creatorEmail": "instructor1@sanitization.tmt",
       "instructions": "unclosed tags </td></div> Attempted script injection '\" <script>alert('hello');</script>",
       "createdAt": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T22:00:00Z",
@@ -609,7 +608,8 @@
       "isPublishedEmailEnabled": true,
       "id": "00000000-0000-4000-8000-000000000713",
       "courseId": "idOfTestingSanitizationCourse",
-      "name": "Normal feedback session name"
+      "name": "Normal feedback session name",
+      "creatorId": "00000000-0000-4000-8000-000000000508"
     }
   },
   "feedbackQuestions": {},

--- a/src/it/resources/data/FeedbackResponsesITBundle.json
+++ b/src/it/resources/data/FeedbackResponsesITBundle.json
@@ -551,7 +551,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "course-1",
       "name": "First feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -564,13 +563,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "course-1",
       "name": "Second feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -583,13 +582,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "unpublishedSession1InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "course-1",
       "name": "Unpublished feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -602,13 +601,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "course-1",
       "name": "Ongoing session 1 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
       "endTime": "2012-01-25T22:00:00Z",
@@ -621,13 +620,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "course-1",
       "name": "Ongoing session 2 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-26T22:00:00Z",
       "endTime": "2012-02-02T22:00:00Z",
@@ -640,13 +639,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession3InCourse1": {
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "course-1",
       "name": "Ongoing session 3 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-26T10:00:00Z",
       "endTime": "2012-01-27T10:00:00Z",
@@ -659,13 +658,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession1InCourse3": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "course-3",
       "name": "Ongoing session 1 in course 3",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-27T22:00:00Z",
       "endTime": "2012-02-02T22:00:00Z",
@@ -678,13 +677,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000506"
     },
     "ongoingSession2InCourse3": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "course-3",
       "name": "Ongoing session 2 in course 3",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -697,7 +696,8 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000506"
     }
   },
   "feedbackQuestions": {
@@ -805,7 +805,7 @@
       "questionDetails": {
         "hasAssignedWeights": false,
         "mcqWeights": [],
-        "mcqOtherWeight": 0.0,
+        "mcqOtherWeight": 0,
         "mcqChoices": ["Great", "Perfect"],
         "otherEnabled": false,
         "questionDropdownEnabled": false,

--- a/src/it/resources/data/typicalDataBundle.json
+++ b/src/it/resources/data/typicalDataBundle.json
@@ -549,7 +549,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "course-1",
       "name": "First feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2028-04-30T22:00:00Z",
@@ -562,13 +561,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "course-1",
       "name": "Second feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2027-04-28T22:00:00Z",
@@ -581,13 +580,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "unpublishedSession1InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "course-1",
       "name": "Unpublished feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2027-04-28T22:00:00Z",
@@ -600,13 +599,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "course-1",
       "name": "Ongoing session 1 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
       "endTime": "2012-01-25T22:00:00Z",
@@ -619,13 +618,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "course-1",
       "name": "Ongoing session 2 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-26T22:00:00Z",
       "endTime": "2012-02-02T22:00:00Z",
@@ -638,13 +637,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession3InCourse1": {
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "course-1",
       "name": "Ongoing session 3 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-26T10:00:00Z",
       "endTime": "2012-01-27T10:00:00Z",
@@ -657,13 +656,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession1InCourse3": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "course-3",
       "name": "Ongoing session 1 in course 3",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-27T22:00:00Z",
       "endTime": "2012-02-02T22:00:00Z",
@@ -676,13 +675,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000506"
     },
     "ongoingSession2InCourse3": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "course-3",
       "name": "Ongoing session 2 in course 3",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
       "endTime": "2028-04-30T22:00:00Z",
@@ -695,7 +694,8 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000506"
     }
   },
   "feedbackQuestions": {
@@ -853,7 +853,7 @@
       "questionDetails": {
         "hasAssignedWeights": false,
         "mcqWeights": [],
-        "mcqOtherWeight": 0.0,
+        "mcqOtherWeight": 0,
         "mcqChoices": ["Great", "Perfect"],
         "otherEnabled": false,
         "questionDropdownEnabled": false,

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -130,31 +130,6 @@ public final class DataBundleLogic {
             section.addTeam(team);
         }
 
-        for (FeedbackSession session : sessions) {
-            UUID placeholderId = session.getId();
-            session.setId(UUID.randomUUID());
-            sessionsMap.put(placeholderId, session);
-            Course course = coursesMap.get(session.getCourseId());
-            session.setCourse(course);
-            course.addFeedbackSession(session);
-        }
-
-        for (FeedbackQuestion question : questions) {
-            UUID placeholderId = question.getId();
-            question.setId(UUID.randomUUID());
-            questionMap.put(placeholderId, question);
-            FeedbackSession fs = sessionsMap.get(question.getSessionId());
-            fs.addFeedbackQuestion(question);
-        }
-
-        for (FeedbackResponse response : responses) {
-            UUID placeholderId = response.getId();
-            response.setId(UUID.randomUUID());
-            responseMap.put(placeholderId, response);
-            FeedbackQuestion fq = questionMap.get(response.getQuestionId());
-            fq.addFeedbackResponse(response);
-        }
-
         for (Account account : accounts) {
             UUID placeholderId = account.getId();
             account.setId(UUID.randomUUID());
@@ -172,6 +147,35 @@ public final class DataBundleLogic {
                 instructor.setAccount(account);
             }
             instructor.generateNewRegistrationKey();
+        }
+
+        for (FeedbackSession session : sessions) {
+            UUID placeholderId = session.getId();
+            session.setId(UUID.randomUUID());
+            sessionsMap.put(placeholderId, session);
+            Course course = coursesMap.get(session.getCourseId());
+            session.setCourse(course);
+            User creator = usersMap.get(session.getCreatorId());
+            if (creator instanceof Instructor instructor) {
+                session.setSessionCreator(instructor);
+            }
+            course.addFeedbackSession(session);
+        }
+
+        for (FeedbackQuestion question : questions) {
+            UUID placeholderId = question.getId();
+            question.setId(UUID.randomUUID());
+            questionMap.put(placeholderId, question);
+            FeedbackSession fs = sessionsMap.get(question.getSessionId());
+            fs.addFeedbackQuestion(question);
+        }
+
+        for (FeedbackResponse response : responses) {
+            UUID placeholderId = response.getId();
+            response.setId(UUID.randomUUID());
+            responseMap.put(placeholderId, response);
+            FeedbackQuestion fq = questionMap.get(response.getQuestionId());
+            fq.addFeedbackResponse(response);
         }
 
         for (Student student : students) {
@@ -309,10 +313,10 @@ public final class DataBundleLogic {
         persistEntities(courses);
         persistEntities(sections);
         persistEntities(teams);
-        persistEntities(sessions);
-        persistEntities(questions);
         persistEntities(instructors);
         persistEntities(students);
+        persistEntities(sessions);
+        persistEntities(questions);
         persistEntities(responses);
         persistEntities(responseComments);
         persistEntities(sessionLogs);

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -734,7 +734,7 @@ public final class FeedbackQuestionsLogic {
         case SESSION_CREATOR:
             FeedbackSession feedbackSession =
                     feedbackSessionsLogic.getFeedbackSession(fq.getFeedbackSessionName(), fq.getCourseId());
-            Instructor instructorGiver = courseRoster.getInstructorForEmail(feedbackSession.getCreatorEmail());
+            Instructor instructorGiver = feedbackSession.getSessionCreator();
             // If the instructorGiver is null, they have been deleted,
             // so we return an empty list of givers instead of a giver with null user.
             possibleGivers = instructorGiver != null

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -48,8 +48,13 @@ public class FeedbackSession extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    private String creatorEmail;
+    @Column(insertable = false, updatable = false)
+    private UUID creatorId;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @JoinColumn(name = "creatorId")
+    private Instructor sessionCreator;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String instructions;
@@ -106,12 +111,12 @@ public class FeedbackSession extends BaseEntity {
         // required by Hibernate
     }
 
-    public FeedbackSession(String name, String creatorEmail, String instructions, Instant startTime,
+    public FeedbackSession(String name, Instructor sessionCreator, String instructions, Instant startTime,
             Instant endTime, Instant sessionVisibleFromTime, Instant resultsVisibleFromTime, Duration gracePeriod,
             boolean isClosingSoonEmailEnabled, boolean isPublishedEmailEnabled) {
         this.setId(UUID.randomUUID());
         this.setName(name);
-        this.setCreatorEmail(creatorEmail);
+        this.setSessionCreator(sessionCreator);
         this.setInstructions(StringUtils.defaultString(instructions));
         this.setStartTime(startTime);
         this.setEndTime(endTime);
@@ -136,16 +141,12 @@ public class FeedbackSession extends BaseEntity {
         addNonEmptyError(FieldValidator.getValidityInfoForNonNullField(
                 "time for the session to become visible", sessionVisibleFromTime), errors);
 
-        addNonEmptyError(FieldValidator.getValidityInfoForNonNullField("creator's email", creatorEmail), errors);
-
         // Early return if any null fields
         if (!errors.isEmpty()) {
             return errors;
         }
 
         addNonEmptyError(FieldValidator.getInvalidityInfoForFeedbackSessionName(name), errors);
-
-        addNonEmptyError(FieldValidator.getInvalidityInfoForEmail(creatorEmail), errors);
 
         addNonEmptyError(FieldValidator.getInvalidityInfoForGracePeriod(gracePeriod), errors);
 
@@ -238,11 +239,23 @@ public class FeedbackSession extends BaseEntity {
     }
 
     public String getCreatorEmail() {
-        return creatorEmail;
+        return sessionCreator == null ? null : sessionCreator.getEmail();
     }
 
-    public void setCreatorEmail(String creatorEmail) {
-        this.creatorEmail = SanitizationHelper.sanitizeEmail(creatorEmail);
+    public UUID getCreatorId() {
+        return creatorId;
+    }
+
+    public Instructor getSessionCreator() {
+        return sessionCreator;
+    }
+
+    /**
+     * Sets the session creator.
+     */
+    public void setSessionCreator(Instructor sessionCreator) {
+        this.sessionCreator = sessionCreator;
+        this.creatorId = sessionCreator == null ? null : sessionCreator.getId();
     }
 
     public String getInstructions() {
@@ -384,7 +397,7 @@ public class FeedbackSession extends BaseEntity {
     @Override
     public String toString() {
         return "FeedbackSession [id=" + id + ", courseId=" + course.getId() + ", name=" + name
-                + ", creatorEmail=" + creatorEmail
+                + ", sessionCreator=" + sessionCreator
                 + ", instructions=" + instructions + ", startTime=" + startTime + ", endTime=" + endTime
                 + ", sessionVisibleFromTime=" + sessionVisibleFromTime
                 + ", resultsVisibleFromTime=" + resultsVisibleFromTime + ", gracePeriod=" + gracePeriod
@@ -520,7 +533,7 @@ public class FeedbackSession extends BaseEntity {
      * Checks if user is the creator.
      */
     public boolean isCreator(Instructor instructor) {
-        return SanitizationHelper.areEmailsEqual(creatorEmail, instructor.getEmail());
+        return sessionCreator != null && sessionCreator.equals(instructor);
     }
 
     /**

--- a/src/main/java/teammates/ui/output/OngoingSession.java
+++ b/src/main/java/teammates/ui/output/OngoingSession.java
@@ -14,6 +14,7 @@ import teammates.storage.entity.FeedbackSession;
  * A single ongoing session.
  */
 public class OngoingSession {
+    private static final String DELETED_INSTRUCTOR_DISPLAY_NAME = "Deleted Instructor";
 
     private final UUID feedbackSessionId;
     private final String sessionStatus;
@@ -27,19 +28,20 @@ public class OngoingSession {
     public OngoingSession(FeedbackSession fs, String googleId) {
         this.feedbackSessionId = fs.getId();
         this.sessionStatus = getSessionStatusForShow(fs);
-        String instructorHomePageLink;
+        String instructorHomePageLinkNullable;
         if (googleId == null) {
-            instructorHomePageLink = null;
+            instructorHomePageLinkNullable = null;
         } else {
-            instructorHomePageLink = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
+            instructorHomePageLinkNullable = Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE)
                     .withUser(googleId)
                     .toString();
         }
-        this.instructorHomePageLink = instructorHomePageLink;
+        this.instructorHomePageLink = instructorHomePageLinkNullable;
         Course course = fs.getCourse();
         this.startTime = fs.getStartTime().toEpochMilli();
         this.endTime = fs.getEndTime().toEpochMilli();
-        this.creatorEmail = fs.getCreatorEmail();
+        String creatorEmailNullable = fs.getCreatorEmail();
+        this.creatorEmail = creatorEmailNullable == null ? DELETED_INSTRUCTOR_DISPLAY_NAME : creatorEmailNullable;
         this.courseId = course.getId();
         this.feedbackSessionName = fs.getName();
     }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -85,7 +85,7 @@ public class CreateFeedbackSessionAction extends Action {
 
         FeedbackSession feedbackSession = new FeedbackSession(
                 feedbackSessionName,
-                instructor.getEmail(),
+                instructor,
                 createRequest.getInstructions(),
                 startTime,
                 endTime,

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -157,7 +157,6 @@
       "id": "00000000-0000-4000-8000-000000000501",
       "courseId": "demo.course",
       "name": "Session with different question types",
-      "creatorEmail": "teammates.demo.instructor@demo.course",
       "instructions": "Please give your feedback based on the following questions.",
       "createdAt": "demo.date1T00:00:00Z",
       "startTime": "demo.date1T00:00:00Z",
@@ -171,13 +170,13 @@
       "isClosedEmailSent": true,
       "isPublishedEmailSent": true,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000101"
     },
     "session2": {
       "id": "00000000-0000-4000-8000-000000000502",
       "courseId": "demo.course",
       "name": "First team feedback session (percentage-based)",
-      "creatorEmail": "teammates.demo.instructor@demo.course",
       "instructions": "Please give your feedback based on the following questions.",
       "createdAt": "demo.date1T00:00:00Z",
       "startTime": "demo.date1T00:00:00Z",
@@ -191,13 +190,13 @@
       "isClosedEmailSent": true,
       "isPublishedEmailSent": true,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000101"
     },
     "session3": {
       "id": "00000000-0000-4000-8000-000000000503",
       "courseId": "demo.course",
       "name": "Second team feedback session (point-based)",
-      "creatorEmail": "teammates.demo.instructor@demo.course",
       "instructions": "Please give your feedback based on the following questions.",
       "createdAt": "demo.date1T00:00:00Z",
       "startTime": "demo.date1T00:00:00Z",
@@ -211,7 +210,8 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "isClosingSoonEmailEnabled": true,
-      "isPublishedEmailEnabled": true
+      "isPublishedEmailEnabled": true,
+      "creatorId": "00000000-0000-4000-8000-000000000101"
     }
   },
   "feedbackQuestions": {

--- a/src/main/resources/db/changelog/migrations/20260602-feedback-session-creator-instructor.xml
+++ b/src/main/resources/db/changelog/migrations/20260602-feedback-session-creator-instructor.xml
@@ -1,0 +1,52 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="samuelfangjw" id="20260602-feedback-session-creator-instructor-1">
+        <addColumn tableName="feedback_sessions">
+            <column name="creator_id" type="UUID"/>
+        </addColumn>
+
+        <sql>
+            UPDATE feedback_sessions fs
+            SET creator_id = i.id
+            FROM instructors i
+            JOIN users u ON u.id = i.id
+            WHERE u.email = fs.creator_email
+                AND u.course_id = fs.course_id
+        </sql>
+
+        <addForeignKeyConstraint baseColumnNames="creator_id"
+            baseTableName="feedback_sessions"
+            constraintName="FK_feedback_sessions_creator_id"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="SET NULL"
+            referencedColumnNames="id"
+            referencedTableName="instructors"
+            validate="true"/>
+
+        <dropColumn columnName="creator_email" tableName="feedback_sessions"/>
+
+        <rollback>
+            <addColumn tableName="feedback_sessions">
+                <column name="creator_email" type="VARCHAR(255)"/>
+            </addColumn>
+
+            <sql>
+                UPDATE feedback_sessions fs
+                SET creator_email = u.email
+                FROM users u
+                WHERE u.id = fs.creator_id
+            </sql>
+
+            <dropForeignKeyConstraint baseTableName="feedback_sessions"
+                constraintName="FK_feedback_sessions_creator_id"/>
+
+            <dropColumn columnName="creator_id" tableName="feedback_sessions"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/teammates/logic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/logic/core/CoursesLogicTest.java
@@ -200,12 +200,12 @@ public class CoursesLogicTest extends BaseTestCase {
     public void testDeleteCourse_shouldDeleteCourse_success() {
         Course course = getTypicalCourse();
 
-        FeedbackSession fs = new FeedbackSession("test-fs", "test@email.com",
+        FeedbackSession fs = new FeedbackSession("test-fs", null,
                 "test", Instant.now(), Instant.now(), Instant.now(), Instant.now(), Duration.ofSeconds(60),
                 false, false);
         course.addFeedbackSession(fs);
 
-        FeedbackSession softDeletedFs = new FeedbackSession("soft-deleted-fs", "test@email.com",
+        FeedbackSession softDeletedFs = new FeedbackSession("soft-deleted-fs", null,
                 "test", Instant.now(), Instant.now(), Instant.now(), Instant.now(), Duration.ofSeconds(60),
                 false, false);
         softDeletedFs.setDeletedAt(Instant.now());

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -220,9 +220,8 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
     public void testGetFeedbackQuestionsForInstructors_instructorIsCreator_success() {
         Course c = getTypicalCourse();
         FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
-        fs.setCreatorEmail("instr1@teammates.tmt");
         Instructor instructor = mock(Instructor.class);
-        when(instructor.getEmail()).thenReturn("instr1@teammates.tmt");
+        fs.setSessionCreator(instructor);
         FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
         FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
         FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);
@@ -246,9 +245,9 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
     public void testGetFeedbackQuestionsForInstructors_instructorIsNotCreator_success() {
         Course c = getTypicalCourse();
         FeedbackSession fs = getTypicalFeedbackSessionForCourse(c);
-        fs.setCreatorEmail("instr1@teammates.tmt");
+        Instructor creator = mock(Instructor.class);
+        fs.setSessionCreator(creator);
         Instructor instructor = mock(Instructor.class);
-        when(instructor.getEmail()).thenReturn("instr2@teammates.tmt");
         FeedbackQuestion fq1 = getTypicalFeedbackQuestionForSession(fs);
         FeedbackQuestion fq2 = getTypicalFeedbackQuestionForSession(fs);
         FeedbackQuestion fq3 = getTypicalFeedbackQuestionForSession(fs);

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -174,7 +174,7 @@ public class BaseTestCase {
         Instant startTime = TimeHelperExtension.getInstantDaysOffsetFromNow(1);
         Instant endTime = TimeHelperExtension.getInstantDaysOffsetFromNow(7);
         FeedbackSession feedbackSession = new FeedbackSession("test-feedbacksession",
-                "test@teammates.tmt",
+                null,
                 "<p>test-instructions</p>",
                 startTime,
                 endTime,

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackSessionActionTest.java
@@ -178,7 +178,7 @@ public class CreateFeedbackSessionActionTest extends BaseActionTest<CreateFeedba
 
     private FeedbackSession generateSession1InCourse(Course course, Instructor instructor) {
         FeedbackSession fs = new FeedbackSession("feedbacksession-1",
-                instructor.getEmail(), "generic instructions",
+                instructor, "generic instructions",
                 nearestHour, endHour,
                 nearestHour, responseVisibleHour,
                 Duration.ofHours(10), false, false);

--- a/src/test/java/teammates/ui/webapi/DeleteFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteFeedbackSessionActionTest.java
@@ -39,7 +39,7 @@ public class DeleteFeedbackSessionActionTest extends BaseActionTest<DeleteFeedba
         course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
         session = new FeedbackSession(
                 "session-name",
-                "creater_email@tm.tmt",
+                null,
                 null,
                 Instant.parse("2020-01-01T00:00:00.000Z"),
                 Instant.parse("2020-10-01T00:00:00.000Z"),

--- a/src/test/java/teammates/ui/webapi/GenerateEmailActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GenerateEmailActionTest.java
@@ -44,7 +44,7 @@ public class GenerateEmailActionTest
     void setUp() {
         course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
         session = new FeedbackSession(
-                "session-name", "creater_email@tm.tmt", null,
+                "session-name", null, null,
                 Instant.parse("2020-01-01T00:00:00.000Z"), Instant.parse("2020-10-01T00:00:00.000Z"),
                 Instant.parse("2020-01-01T00:00:00.000Z"), Instant.parse("2020-11-01T00:00:00.000Z"),
                 null, false, false);

--- a/src/test/java/teammates/ui/webapi/GetFeedbackQuestionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackQuestionsActionTest.java
@@ -84,7 +84,7 @@ public class GetFeedbackQuestionsActionTest extends BaseActionTest<GetFeedbackQu
 
     private FeedbackSession generateSession1InCourse(Course course) {
         FeedbackSession fs = new FeedbackSession("feedbacksession-1",
-                "instructor1@gmail.com", "generic instructions",
+                null, "generic instructions",
                 Instant.parse("2012-04-01T22:00:00Z"), Instant.parse("2027-04-30T22:00:00Z"),
                 Instant.parse("2012-03-28T22:00:00Z"), Instant.parse("2027-05-01T22:00:00Z"),
                 Duration.ofHours(10), true, true);

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionActionTest.java
@@ -349,7 +349,7 @@ public class GetFeedbackSessionActionTest extends BaseActionTest<GetFeedbackSess
 
     private FeedbackSession generateSession1InCourse(Course course) {
         FeedbackSession fs = new FeedbackSession("feedbacksession-1",
-                "instructor1@gmail.com", "generic instructions",
+                null, "generic instructions",
                 Instant.parse("2012-04-01T22:00:00Z"), Instant.parse("2027-04-30T22:00:00Z"),
                 Instant.parse("2012-03-28T22:00:00Z"), Instant.parse("2027-05-01T22:00:00Z"),
                 Duration.ofHours(10), true, true);

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
@@ -284,7 +284,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
 
     private FeedbackSession generateSession1InCourse(Course course, String name) {
         FeedbackSession fs = new FeedbackSession(name,
-                "instructor1@gmail.com", "generic instructions",
+                null, "generic instructions",
                 Instant.parse("2012-04-01T22:00:00Z"), Instant.parse("2027-04-30T22:00:00Z"),
                 Instant.parse("2012-03-28T22:00:00Z"), Instant.parse("2027-05-01T22:00:00Z"),
                 Duration.ofHours(10), true, true);
@@ -305,7 +305,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
     private FeedbackSession generateClosedFeedbackSessionInCourse(Course course, String name) {
         FeedbackSession closedSession = new FeedbackSession(
                 name,
-                "instructor1@gmail.com", "generic instructions",
+                null, "generic instructions",
                 Instant.parse("2012-04-01T22:00:00Z"),
                 Instant.parse("2025-01-01T00:00:00Z"),
                 Instant.parse("2012-03-28T22:00:00Z"),

--- a/src/test/java/teammates/ui/webapi/GetHasResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetHasResponsesActionTest.java
@@ -371,7 +371,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         Instant startTime = Instant.now().minus(Duration.ofDays(3));
         Instant endTime = Instant.now().minus(Duration.ofDays(1));
         FeedbackSession fs = new FeedbackSession("Template feedback session",
-                "test@teammates.tmt",
+                null,
                 "test-instructions",
                 startTime,
                 endTime,

--- a/src/test/java/teammates/ui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetOngoingSessionsActionTest.java
@@ -174,17 +174,17 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor4.setAccount(instructor4Account);
         when(mockLogic.getInstructorsByCourse(course3.getId())).thenReturn(Collections.singletonList(instructor4));
-        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", "test2@test.com", "test-instruction",
+        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", null, "test-instruction",
                 instantNow.plus(Duration.ofHours(12L)), instantNow.plus(Duration.ofDays(7L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
         course1.addFeedbackSession(c1Fs2);
-        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", "test3@test.com", "test-instruction",
+        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", null, "test-instruction",
                 instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
         course2.addFeedbackSession(c2Fs1);
-        FeedbackSession c3Fs1 = new FeedbackSession("name3-1", "test4@test.com", "test-instruction",
+        FeedbackSession c3Fs1 = new FeedbackSession("name3-1", null, "test-instruction",
                 instantNow.minus(Duration.ofDays(7L)), instantNow.minus(Duration.ofHours(12L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
@@ -249,12 +249,12 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                 new InstructorPrivileges(InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         instructor3.setAccount(instructor3Account);
         when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
-        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", "test2@test.com", "test-instruction",
+        FeedbackSession c1Fs2 = new FeedbackSession("name1-2", null, "test-instruction",
                 instantNow.plus(Duration.ofHours(12L)), instantNow.plus(Duration.ofDays(7L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
         course1.addFeedbackSession(c1Fs2);
-        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", "test3@test.com", "test-instruction",
+        FeedbackSession c2Fs1 = new FeedbackSession("name2-1", null, "test-instruction",
                 instantNow.minus(Duration.ofHours(12L)), instantNow.plus(Duration.ofHours(12L)),
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);

--- a/src/test/java/teammates/ui/webapi/RemindFeedbackSessionResultActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RemindFeedbackSessionResultActionTest.java
@@ -141,7 +141,7 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
     private FeedbackSession generatePublishedSessionInCourse(Course course, Instructor instructor) {
         Instant beforeNow = nearestHour.minus(3, java.time.temporal.ChronoUnit.HOURS);
         FeedbackSession fs = new FeedbackSession("published-feedback-session",
-                instructor.getEmail(), "generic instructions",
+                instructor, "generic instructions",
                 beforeNow, beforeNow,
                 beforeNow, beforeNow,
                 Duration.ofHours(10), false, false);
@@ -155,7 +155,7 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
         Instant afterNowStartTime = nearestHour.plus(10, java.time.temporal.ChronoUnit.HOURS);
         Instant afterNowEndTime = nearestHour.plus(15, java.time.temporal.ChronoUnit.HOURS);
         FeedbackSession fs = new FeedbackSession("unpublished-feedback-session",
-                instructor.getEmail(), "generic instructions",
+                instructor, "generic instructions",
                 afterNowStartTime,
                 afterNowEndTime,
                 afterNowStartTime, afterNowEndTime,

--- a/src/test/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionActionTest.java
@@ -141,7 +141,7 @@ public class RemindFeedbackSessionSubmissionActionTest
         Instant beforeNow = nearestHour.minus(3, java.time.temporal.ChronoUnit.HOURS);
         Instant afterNow = nearestHour.plus(3, java.time.temporal.ChronoUnit.HOURS);
         FeedbackSession fs = new FeedbackSession("published-feedback-session",
-                instructor.getEmail(), "generic instructions",
+                instructor, "generic instructions",
                 beforeNow, afterNow,
                 beforeNow, afterNow,
                 Duration.ofHours(0), false, false);
@@ -154,7 +154,7 @@ public class RemindFeedbackSessionSubmissionActionTest
     private FeedbackSession generateClosedSessionInCourse(Course course, Instructor instructor) {
         Instant beforeNow = nearestHour.minus(3, java.time.temporal.ChronoUnit.HOURS);
         FeedbackSession fs = new FeedbackSession("unpublished-feedback-session",
-                instructor.getEmail(), "generic instructions",
+                instructor, "generic instructions",
                 beforeNow,
                 beforeNow,
                 beforeNow, beforeNow,

--- a/src/test/java/teammates/ui/webapi/UpdateDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateDeadlineExtensionsActionTest.java
@@ -127,7 +127,7 @@ public class UpdateDeadlineExtensionsActionTest
 
     private FeedbackSession generateSession1InCourse(Course course, Instructor instructor) {
         FeedbackSession fs = new FeedbackSession("feedbacksession-1",
-                instructor.getEmail(), "generic instructions",
+                instructor, "generic instructions",
                 nearestHour, endHour,
                 nearestHour, responseVisibleHour,
                 Duration.ofHours(10), false, false);

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -205,7 +205,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
 
     private FeedbackSession generateSession1InCourse(Course course, Instructor inst) {
         FeedbackSession fs = new FeedbackSession("feedbacksession-1",
-                inst.getEmail(), "generic instructions",
+                inst, "generic instructions",
                 nearestHour, endHour,
                 nearestHour, responseVisibleHour,
                 Duration.ofHours(10), false, false);

--- a/src/test/resources/data/FeedbackContributionQuestionTest.json
+++ b/src/test/resources/data/FeedbackContributionQuestionTest.json
@@ -768,7 +768,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "idOfTypicalCourse1",
       "name": "First feedback session",
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -782,13 +781,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "idOfTypicalCourse1",
       "name": "Second feedback session",
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -802,13 +801,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2013-03-20T23:59:00Z"
+      "createdAt": "2013-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "gracePeriodSession": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "idOfTypicalCourse1",
       "name": "Grace Period Session",
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -822,13 +821,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2013-03-20T23:59:00Z"
+      "createdAt": "2013-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "closedSession": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "idOfTypicalCourse1",
       "name": "Closed Session",
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2013-06-01T22:00:00Z",
@@ -842,13 +841,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2013-03-20T23:59:00Z"
+      "createdAt": "2013-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "empty.session": {
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "idOfTypicalCourse1",
       "name": "Empty session",
-      "creatorEmail": "instructor2@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-02-02T00:00:00Z",
       "endTime": "2013-04-29T00:00:00Z",
@@ -862,13 +861,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2013-01-20T23:57:00Z"
+      "createdAt": "2013-01-20T23:57:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     },
     "awaiting.session": {
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "idOfTypicalCourse1",
       "name": "non visible session",
-      "creatorEmail": "instructor2@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2026-04-01T23:00:00Z",
       "endTime": "2026-04-28T23:00:00Z",
@@ -882,13 +881,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2013-01-20T23:00:00Z"
+      "createdAt": "2013-01-20T23:00:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000502"
     },
     "archiveCourse.session1": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "idOfArchivedCourse",
       "name": "session without student questions",
-      "creatorEmail": "instructor1@course1.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-02-20T23:00:00Z",
       "endTime": "2026-04-28T23:00:00Z",
@@ -902,13 +901,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2013-01-20T23:00:00Z"
+      "createdAt": "2013-01-20T23:00:00Z",
+      "creatorId": null
     },
     "session1InCourse2": {
       "id": "00000000-0000-4000-8000-000000000708",
       "courseId": "idOfTypicalCourse2",
       "name": "Instructor feedback session",
-      "creatorEmail": "instructor1@course2.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T16:00:00Z",
       "endTime": "2027-04-30T16:00:00Z",
@@ -922,13 +921,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000505"
     },
     "session2InCourse2": {
       "id": "00000000-0000-4000-8000-000000000709",
       "courseId": "idOfTypicalCourse2",
       "name": "Not answerable feedback session",
-      "creatorEmail": "instructor1@course2.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T16:00:00Z",
       "endTime": "2027-04-30T16:00:00Z",
@@ -942,13 +941,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000505"
     },
     "session1InCourse3": {
       "id": "00000000-0000-4000-8000-000000000710",
       "courseId": "idOfTypicalCourse3",
       "name": "First feedback session",
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -962,13 +961,13 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000507"
     },
     "session2InCourse3": {
       "id": "00000000-0000-4000-8000-000000000711",
       "courseId": "idOfTypicalCourse3",
       "name": "Second feedback session",
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -983,13 +982,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "deletedAt": "2012-05-20T23:59:00Z",
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000507"
     },
     "session1InCourse4": {
       "id": "00000000-0000-4000-8000-000000000712",
       "courseId": "idOfTypicalCourse4",
       "name": "First feedback session",
-      "creatorEmail": "instructor1@course3.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -1004,13 +1003,13 @@
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
       "deletedAt": "2012-05-20T23:59:00Z",
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000509"
     },
     "session1InTestingSanitizationCourse": {
       "id": "00000000-0000-4000-8000-000000000713",
       "courseId": "idOfTestingSanitizationCourse",
       "name": "Normal feedback session name",
-      "creatorEmail": "instructor1@sanitization.tmt",
       "instructions": "unclosed tags  Attempted script injection &#39;&#34; ",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -1024,7 +1023,8 @@
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
       "isPublishedEmailSent": false,
-      "createdAt": "2012-03-20T23:59:00Z"
+      "createdAt": "2012-03-20T23:59:00Z",
+      "creatorId": "00000000-0000-4000-8000-000000000519"
     }
   },
   "feedbackQuestions": {

--- a/src/test/resources/data/FeedbackSessionResultsBundleTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsBundleTest.json
@@ -526,7 +526,6 @@
       "id": "00000000-0000-4000-8000-000000000701",
       "courseId": "course-1",
       "name": "First feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-04-01T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -539,13 +538,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "session2InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000702",
       "courseId": "course-1",
       "name": "Second feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -558,13 +557,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "unpublishedSession1InTypicalCourse": {
       "id": "00000000-0000-4000-8000-000000000703",
       "courseId": "course-1",
       "name": "Unpublished feedback session",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2013-06-01T22:00:00Z",
       "endTime": "2026-04-28T22:00:00Z",
@@ -577,13 +576,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": false,
       "isClosedEmailSent": false,
-      "isPublishedEmailSent": false
+      "isPublishedEmailSent": false,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000704",
       "courseId": "course-1",
       "name": "Ongoing session 1 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
       "endTime": "2012-01-25T22:00:00Z",
@@ -596,13 +595,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000705",
       "courseId": "course-1",
       "name": "Ongoing session 2 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-26T22:00:00Z",
       "endTime": "2012-02-02T22:00:00Z",
@@ -615,13 +614,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession3InCourse1": {
       "id": "00000000-0000-4000-8000-000000000706",
       "courseId": "course-1",
       "name": "Ongoing session 3 in course 1",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-26T10:00:00Z",
       "endTime": "2012-01-27T10:00:00Z",
@@ -634,13 +633,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000501"
     },
     "ongoingSession1InCourse3": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "course-3",
       "name": "Ongoing session 1 in course 3",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-27T22:00:00Z",
       "endTime": "2012-02-02T22:00:00Z",
@@ -653,13 +652,13 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000506"
     },
     "ongoingSession2InCourse3": {
       "id": "00000000-0000-4000-8000-000000000707",
       "courseId": "course-3",
       "name": "Ongoing session 2 in course 3",
-      "creatorEmail": "instr1@teammates.tmt",
       "instructions": "Please please fill in the following questions.",
       "startTime": "2012-01-19T22:00:00Z",
       "endTime": "2027-04-30T22:00:00Z",
@@ -672,7 +671,8 @@
       "isOpenedEmailSent": true,
       "isClosingSoonEmailSent": true,
       "isClosedEmailSent": true,
-      "isPublishedEmailSent": true
+      "isPublishedEmailSent": true,
+      "creatorId": "00000000-0000-4000-8000-000000000506"
     }
   },
   "feedbackQuestions": {
@@ -780,7 +780,7 @@
       "questionDetails": {
         "hasAssignedWeights": false,
         "mcqWeights": [],
-        "mcqOtherWeight": 0.0,
+        "mcqOtherWeight": 0,
         "mcqChoices": ["Great", "Perfect"],
         "otherEnabled": false,
         "questionDropdownEnabled": false,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Replacing creatorEmail with reference to actual instructor as part of SQL migration. This PR also introduces the concept of nullable feedback creator. This happens if the instructor is deleted after creating a feedback session.
