### PR TITLE
[#14098] Remove left padding and update heading colors on features page

### DIFF
--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -1,170 +1,170 @@
 <div class="lead">
-    <h1 class="color-orange">Features</h1>
-    <p class="h6">
-        Here is an overview of some notable TEAMMATES features. The
-        <a tmRouterLink="/web/front/help/instructor">help page</a> contains more details about how to use these features.
-    </p>
+  <h1 class="color-orange">Features</h1>
+  <p class="h6">
+    Here is an overview of some notable TEAMMATES features. The
+    <a tmRouterLink="/web/front/help/instructor">help page</a> contains more details about how to use these features.
+  </p>
 </div>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Team peer evaluations</h2>
-        <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
-        <div>
-            Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous
-            peer feedback to team members.
-            <br /><br />
-            Students can provide confidential peer evaluations to you too.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Team peer evaluations</h2>
+    <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
+    <div>
+      Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer
+      feedback to team members.
+      <br /><br />
+      Students can provide confidential peer evaluations to you too.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Flexible feedback paths</h2>
-        <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
-        <div>
-            There are many other feedback paths available. Some examples:<br />
-            a) feedback between teams<br />
-            b) from instructors to students<br />
-            c) from each student to three other students
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Flexible feedback paths</h2>
+    <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
+    <div>
+      There are many other feedback paths available. Some examples:<br />
+      a) feedback between teams<br />
+      b) from instructors to students<br />
+      c) from each student to three other students
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Powerful visibility control</h2>
-        <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
-        <div>
-            If you plan to publish the responses collected, you can set the visibility level for each question i.e. who
-            can see the<br />
-            (i) response text,<br />
-            (ii) the identity of the feedback giver, and<br />
-            (iii) the identity of the feedback receiver.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Powerful visibility control</h2>
+    <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
+    <div>
+      If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can
+      see the<br />
+      (i) response text,<br />
+      (ii) the identity of the feedback giver, and<br />
+      (iii) the identity of the feedback receiver.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Reports and statistics</h2>
-        <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
-        <div>
-            There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
-            <br /><br />
-            Some statistics for the responses are available too.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Reports and statistics</h2>
+    <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
+    <div>
+      There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
+      <br /><br />
+      Some statistics for the responses are available too.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Fine-grain access control</h2>
-        <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
-        <div>
-            You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them
-            different access levels.
-            <br /><br />
-            If required, you can even set which sessions of which section of students are accessible to a particular
-            instructor.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Fine-grain access control</h2>
+    <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
+    <div>
+      You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different
+      access levels.
+      <br /><br />
+      If required, you can even set which sessions of which section of students are accessible to a particular
+      instructor.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Different question types</h2>
-        <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
-        <div>
-            Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number
-            of points among options' questions, questions measuring contribution in team projects, and more choices coming
-            soon...
-            <br /><br />
-            You can even generate MCQ options from student names, as illustrated in the above example.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Different question types</h2>
+    <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
+    <div>
+      Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number of
+      points among options' questions, questions measuring contribution in team projects, and more choices coming
+      soon...
+      <br /><br />
+      You can even generate MCQ options from student names, as illustrated in the above example.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Reuse past questions</h2>
-        <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
-        <div>
-            Once you have a perfect set of questions configured for a session, you can reuse those questions later,
-            without needing to configure the same questions from scratch again.
-            <br /><br />
-            TEAMMATES also provides some session templates to choose from.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Reuse past questions</h2>
+    <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
+    <div>
+      Once you have a perfect set of questions configured for a session, you can reuse those questions later, without
+      needing to configure the same questions from scratch again.
+      <br /><br />
+      TEAMMATES also provides some session templates to choose from.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">No signup required for students</h2>
-        <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
-        <div>
-            Students can submit responses and view published responses using the unique links TEAMMATES emails them,
-            without having to log in or sign up.
-            <br /><br />
-            If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in
-            one page and access even more features such as setting up profiles.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">No signup required for students</h2>
+    <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
+    <div>
+      Students can submit responses and view published responses using the unique links TEAMMATES emails them, without
+      having to log in or sign up.
+      <br /><br />
+      If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one
+      page and access even more features such as setting up profiles.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Downloadable data</h2>
-        <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
-        <div>
-            You can download the collected responses (and statistics) as spreadsheets.
-            <br /><br />
-            The collected data belongs to you and you may delete your data from TEAMMATES any time.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Downloadable data</h2>
+    <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
+    <div>
+      You can download the collected responses (and statistics) as spreadsheets.
+      <br /><br />
+      The collected data belongs to you and you may delete your data from TEAMMATES any time.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Shareable comments</h2>
-        <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
-        <div>
-            You can add comments about responses collected. You can even share these comments with students/instructors.
-            <br /><br />
-            Fine-grained visibility control is available for comments too. For example, you can give a comment to a
-            student that the receiving student can see while other students in the course can only see the comment text
-            but cannot see the recipient name.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Shareable comments</h2>
+    <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
+    <div>
+      You can add comments about responses collected. You can even share these comments with students/instructors.
+      <br /><br />
+      Fine-grained visibility control is available for comments too. For example, you can give a comment to a student
+      that the receiving student can see while other students in the course can only see the comment text but cannot see
+      the recipient name.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Powerful search</h2>
-        <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
-        <div>
-            TEAMMATES has a powerful search feature to locate details about students.
-            <br /><br />
-            Given above is an example of searching for a student whose name you are not very sure of.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Powerful search</h2>
+    <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
+    <div>
+      TEAMMATES has a powerful search feature to locate details about students.
+      <br /><br />
+      Given above is an example of searching for a student whose name you are not very sure of.
     </div>
