### PR TITLE
[#14083] Move primary action button to the right

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-edit-page/__snapshots__/instructor-course-edit-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/__snapshots__/instructor-course-edit-page.component.spec.ts.snap
@@ -79,18 +79,18 @@ exports[`InstructorCourseEditPageComponent > should snap when editing course det
     class="card-body text-center"
   >
     <button
-      class="btn btn-success mx-2 my-1"
-      id="btn-add-instructor"
-      type="button"
-    >
-       Add New Instructor 
-    </button>
-    <button
       class="btn btn-info mx-2 my-1"
       id="btn-copy-instructor"
       type="button"
     >
        Copy Instructors from Other Courses 
+    </button>
+    <button
+      class="btn btn-success mx-2 my-1"
+      id="btn-add-instructor"
+      type="button"
+    >
+       Add New Instructor 
     </button>
   </div><div
     class="collapse"
@@ -384,18 +384,18 @@ exports[`InstructorCourseEditPageComponent > should snap with course details 1`]
     class="card-body text-center"
   >
     <button
-      class="btn btn-success mx-2 my-1"
-      id="btn-add-instructor"
-      type="button"
-    >
-       Add New Instructor 
-    </button>
-    <button
       class="btn btn-info mx-2 my-1"
       id="btn-copy-instructor"
       type="button"
     >
        Copy Instructors from Other Courses 
+    </button>
+    <button
+      class="btn btn-success mx-2 my-1"
+      id="btn-add-instructor"
+      type="button"
+    >
+       Add New Instructor 
     </button>
   </div><div
     class="collapse"
@@ -689,18 +689,18 @@ exports[`InstructorCourseEditPageComponent > should snap with default fields 1`]
     class="card-body text-center"
   >
     <button
-      class="btn btn-success mx-2 my-1"
-      id="btn-add-instructor"
-      type="button"
-    >
-       Add New Instructor 
-    </button>
-    <button
       class="btn btn-info mx-2 my-1"
       id="btn-copy-instructor"
       type="button"
     >
        Copy Instructors from Other Courses 
+    </button>
+    <button
+      class="btn btn-success mx-2 my-1"
+      id="btn-add-instructor"
+      type="button"
+    >
+       Add New Instructor 
     </button>
   </div><div
     class="collapse"
@@ -1153,18 +1153,18 @@ exports[`InstructorCourseEditPageComponent > should snap with some instructor de
     class="card-body text-center"
   >
     <button
-      class="btn btn-success mx-2 my-1"
-      id="btn-add-instructor"
-      type="button"
-    >
-       Add New Instructor 
-    </button>
-    <button
       class="btn btn-info mx-2 my-1"
       id="btn-copy-instructor"
       type="button"
     >
        Copy Instructors from Other Courses 
+    </button>
+    <button
+      class="btn btn-success mx-2 my-1"
+      id="btn-add-instructor"
+      type="button"
+    >
+       Add New Instructor 
     </button>
   </div><div
     class="collapse"

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
@@ -52,16 +52,7 @@
 </tm-loading-retry>
 @if (!isAddingNewInstructor) {
   <div class="card-body text-center">
-    <button
-      id="btn-add-instructor"
-      class="btn btn-success mx-2 my-1"
-      type="button"
-      (click)="isAddingNewInstructor = true"
-      [disabled]="isCopyingInstructor"
-    >
-      Add New Instructor
-    </button>
-    <button
+      <button
       id="btn-copy-instructor"
       class="btn btn-info mx-2 my-1"
       type="button"
@@ -73,6 +64,16 @@
       }
       Copy Instructors from Other Courses
     </button>
+    <button
+      id="btn-add-instructor"
+      class="btn btn-success mx-2 my-1"
+      type="button"
+      (click)="isAddingNewInstructor = true"
+      [disabled]="isCopyingInstructor"
+    >
+      Add New Instructor
+    </button>
+  
   </div>
 }
 <div [ngbCollapse]="!isAddingNewInstructor">

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.html
@@ -52,7 +52,7 @@
 </tm-loading-retry>
 @if (!isAddingNewInstructor) {
   <div class="card-body text-center">
-      <button
+    <button
       id="btn-copy-instructor"
       class="btn btn-info mx-2 my-1"
       type="button"
@@ -73,7 +73,6 @@
     >
       Add New Instructor
     </button>
-  
   </div>
 }
 <div [ngbCollapse]="!isAddingNewInstructor">


### PR DESCRIPTION
Fixes #14083

## Summary

Reordered the action buttons in the instructor course edit page so that the primary action appears to the right of the secondary action, following common LTR UI conventions.

### Changes

* Moved "Add New Instructor" button to the right of "Copy Instructors from Other Courses".
* No functional changes; only button ordering was updated.
