### PR TITLE
[#14096] Hide redundant warning messages on submission page when grouping by recipient

### DIFF
--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -165,12 +165,8 @@
 >
   <div *tmIsLoading="isFeedbackSessionQuestionsLoading">
     @if (currentSelectedSessionView === allSessionViews.GROUP_RECIPIENTS) {
+      @if (recipientQuestionMap.size > 0) {
       <h1 class="my-3">Grouped Questions</h1>
-      @if (recipientQuestionMap.size === 0) {
-        <div class="card">
-          <h2 class="my-2 mx-2">There are no groupable questions</h2>
-        </div>
-      }
       @for (entry of recipientQuestionMap | keyvalue; track entry) {
         <div class="card px-4">
           <h2 class="my-4">{{ getRecipientName(entry.key) }}</h2>
@@ -214,12 +210,9 @@
           </div>
         </div>
       }
-      <h1 class="my-3">Ungrouped Questions</h1>
-      @if (ungroupableQuestionsSorted.length === 0) {
-        <div class="card">
-          <h2 class="my-2 mx-2">There are no ungroupable questions</h2>
-        </div>
       }
+      @if (ungroupableQuestionsSorted.length > 0) {
+      <h1 class="my-3">Ungrouped Questions</h1>
       @for (
         questionSubmissionForm of questionSubmissionForms;
         track questionSubmissionForm.feedbackQuestionId;
@@ -238,6 +231,7 @@
             [isQuestionCountOne]="isQuestionCountOne"
           ></tm-question-submission-form>
         }
+      }
       }
     }
     @if (currentSelectedSessionView === allSessionViews.DEFAULT) {
@@ -262,7 +256,7 @@
     }
     @if (questionsNeedingSubmission.length === 0) {
       <div class="text-center">
-        <div class="alert alert-info" role="alert">There are no questions for you to answer here!</div>
+        <div class="alert alert-info" role="alert">There are no questions for you to answer.</div>
       </div>
     } @else {
       <div class="d-flex justify-content-center gap-2 flex-wrap">


### PR DESCRIPTION
Fixes #14096

### Changes made
- Wrapped the "Grouped Questions" header and recipient loop in `@if (recipientQuestionMap.size > 0)` so the section hides entirely when there are no groupable questions
- Wrapped the "Ungrouped Questions" header and question loop in `@if (ungroupableQuestionsSorted.length > 0)` so the section hides entirely when there are no ungroupable questions
- Updated empty-state message from "There are no questions for you to answer here!" to "There are no questions for you to answer."