+  </div>
 </section>
 
 <section class="row mb-5">
-    <div class="col-xs-12 col-sm-8">
-        <h2 class="color-blue">Support for big courses</h2>
-        <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
-        <div>
-            TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students
-            into sections of no more than 100 students. There is no limit on the number of courses or sessions you could
-            have either.
-        </div>
+  <div class="col-xs-12 col-sm-8">
+    <h2 class="color-blue">Support for big courses</h2>
+    <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
+    <div>
+      TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into
+      sections of no more than 100 students. There is no limit on the number of courses or sessions you could have
+      either.
     </div>
+  </div>
 </section>
 
 <p class="h6">
-    For more details about these features, visit our
-    <a tmRouterLink="/web/front/help/instructor">Help for Instructors</a> or
-    <a tmRouterLink="/web/front/contact">contact us</a>.
+  For more details about these features, visit our
+  <a tmRouterLink="/web/front/help/instructor">Help for Instructors</a> or
+  <a tmRouterLink="/web/front/contact">contact us</a>.
 </p>

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -7,9 +7,9 @@
 </div>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Team peer evaluations</h2>
+      <h2 class="color-blue col-xs-12">Team peer evaluations</h2>
       <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
       <div class="col-lg-9">
         <div>
@@ -24,9 +24,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Flexible feedback paths</h2>
+      <h2 class="color-blue col-xs-12">Flexible feedback paths</h2>
       <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
       <div class="col-lg-9">
         <div>
@@ -41,9 +41,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Powerful visibility control</h2>
+      <h2 class="color-blue col-xs-12">Powerful visibility control</h2>
       <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
       <div class="col-lg-9">
         <div>
@@ -59,9 +59,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Reports and statistics</h2>
+      <h2 class="color-blue col-xs-12">Reports and statistics</h2>
       <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
       <div class="col-lg-9">
         <div>
@@ -75,9 +75,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Fine-grain access control</h2>
+      <h2 class="color-blue col-xs-12">Fine-grain access control</h2>
       <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
       <div class="col-lg-9">
         <div>
@@ -93,9 +93,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Different question types</h2>
+      <h2 class="color-blue col-xs-12">Different question types</h2>
       <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
       <div class="col-lg-9">
         <div>
@@ -111,9 +111,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Reuse past questions</h2>
+      <h2 class="color-blue col-xs-12">Reuse past questions</h2>
       <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
       <div class="col-lg-9">
         <div>
@@ -128,9 +128,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">No signup required for students</h2>
+      <h2 class="color-blue col-xs-12">No signup required for students</h2>
       <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
       <div class="col-lg-9">
         <div>
@@ -146,9 +146,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Downloadable data</h2>
+      <h2 class="color-blue col-xs-12">Downloadable data</h2>
       <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
       <div class="col-lg-9">
         <div>
@@ -162,9 +162,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Shareable comments</h2>
+      <h2 class="color-blue col-xs-12">Shareable comments</h2>
       <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
       <div class="col-lg-9">
         <div>
@@ -180,9 +180,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Powerful search</h2>
+      <h2 class="color-blue col-xs-12">Powerful search</h2>
       <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
       <div class="col-lg-9">
         <div>
@@ -196,9 +196,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8 offset-sm-1">
+  <div class="col-xs-12 col-sm-8">
     <div class="inner-content">
-      <h2 class="color-orange col-xs-12">Support for big courses</h2>
+      <h2 class="color-blue col-xs-12">Support for big courses</h2>
       <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
       <div class="col-lg-9">
         <div>

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -1,194 +1,170 @@
 <div class="lead">
-  <h1 class="color-orange">Features</h1>
-  <p class="h6">
-    Here is an overview of some notable TEAMMATES features. The
-    <a tmRouterLink="/web/front/help/instructor">help page</a> contains more details about how to use these features.
-  </p>
+    <h1 class="color-orange">Features</h1>
+    <p class="h6">
+        Here is an overview of some notable TEAMMATES features. The
+        <a tmRouterLink="/web/front/help/instructor">help page</a> contains more details about how to use these features.
+    </p>
 </div>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Team peer evaluations</h2>
-    <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
-    <div class="col-lg-9">
-      <div>
-        Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer
-        feedback to team members.
-        <br /><br />
-        Students can provide confidential peer evaluations to you too.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Team peer evaluations</h2>
+        <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
+        <div>
+            Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous
+            peer feedback to team members.
+            <br /><br />
+            Students can provide confidential peer evaluations to you too.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Flexible feedback paths</h2>
-    <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
-    <div class="col-lg-9">
-      <div>
-        There are many other feedback paths available. Some examples:<br />
-        a) feedback between teams<br />
-        b) from instructors to students<br />
-        c) from each student to three other students
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Flexible feedback paths</h2>
+        <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
+        <div>
+            There are many other feedback paths available. Some examples:<br />
+            a) feedback between teams<br />
+            b) from instructors to students<br />
+            c) from each student to three other students
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Powerful visibility control</h2>
-    <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
-    <div class="col-lg-9">
-      <div>
-        If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can
-        see the<br />
-        (i) response text,<br />
-        (ii) the identity of the feedback giver, and<br />
-        (iii) the identity of the feedback receiver.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Powerful visibility control</h2>
+        <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
+        <div>
+            If you plan to publish the responses collected, you can set the visibility level for each question i.e. who
+            can see the<br />
+            (i) response text,<br />
+            (ii) the identity of the feedback giver, and<br />
+            (iii) the identity of the feedback receiver.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Reports and statistics</h2>
-    <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
-    <div class="col-lg-9">
-      <div>
-        There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
-        <br /><br />
-        Some statistics for the responses are available too.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Reports and statistics</h2>
+        <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
+        <div>
+            There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
+            <br /><br />
+            Some statistics for the responses are available too.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Fine-grain access control</h2>
-    <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
-    <div class="col-lg-9">
-      <div>
-        You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different
-        access levels.
-        <br /><br />
-        If required, you can even set which sessions of which section of students are accessible to a particular
-        instructor.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Fine-grain access control</h2>
+        <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
+        <div>
+            You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them
+            different access levels.
+            <br /><br />
+            If required, you can even set which sessions of which section of students are accessible to a particular
+            instructor.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Different question types</h2>
-    <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
-    <div class="col-lg-9">
-      <div>
-        Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number
-        of points among options' questions, questions measuring contribution in team projects, and more choices coming
-        soon...
-        <br /><br />
-        You can even generate MCQ options from student names, as illustrated in the above example.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Different question types</h2>
+        <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
+        <div>
+            Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number
+            of points among options' questions, questions measuring contribution in team projects, and more choices coming
+            soon...
+            <br /><br />
+            You can even generate MCQ options from student names, as illustrated in the above example.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Reuse past questions</h2>
-    <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
-    <div class="col-lg-9">
-      <div>
-        Once you have a perfect set of questions configured for a session, you can reuse those questions later, without
-        needing to configure the same questions from scratch again.
-        <br /><br />
-        TEAMMATES also provides some session templates to choose from.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Reuse past questions</h2>
+        <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
+        <div>
+            Once you have a perfect set of questions configured for a session, you can reuse those questions later,
+            without needing to configure the same questions from scratch again.
+            <br /><br />
+            TEAMMATES also provides some session templates to choose from.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">No signup required for students</h2>
-    <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
-    <div class="col-lg-9">
-      <div>
-        Students can submit responses and view published responses using the unique links TEAMMATES emails them, without
-        having to log in or sign up.
-        <br /><br />
-        If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one
-        page and access even more features such as setting up profiles.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">No signup required for students</h2>
+        <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
+        <div>
+            Students can submit responses and view published responses using the unique links TEAMMATES emails them,
+            without having to log in or sign up.
+            <br /><br />
+            If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in
+            one page and access even more features such as setting up profiles.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Downloadable data</h2>
-    <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
-    <div class="col-lg-9">
-      <div>
-        You can download the collected responses (and statistics) as spreadsheets.
-        <br /><br />
-        The collected data belongs to you and you may delete your data from TEAMMATES any time.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Downloadable data</h2>
+        <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
+        <div>
+            You can download the collected responses (and statistics) as spreadsheets.
+            <br /><br />
+            The collected data belongs to you and you may delete your data from TEAMMATES any time.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Shareable comments</h2>
-    <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
-    <div class="col-lg-9">
-      <div>
-        You can add comments about responses collected. You can even share these comments with students/instructors.
-        <br /><br />
-        Fine-grained visibility control is available for comments too. For example, you can give a comment to a student
-        that the receiving student can see while other students in the course can only see the comment text but cannot
-        see the recipient name.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Shareable comments</h2>
+        <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
+        <div>
+            You can add comments about responses collected. You can even share these comments with students/instructors.
+            <br /><br />
+            Fine-grained visibility control is available for comments too. For example, you can give a comment to a
+            student that the receiving student can see while other students in the course can only see the comment text
+            but cannot see the recipient name.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Powerful search</h2>
-    <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
-    <div class="col-lg-9">
-      <div>
-        TEAMMATES has a powerful search feature to locate details about students.
-        <br /><br />
-        Given above is an example of searching for a student whose name you are not very sure of.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Powerful search</h2>
+        <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
+        <div>
+            TEAMMATES has a powerful search feature to locate details about students.
+            <br /><br />
+            Given above is an example of searching for a student whose name you are not very sure of.
+        </div>
     </div>
-  </div>
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12">
-    <h2 class="color-blue">Support for big courses</h2>
-    <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
-    <div class="col-lg-9">
-      <div>
-        TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into
-        sections of no more than 100 students. There is no limit on the number of courses or sessions you could have
-        either.
-      </div>
+    <div class="col-xs-12 col-sm-8">
+        <h2 class="color-blue">Support for big courses</h2>
+        <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
+        <div>
+            TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students
+            into sections of no more than 100 students. There is no limit on the number of courses or sessions you could
+            have either.
+        </div>
     </div>
-  </div>
 </section>
 
 <p class="h6">
-  For more details about these features, visit our
-  <a tmRouterLink="/web/front/help/instructor">Help for Instructors</a> or
-  <a tmRouterLink="/web/front/contact">contact us</a>.
+    For more details about these features, visit our
+    <a tmRouterLink="/web/front/help/instructor">Help for Instructors</a> or
+    <a tmRouterLink="/web/front/contact">contact us</a>.
 </p>

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -7,9 +7,9 @@
 </div>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Team peer evaluations</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Team peer evaluations</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
       <div class="col-lg-9">
         <div>
@@ -24,9 +24,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Flexible feedback paths</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Flexible feedback paths</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
       <div class="col-lg-9">
         <div>
@@ -41,9 +41,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Powerful visibility control</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Powerful visibility control</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
       <div class="col-lg-9">
         <div>
@@ -59,9 +59,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Reports and statistics</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Reports and statistics</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
       <div class="col-lg-9">
         <div>
@@ -75,9 +75,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Fine-grain access control</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Fine-grain access control</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
       <div class="col-lg-9">
         <div>
@@ -93,9 +93,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Different question types</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Different question types</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
       <div class="col-lg-9">
         <div>
@@ -111,9 +111,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Reuse past questions</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Reuse past questions</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
       <div class="col-lg-9">
         <div>
@@ -128,9 +128,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">No signup required for students</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">No signup required for students</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
       <div class="col-lg-9">
         <div>
@@ -146,9 +146,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Downloadable data</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Downloadable data</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
       <div class="col-lg-9">
         <div>
@@ -162,9 +162,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Shareable comments</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Shareable comments</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
       <div class="col-lg-9">
         <div>
@@ -180,9 +180,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
-      <h2 class="color-blue">Powerful search</h2>
-      <div class="inner-content">
+  <div class="col-xs-12">
+    <h2 class="color-blue">Powerful search</h2>
+    <div class="inner-content">
       <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
       <div class="col-lg-9">
         <div>
@@ -196,7 +196,7 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 ">
+  <div class="col-xs-12">
     <div class="inner-content">
       <h2 class="color-blue">Support for big courses</h2>
       <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -7,9 +7,9 @@
 </div>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Team peer evaluations</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Team peer evaluations</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
       <div class="col-lg-9">
         <div>
@@ -24,9 +24,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Flexible feedback paths</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Flexible feedback paths</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
       <div class="col-lg-9">
         <div>
@@ -41,9 +41,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Powerful visibility control</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Powerful visibility control</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
       <div class="col-lg-9">
         <div>
@@ -59,9 +59,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Reports and statistics</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Reports and statistics</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
       <div class="col-lg-9">
         <div>
@@ -75,9 +75,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Fine-grain access control</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Fine-grain access control</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
       <div class="col-lg-9">
         <div>
@@ -93,9 +93,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Different question types</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Different question types</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
       <div class="col-lg-9">
         <div>
@@ -111,9 +111,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Reuse past questions</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Reuse past questions</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
       <div class="col-lg-9">
         <div>
@@ -128,9 +128,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">No signup required for students</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">No signup required for students</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
       <div class="col-lg-9">
         <div>
@@ -146,9 +146,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Downloadable data</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Downloadable data</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
       <div class="col-lg-9">
         <div>
@@ -162,9 +162,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Shareable comments</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Shareable comments</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
       <div class="col-lg-9">
         <div>
@@ -180,9 +180,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
-    <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Powerful search</h2>
+  <div class="col-xs-12 ">
+      <h2 class="color-blue">Powerful search</h2>
+      <div class="inner-content">
       <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
       <div class="col-lg-9">
         <div>
@@ -196,9 +196,9 @@
 </section>
 
 <section class="row mb-5">
-  <div class="col-xs-12 col-sm-8">
+  <div class="col-xs-12 ">
     <div class="inner-content">
-      <h2 class="color-blue col-xs-12">Support for big courses</h2>
+      <h2 class="color-blue">Support for big courses</h2>
       <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
       <div class="col-lg-9">
         <div>

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -9,15 +9,13 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Team peer evaluations</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
-      <div class="col-lg-9">
-        <div>
-          Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous
-          peer feedback to team members.
-          <br /><br />
-          Students can provide confidential peer evaluations to you too.
-        </div>
+    <img src="assets/images/feature-teampeerevaluations.png" alt="Team peer evaluations" />
+    <div class="col-lg-9">
+      <div>
+        Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer
+        feedback to team members.
+        <br /><br />
+        Students can provide confidential peer evaluations to you too.
       </div>
     </div>
   </div>
@@ -26,15 +24,13 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Flexible feedback paths</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
-      <div class="col-lg-9">
-        <div>
-          There are many other feedback paths available. Some examples:<br />
-          a) feedback between teams<br />
-          b) from instructors to students<br />
-          c) from each student to three other students
-        </div>
+    <img src="assets/images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths" />
+    <div class="col-lg-9">
+      <div>
+        There are many other feedback paths available. Some examples:<br />
+        a) feedback between teams<br />
+        b) from instructors to students<br />
+        c) from each student to three other students
       </div>
     </div>
   </div>
@@ -43,16 +39,14 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Powerful visibility control</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
-      <div class="col-lg-9">
-        <div>
-          If you plan to publish the responses collected, you can set the visibility level for each question i.e. who
-          can see the<br />
-          (i) response text,<br />
-          (ii) the identity of the feedback giver, and<br />
-          (iii) the identity of the feedback receiver.
-        </div>
+    <img src="assets/images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control" />
+    <div class="col-lg-9">
+      <div>
+        If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can
+        see the<br />
+        (i) response text,<br />
+        (ii) the identity of the feedback giver, and<br />
+        (iii) the identity of the feedback receiver.
       </div>
     </div>
   </div>
@@ -61,14 +55,12 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Reports and statistics</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
-      <div class="col-lg-9">
-        <div>
-          There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
-          <br /><br />
-          Some statistics for the responses are available too.
-        </div>
+    <img src="assets/images/feature-reportsandstatistics.png" alt="Reports and statistics" />
+    <div class="col-lg-9">
+      <div>
+        There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
+        <br /><br />
+        Some statistics for the responses are available too.
       </div>
     </div>
   </div>
@@ -77,16 +69,14 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Fine-grain access control</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
-      <div class="col-lg-9">
-        <div>
-          You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them
-          different access levels.
-          <br /><br />
-          If required, you can even set which sessions of which section of students are accessible to a particular
-          instructor.
-        </div>
+    <img src="assets/images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control" />
+    <div class="col-lg-9">
+      <div>
+        You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different
+        access levels.
+        <br /><br />
+        If required, you can even set which sessions of which section of students are accessible to a particular
+        instructor.
       </div>
     </div>
   </div>
@@ -95,16 +85,14 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Different question types</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
-      <div class="col-lg-9">
-        <div>
-          Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number
-          of points among options' questions, questions measuring contribution in team projects, and more choices coming
-          soon...
-          <br /><br />
-          You can even generate MCQ options from student names, as illustrated in the above example.
-        </div>
+    <img src="assets/images/feature-differentquestiontypes.png" alt="Different question types" />
+    <div class="col-lg-9">
+      <div>
+        Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number
+        of points among options' questions, questions measuring contribution in team projects, and more choices coming
+        soon...
+        <br /><br />
+        You can even generate MCQ options from student names, as illustrated in the above example.
       </div>
     </div>
   </div>
@@ -113,15 +101,13 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Reuse past questions</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
-      <div class="col-lg-9">
-        <div>
-          Once you have a perfect set of questions configured for a session, you can reuse those questions later,
-          without needing to configure the same questions from scratch again.
-          <br /><br />
-          TEAMMATES also provides some session templates to choose from.
-        </div>
+    <img src="assets/images/feature-reusepastquestions.png" alt="Reuse past questions" />
+    <div class="col-lg-9">
+      <div>
+        Once you have a perfect set of questions configured for a session, you can reuse those questions later, without
+        needing to configure the same questions from scratch again.
+        <br /><br />
+        TEAMMATES also provides some session templates to choose from.
       </div>
     </div>
   </div>
@@ -130,16 +116,14 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">No signup required for students</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
-      <div class="col-lg-9">
-        <div>
-          Students can submit responses and view published responses using the unique links TEAMMATES emails them,
-          without having to log in or sign up.
-          <br /><br />
-          If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in
-          one page and access even more features such as setting up profiles.
-        </div>
+    <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
+    <div class="col-lg-9">
+      <div>
+        Students can submit responses and view published responses using the unique links TEAMMATES emails them, without
+        having to log in or sign up.
+        <br /><br />
+        If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one
+        page and access even more features such as setting up profiles.
       </div>
     </div>
   </div>
@@ -148,14 +132,12 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Downloadable data</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
-      <div class="col-lg-9">
-        <div>
-          You can download the collected responses (and statistics) as spreadsheets.
-          <br /><br />
-          The collected data belongs to you and you may delete your data from TEAMMATES any time.
-        </div>
+    <img src="assets/images/feature-downloadbledata.png" alt="Downloadable data" />
+    <div class="col-lg-9">
+      <div>
+        You can download the collected responses (and statistics) as spreadsheets.
+        <br /><br />
+        The collected data belongs to you and you may delete your data from TEAMMATES any time.
       </div>
     </div>
   </div>
@@ -164,16 +146,14 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Shareable comments</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
-      <div class="col-lg-9">
-        <div>
-          You can add comments about responses collected. You can even share these comments with students/instructors.
-          <br /><br />
-          Fine-grained visibility control is available for comments too. For example, you can give a comment to a
-          student that the receiving student can see while other students in the course can only see the comment text
-          but cannot see the recipient name.
-        </div>
+    <img src="assets/images/feature-sharablecomments.png" alt="Sharable" />
+    <div class="col-lg-9">
+      <div>
+        You can add comments about responses collected. You can even share these comments with students/instructors.
+        <br /><br />
+        Fine-grained visibility control is available for comments too. For example, you can give a comment to a student
+        that the receiving student can see while other students in the course can only see the comment text but cannot
+        see the recipient name.
       </div>
     </div>
   </div>
@@ -182,14 +162,12 @@
 <section class="row mb-5">
   <div class="col-xs-12">
     <h2 class="color-blue">Powerful search</h2>
-    <div class="inner-content">
-      <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
-      <div class="col-lg-9">
-        <div>
-          TEAMMATES has a powerful search feature to locate details about students.
-          <br /><br />
-          Given above is an example of searching for a student whose name you are not very sure of.
-        </div>
+    <img src="assets/images/feature-powerfulsearch.png" alt="Powerful search" />
+    <div class="col-lg-9">
+      <div>
+        TEAMMATES has a powerful search feature to locate details about students.
+        <br /><br />
+        Given above is an example of searching for a student whose name you are not very sure of.
       </div>
     </div>
   </div>
@@ -197,15 +175,13 @@
 
 <section class="row mb-5">
   <div class="col-xs-12">
-    <div class="inner-content">
-      <h2 class="color-blue">Support for big courses</h2>
-      <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
-      <div class="col-lg-9">
-        <div>
-          TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students
-          into sections of no more than 100 students. There is no limit on the number of courses or sessions you could
-          have either.
-        </div>
+    <h2 class="color-blue">Support for big courses</h2>
+    <img src="assets/images/feature-supportforbigcourses.png" alt="Support for big courses" />
+    <div class="col-lg-9">
+      <div>
+        TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into
+        sections of no more than 100 students. There is no limit on the number of courses or sessions you could have
+        either.
       </div>
     </div>
   </div>

--- a/src/web/app/pages-static/features-page/features-page.component.scss
+++ b/src/web/app/pages-static/features-page/features-page.component.scss
@@ -3,17 +3,9 @@ img {
   max-width: 80%;
 }
 
-.inner-content {
-  margin: 0 20px;
-}
-
 @media (width <= 991px) {
   img {
     margin: 0;
     max-width: 100%;
-  }
-
-  .inner-content {
-    margin: 0;
   }
 }


### PR DESCRIPTION
Fixes #14098

**Outline of Solution**

- Removed the unnecessary offset-sm-1 class from the features page layout to eliminate the awkward left padding.
- Updated second-level headings from color-orange to color-blue to maintain visual hierarchy consistency with other help pages.
- Verified the UI changes locally using the frontend development server.

<img width="1192" height="885" alt="image" src="https://github.com/user-attachments/assets/852e724c-ecee-4378-b25f-2f4cbd5e85f7" />
