### PR TITLE
[#13721] Standardize naming of db methods

### DIFF
--- a/src/main/java/teammates/logic/core/AccountRequestsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountRequestsLogic.java
@@ -102,7 +102,7 @@ public final class AccountRequestsLogic {
     public void deleteAccountRequest(UUID id) {
         AccountRequest toDelete = accountRequestDb.getAccountRequest(id);
 
-        accountRequestDb.deleteAccountRequest(toDelete);
+        accountRequestDb.removeAccountRequest(toDelete);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/AccountRequestsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountRequestsLogic.java
@@ -40,7 +40,7 @@ public final class AccountRequestsLogic {
      */
     public AccountRequest createAccountRequest(AccountRequest accountRequest) throws InvalidParametersException {
         validateAccountRequest(accountRequest);
-        return accountRequestDb.createAccountRequest(accountRequest);
+        return accountRequestDb.persistAccountRequest(accountRequest);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -148,7 +148,7 @@ public final class AccountsLogic {
             return;
         }
 
-        accountsDb.deleteAccount(account);
+        accountsDb.removeAccount(account);
     }
 
     /**
@@ -168,7 +168,7 @@ public final class AccountsLogic {
             usersLogic.deleteUser(user);
         }
 
-        accountsDb.deleteAccount(account);
+        accountsDb.removeAccount(account);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -178,7 +178,7 @@ public final class CoursesLogic {
             return;
         }
 
-        coursesDb.deleteCourse(course);
+        coursesDb.removeCourse(course);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -69,7 +69,7 @@ public final class CoursesLogic {
             throw new EntityAlreadyExistsException(String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, course.toString()));
         }
 
-        return coursesDb.createCourse(course);
+        return coursesDb.persistCourse(course);
     }
 
     /**
@@ -245,7 +245,7 @@ public final class CoursesLogic {
 
         validateSection(section);
 
-        return coursesDb.createSection(section);
+        return coursesDb.persistSection(section);
     }
 
     /**
@@ -286,7 +286,7 @@ public final class CoursesLogic {
 
         validateTeam(team);
 
-        return coursesDb.createTeam(team);
+        return coursesDb.persistTeam(team);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/logic/core/DeadlineExtensionsLogic.java
@@ -108,7 +108,7 @@ public final class DeadlineExtensionsLogic {
                     String.format(Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS, deadlineExtension.toString()));
         }
 
-        return deadlineExtensionsDb.createDeadlineExtension(deadlineExtension);
+        return deadlineExtensionsDb.persistDeadlineExtension(deadlineExtension);
     }
 
     /**
@@ -145,7 +145,7 @@ public final class DeadlineExtensionsLogic {
                 feedbackSession.addDeadlineExtension(newDeadlineExtension);
 
                 validateDeadlineExtension(newDeadlineExtension);
-                deadlineExtensionsDb.createDeadlineExtension(newDeadlineExtension);
+                deadlineExtensionsDb.persistDeadlineExtension(newDeadlineExtension);
                 results.add(new UpdateExtensionsResult(user, sessionDeadline, newDeadline, ExtensionUpdateType.CREATED));
             } else if (!existingDeadlineExtension.getEndTime().equals(newDeadline)) {
                 Instant oldDeadline = existingDeadlineExtension.getEndTime();

--- a/src/main/java/teammates/logic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/logic/core/DeadlineExtensionsLogic.java
@@ -179,7 +179,7 @@ public final class DeadlineExtensionsLogic {
             return;
         }
 
-        deadlineExtensionsDb.deleteDeadlineExtension(de);
+        deadlineExtensionsDb.removeDeadlineExtension(de);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -720,7 +720,7 @@ public final class FeedbackQuestionsLogic {
         List<FeedbackQuestion> questionsToShiftQnNumber =
                 getFeedbackQuestionsForSession(questionToDelete.getFeedbackSession());
 
-        fqDb.deleteFeedbackQuestion(questionToDelete);
+        fqDb.removeFeedbackQuestion(questionToDelete);
 
         // Shift question numbers down for all questions after the deleted one
         shiftQuestionNumbersDown(questionNumberToDelete, questionsToShiftQnNumber);

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -93,7 +93,7 @@ public final class FeedbackQuestionsLogic {
             throw new EntityAlreadyExistsException(errorMessage);
         }
 
-        FeedbackQuestion createdQuestion = fqDb.createFeedbackQuestion(feedbackQuestion);
+        FeedbackQuestion createdQuestion = fqDb.persistFeedbackQuestion(feedbackQuestion);
 
         List<FeedbackQuestion> questionsBefore = getFeedbackQuestionsForSession(feedbackQuestion.getFeedbackSession());
         questionsBefore.remove(createdQuestion);

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -343,7 +343,7 @@ public final class FeedbackResponsesLogic {
                 feedbackQuestion.addFeedbackResponse(feedbackResponse);
                 feedbackResponses.add(feedbackResponse);
                 validateFeedbackResponse(feedbackResponse);
-                frDb.createFeedbackResponse(feedbackResponse);
+                frDb.persistFeedbackResponse(feedbackResponse);
             }
         }
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -387,7 +387,7 @@ public final class FeedbackResponsesLogic {
             return;
         }
 
-        frDb.deleteFeedbackResponse(feedbackResponse);
+        frDb.removeFeedbackResponse(feedbackResponse);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionLogsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionLogsLogic.java
@@ -52,7 +52,7 @@ public final class FeedbackSessionLogsLogic {
 
         validateFeedbackSessionLog(fsLog);
 
-        return fslDb.createFeedbackSessionLog(fsLog);
+        return fslDb.persistFeedbackSessionLog(fsLog);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -259,7 +259,7 @@ public final class FeedbackSessionsLogic {
                     String.format(Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS, session.toString()));
         }
 
-        return fsDb.createFeedbackSession(session);
+        return fsDb.persistFeedbackSession(session);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -397,7 +397,7 @@ public final class FeedbackSessionsLogic {
             return;
         }
 
-        fsDb.deleteFeedbackSession(feedbackSession);
+        fsDb.removeFeedbackSession(feedbackSession);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -116,7 +116,7 @@ public final class NotificationsLogic {
         if (notification == null) {
             return;
         }
-        notificationsDb.deleteNotification(notification);
+        notificationsDb.removeNotification(notification);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/NotificationsLogic.java
+++ b/src/main/java/teammates/logic/core/NotificationsLogic.java
@@ -63,7 +63,7 @@ public final class NotificationsLogic {
                     String.format(Const.ERROR_CREATE_ENTITY_ALREADY_EXISTS, notification.toString()));
         }
 
-        return notificationsDb.createNotification(notification);
+        return notificationsDb.persistNotification(notification);
     }
 
     /**
@@ -158,7 +158,7 @@ public final class NotificationsLogic {
         account.addReadNotification(readNotification);
         notification.addReadNotification(readNotification);
 
-        return notificationsDb.createReadNotification(readNotification);
+        return notificationsDb.persistReadNotification(readNotification);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
@@ -91,7 +91,7 @@ public final class ResponseInstructorCommentsLogic {
         if (frc == null) {
             return;
         }
-        frcDb.deleteResponseInstructorComment(frc);
+        frcDb.removeResponseInstructorComment(frc);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
@@ -78,7 +78,7 @@ public final class ResponseInstructorCommentsLogic {
 
         validateResponseInstructorComment(frc);
 
-        return frcDb.createResponseInstructorComment(frc);
+        return frcDb.persistResponseInstructorComment(frc);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/UsageStatisticsLogic.java
+++ b/src/main/java/teammates/logic/core/UsageStatisticsLogic.java
@@ -66,7 +66,7 @@ public final class UsageStatisticsLogic {
      * @return the created usage statistics object
      */
     public UsageStatistics createUsageStatistics(UsageStatistics usageStatistics) {
-        return usageStatisticsDb.createUsageStatistics(usageStatistics);
+        return usageStatisticsDb.persistUsageStatistics(usageStatistics);
     }
 
 }

--- a/src/main/java/teammates/logic/core/UsersLogic.java
+++ b/src/main/java/teammates/logic/core/UsersLogic.java
@@ -297,7 +297,7 @@ public final class UsersLogic {
             return;
         }
 
-        usersDb.deleteUser(user);
+        usersDb.removeUser(user);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/UsersLogic.java
+++ b/src/main/java/teammates/logic/core/UsersLogic.java
@@ -122,7 +122,7 @@ public final class UsersLogic {
             throw new EntityAlreadyExistsException("Instructor already exists.");
         }
 
-        return usersDb.createInstructor(instructor);
+        return usersDb.persistInstructor(instructor);
     }
 
     /**
@@ -196,7 +196,7 @@ public final class UsersLogic {
 
         team.addUser(student);
         validateUser(student);
-        return usersDb.createStudent(student);
+        return usersDb.persistStudent(student);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/AccountRequestsDb.java
+++ b/src/main/java/teammates/storage/api/AccountRequestsDb.java
@@ -117,9 +117,9 @@ public final class AccountRequestsDb {
     }
 
     /**
-     * Deletes an AccountRequest.
+     * Removes an AccountRequest.
      */
-    public void deleteAccountRequest(AccountRequest accountRequest) {
+    public void removeAccountRequest(AccountRequest accountRequest) {
         if (accountRequest != null) {
             HibernateUtil.remove(accountRequest);
         }

--- a/src/main/java/teammates/storage/api/AccountRequestsDb.java
+++ b/src/main/java/teammates/storage/api/AccountRequestsDb.java
@@ -47,8 +47,6 @@ public final class AccountRequestsDb {
      * Creates an AccountRequest in the database.
      */
     public AccountRequest createAccountRequest(AccountRequest accountRequest) {
-        assert accountRequest != null;
-
         HibernateUtil.persist(accountRequest);
         return accountRequest;
     }
@@ -57,7 +55,6 @@ public final class AccountRequestsDb {
      * Get AccountRequest by {@code id} from the database.
      */
     public AccountRequest getAccountRequest(UUID id) {
-        assert id != null;
         return HibernateUtil.get(AccountRequest.class, id);
     }
 

--- a/src/main/java/teammates/storage/api/AccountRequestsDb.java
+++ b/src/main/java/teammates/storage/api/AccountRequestsDb.java
@@ -44,9 +44,9 @@ public final class AccountRequestsDb {
     }
 
     /**
-     * Creates an AccountRequest in the database.
+     * Persists an AccountRequest in the database.
      */
-    public AccountRequest createAccountRequest(AccountRequest accountRequest) {
+    public AccountRequest persistAccountRequest(AccountRequest accountRequest) {
         HibernateUtil.persist(accountRequest);
         return accountRequest;
     }

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -63,9 +63,9 @@ public final class AccountsDb {
     }
 
     /**
-     * Deletes an Account.
+     * Removes an Account.
      */
-    public void deleteAccount(Account account) {
+    public void removeAccount(Account account) {
         HibernateUtil.remove(account);
     }
 

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -31,8 +31,6 @@ public final class AccountsDb {
      * Returns an Account with the {@code id} or null if it does not exist.
      */
     public Account getAccount(UUID id) {
-        assert id != null;
-
         return HibernateUtil.get(Account.class, id);
     }
 
@@ -40,8 +38,6 @@ public final class AccountsDb {
      * Returns an Account with the {@code googleId} or null if it does not exist.
      */
     public Account getAccountByGoogleId(String googleId) {
-        assert googleId != null;
-
         return HibernateUtil.getBySimpleNaturalId(Account.class, googleId);
     }
 
@@ -49,8 +45,6 @@ public final class AccountsDb {
      * Gets accounts based on email.
      */
     public List<Account> getAccountsByEmail(String email) {
-        assert email != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Account> cr = cb.createQuery(Account.class);
         Root<Account> accountRoot = cr.from(Account.class);
@@ -64,8 +58,6 @@ public final class AccountsDb {
      * Persists an Account.
      */
     public Account persistAccount(Account account) {
-        assert account != null;
-
         HibernateUtil.persist(account);
         return account;
     }

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -38,9 +38,9 @@ public final class CoursesDb {
     }
 
     /**
-     * Creates a course.
+     * Persists a course.
      */
-    public Course createCourse(Course course) {
+    public Course persistCourse(Course course) {
         HibernateUtil.persist(course);
         return course;
     }
@@ -53,9 +53,9 @@ public final class CoursesDb {
     }
 
     /**
-     * Creates a section.
+     * Persists a section.
      */
-    public Section createSection(Section section) {
+    public Section persistSection(Section section) {
         HibernateUtil.persist(section);
         return section;
     }
@@ -110,9 +110,9 @@ public final class CoursesDb {
     }
 
     /**
-     * Creates a team.
+     * Persists a team.
      */
-    public Team createTeam(Team team) {
+    public Team persistTeam(Team team) {
         HibernateUtil.persist(team);
         return team;
     }

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -46,9 +46,9 @@ public final class CoursesDb {
     }
 
     /**
-     * Deletes a course.
+     * Removes a course.
      */
-    public void deleteCourse(Course course) {
+    public void removeCourse(Course course) {
         HibernateUtil.remove(course);
     }
 

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -34,8 +34,6 @@ public final class CoursesDb {
      * Returns a course with the {@code courseID} or null if it does not exist.
      */
     public Course getCourse(String courseId) {
-        assert courseId != null;
-
         return HibernateUtil.get(Course.class, courseId);
     }
 
@@ -43,8 +41,6 @@ public final class CoursesDb {
      * Creates a course.
      */
     public Course createCourse(Course course) {
-        assert course != null;
-
         HibernateUtil.persist(course);
         return course;
     }
@@ -60,8 +56,6 @@ public final class CoursesDb {
      * Creates a section.
      */
     public Section createSection(Section section) {
-        assert section != null;
-
         HibernateUtil.persist(section);
         return section;
     }
@@ -70,9 +64,6 @@ public final class CoursesDb {
      * Get section by name.
      */
     public Section getSectionByName(String courseId, String sectionName) {
-        assert courseId != null;
-        assert sectionName != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Section> cr = cb.createQuery(Section.class);
         Root<Section> sectionRoot = cr.from(Section.class);
@@ -89,9 +80,6 @@ public final class CoursesDb {
      * Get section by {@code courseId} and {@code teamName}.
      */
     public Section getSectionByCourseIdAndTeam(String courseId, String teamName) {
-        assert courseId != null;
-        assert teamName != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Section> cr = cb.createQuery(Section.class);
         Root<Section> sectionRoot = cr.from(Section.class);
@@ -109,8 +97,6 @@ public final class CoursesDb {
      * Get teams by {@code course}.
      */
     public List<Team> getTeamsForCourse(String courseId) {
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Team> cr = cb.createQuery(Team.class);
         Root<Team> teamRoot = cr.from(Team.class);
@@ -127,8 +113,6 @@ public final class CoursesDb {
      * Creates a team.
      */
     public Team createTeam(Team team) {
-        assert team != null;
-
         HibernateUtil.persist(team);
         return team;
     }
@@ -137,9 +121,6 @@ public final class CoursesDb {
      * Gets a team by name.
      */
     public Team getTeamByName(UUID sectionId, String teamName) {
-        assert sectionId != null;
-        assert teamName != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Team> cr = cb.createQuery(Team.class);
         Root<Team> teamRoot = cr.from(Team.class);

--- a/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
@@ -35,9 +35,9 @@ public final class DeadlineExtensionsDb {
     }
 
     /**
-     * Creates a deadline extension.
+     * Persists a deadline extension.
      */
-    public DeadlineExtension createDeadlineExtension(DeadlineExtension de) {
+    public DeadlineExtension persistDeadlineExtension(DeadlineExtension de) {
         HibernateUtil.persist(de);
         return de;
     }

--- a/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
@@ -38,8 +38,6 @@ public final class DeadlineExtensionsDb {
      * Creates a deadline extension.
      */
     public DeadlineExtension createDeadlineExtension(DeadlineExtension de) {
-        assert de != null;
-
         HibernateUtil.persist(de);
         return de;
     }
@@ -48,8 +46,6 @@ public final class DeadlineExtensionsDb {
      * Gets a deadline extension by {@code id}.
      */
     public DeadlineExtension getDeadlineExtension(UUID id) {
-        assert id != null;
-
         return HibernateUtil.get(DeadlineExtension.class, id);
     }
 
@@ -57,9 +53,6 @@ public final class DeadlineExtensionsDb {
      * Get DeadlineExtension by {@code userId} and {@code feedbackSessionId}.
      */
     public DeadlineExtension getDeadlineExtension(UUID userId, UUID feedbackSessionId) {
-        assert userId != null;
-        assert feedbackSessionId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<DeadlineExtension> cr = cb.createQuery(DeadlineExtension.class);
         Root<DeadlineExtension> root = cr.from(DeadlineExtension.class);
@@ -109,9 +102,6 @@ public final class DeadlineExtensionsDb {
      * Otherwise, return null.
      */
     public DeadlineExtension getDeadlineExtensionForUser(UUID feedbackSessionId, UUID userId) {
-        assert feedbackSessionId != null;
-        assert userId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<DeadlineExtension> cr = cb.createQuery(DeadlineExtension.class);
         Root<DeadlineExtension> deadlineExtensionRoot = cr.from(DeadlineExtension.class);

--- a/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
+++ b/src/main/java/teammates/storage/api/DeadlineExtensionsDb.java
@@ -68,9 +68,9 @@ public final class DeadlineExtensionsDb {
     }
 
     /**
-     * Deletes a deadline extension.
+     * Removes a deadline extension.
      */
-    public void deleteDeadlineExtension(DeadlineExtension de) {
+    public void removeDeadlineExtension(DeadlineExtension de) {
         HibernateUtil.remove(de);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -37,8 +37,6 @@ public final class FeedbackQuestionsDb {
      * @return the created question
      */
     public FeedbackQuestion createFeedbackQuestion(FeedbackQuestion feedbackQuestion) {
-        assert feedbackQuestion != null;
-
         HibernateUtil.persist(feedbackQuestion);
         return feedbackQuestion;
     }
@@ -49,8 +47,6 @@ public final class FeedbackQuestionsDb {
      * @return null if not found
      */
     public FeedbackQuestion getFeedbackQuestion(UUID fqId) {
-        assert fqId != null;
-
         return HibernateUtil.get(FeedbackQuestion.class, fqId);
     }
 
@@ -73,9 +69,6 @@ public final class FeedbackQuestionsDb {
      */
     public List<FeedbackQuestion> getFeedbackQuestionsForGiverType(
             FeedbackSession feedbackSession, QuestionGiverType giverType) {
-        assert feedbackSession != null;
-        assert giverType != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackQuestion> cq = cb.createQuery(FeedbackQuestion.class);
         Root<FeedbackQuestion> root = cq.from(FeedbackQuestion.class);

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -79,9 +79,9 @@ public final class FeedbackQuestionsDb {
     }
 
     /**
-     * Deletes a feedback question.
+     * Removes a feedback question.
      */
-    public void deleteFeedbackQuestion(FeedbackQuestion fq) {
+    public void removeFeedbackQuestion(FeedbackQuestion fq) {
         HibernateUtil.remove(fq);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -32,11 +32,9 @@ public final class FeedbackQuestionsDb {
     }
 
     /**
-     * Creates a new feedback question.
-     *
-     * @return the created question
+     * Persists a new feedback question.
      */
-    public FeedbackQuestion createFeedbackQuestion(FeedbackQuestion feedbackQuestion) {
+    public FeedbackQuestion persistFeedbackQuestion(FeedbackQuestion feedbackQuestion) {
         HibernateUtil.persist(feedbackQuestion);
         return feedbackQuestion;
     }

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -35,8 +35,6 @@ public final class FeedbackResponsesDb {
      * Gets a feedbackResponse or null if it does not exist.
      */
     public FeedbackResponse getFeedbackResponse(UUID frId) {
-        assert frId != null;
-
         return HibernateUtil.get(FeedbackResponse.class, frId);
     }
 
@@ -44,8 +42,6 @@ public final class FeedbackResponsesDb {
      * Creates a feedbackResponse.
      */
     public FeedbackResponse createFeedbackResponse(FeedbackResponse feedbackResponse) {
-        assert feedbackResponse != null;
-
         HibernateUtil.persist(feedbackResponse);
         return feedbackResponse;
     }
@@ -165,9 +161,6 @@ public final class FeedbackResponsesDb {
      */
     public List<FeedbackResponse> getFeedbackResponsesForSession(
             FeedbackSession feedbackSession, String courseId) {
-        assert feedbackSession != null;
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackResponse> cq = cb.createQuery(FeedbackResponse.class);
         Root<FeedbackResponse> root = cq.from(FeedbackResponse.class);

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -39,9 +39,9 @@ public final class FeedbackResponsesDb {
     }
 
     /**
-     * Creates a feedbackResponse.
+     * Persists a feedbackResponse.
      */
-    public FeedbackResponse createFeedbackResponse(FeedbackResponse feedbackResponse) {
+    public FeedbackResponse persistFeedbackResponse(FeedbackResponse feedbackResponse) {
         HibernateUtil.persist(feedbackResponse);
         return feedbackResponse;
     }

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -47,9 +47,9 @@ public final class FeedbackResponsesDb {
     }
 
     /**
-     * Deletes a feedbackResponse.
+     * Removes a feedbackResponse.
      */
-    public void deleteFeedbackResponse(FeedbackResponse feedbackResponse) {
+    public void removeFeedbackResponse(FeedbackResponse feedbackResponse) {
         HibernateUtil.remove(feedbackResponse);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackSessionLogsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionLogsDb.java
@@ -77,9 +77,9 @@ public final class FeedbackSessionLogsDb {
     }
 
     /**
-     * Creates feedback session logs.
+     * Persists a feedback session log.
      */
-    public FeedbackSessionLog createFeedbackSessionLog(FeedbackSessionLog log) {
+    public FeedbackSessionLog persistFeedbackSessionLog(FeedbackSessionLog log) {
         HibernateUtil.persist(log);
         return log;
     }

--- a/src/main/java/teammates/storage/api/FeedbackSessionLogsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionLogsDb.java
@@ -51,11 +51,6 @@ public final class FeedbackSessionLogsDb {
      */
     public List<FeedbackSessionLog> getOrderedFeedbackSessionLogs(String courseId, UUID userId,
             UUID feedbackSessionId, Instant startTime, Instant endTime) {
-
-        assert courseId != null;
-        assert startTime != null;
-        assert endTime != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSessionLog> cr = cb.createQuery(FeedbackSessionLog.class);
         Root<FeedbackSessionLog> root = cr.from(FeedbackSessionLog.class);
@@ -93,8 +88,6 @@ public final class FeedbackSessionLogsDb {
      * Deletes feedback session logs older than the given cutoff time.
      */
     public int deleteFeedbackSessionLogsOlderThan(Instant cutoffTime) {
-        assert cutoffTime != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaDelete<FeedbackSessionLog> cd = cb.createCriteriaDelete(FeedbackSessionLog.class);
         Root<FeedbackSessionLog> root = cd.from(FeedbackSessionLog.class);

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -139,9 +139,9 @@ public final class FeedbackSessionsDb {
     }
 
     /**
-     * Creates a feedback session.
+     * Persists a feedback session.
      */
-    public FeedbackSession createFeedbackSession(FeedbackSession session) {
+    public FeedbackSession persistFeedbackSession(FeedbackSession session) {
         HibernateUtil.persist(session);
         return session;
     }

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -147,9 +147,9 @@ public final class FeedbackSessionsDb {
     }
 
     /**
-     * Deletes a feedback session.
+     * Removes a feedback session.
      */
-    public void deleteFeedbackSession(FeedbackSession feedbackSession) {
+    public void removeFeedbackSession(FeedbackSession feedbackSession) {
         HibernateUtil.remove(feedbackSession);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -68,9 +68,6 @@ public final class FeedbackSessionsDb {
      * @return null if not found or not soft-deleted.
      */
     public FeedbackSession getSoftDeletedFeedbackSession(String feedbackSessionName, String courseId) {
-        assert feedbackSessionName != null;
-        assert courseId != null;
-
         FeedbackSession feedbackSession = getFeedbackSession(feedbackSessionName, courseId);
 
         if (feedbackSession != null && feedbackSession.getDeletedAt() == null) {
@@ -131,8 +128,6 @@ public final class FeedbackSessionsDb {
      * Gets all and only the feedback sessions ongoing within a range of time.
      */
     public List<FeedbackSession> getOngoingSessions(Instant rangeStart, Instant rangeEnd) {
-        assert rangeStart != null;
-        assert rangeEnd != null;
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);
@@ -147,8 +142,6 @@ public final class FeedbackSessionsDb {
      * Creates a feedback session.
      */
     public FeedbackSession createFeedbackSession(FeedbackSession session) {
-        assert session != null;
-
         HibernateUtil.persist(session);
         return session;
     }
@@ -165,8 +158,6 @@ public final class FeedbackSessionsDb {
      * Includes sessions from soft-deleted courses.
      */
     public List<FeedbackSession> getFeedbackSessionsForCourse(String courseId) {
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cq = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cq.from(FeedbackSession.class);
@@ -183,9 +174,6 @@ public final class FeedbackSessionsDb {
      * Gets feedback sessions for a given {@code courseId} that start after {@code after}.
      */
     public List<FeedbackSession> getFeedbackSessionsForCourseStartingAfter(String courseId, Instant after) {
-        assert courseId != null;
-        assert after != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<FeedbackSession> cr = cb.createQuery(FeedbackSession.class);
         Root<FeedbackSession> root = cr.from(FeedbackSession.class);

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -38,8 +38,6 @@ public final class NotificationsDb {
      * * Notification fields are valid.
      */
     public Notification createNotification(Notification notification) {
-        assert notification != null;
-
         HibernateUtil.persist(notification);
         return notification;
     }
@@ -48,8 +46,6 @@ public final class NotificationsDb {
      * Gets a notification by its unique ID.
      */
     public Notification getNotification(UUID notificationId) {
-        assert notificationId != null;
-
         return HibernateUtil.get(Notification.class, notificationId);
     }
 

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -32,12 +32,9 @@ public final class NotificationsDb {
     }
 
     /**
-     * Creates a notification.
-     *
-     * <p>Preconditions:</p>
-     * * Notification fields are valid.
+     * Persists a notification.
      */
-    public Notification createNotification(Notification notification) {
+    public Notification persistNotification(Notification notification) {
         HibernateUtil.persist(notification);
         return notification;
     }
@@ -90,9 +87,9 @@ public final class NotificationsDb {
     }
 
     /**
-     * Creates a read notification.
+     * Persists a read notification.
      */
-    public ReadNotification createReadNotification(ReadNotification readNotification) {
+    public ReadNotification persistReadNotification(ReadNotification readNotification) {
         HibernateUtil.persist(readNotification);
         return readNotification;
     }

--- a/src/main/java/teammates/storage/api/NotificationsDb.java
+++ b/src/main/java/teammates/storage/api/NotificationsDb.java
@@ -47,9 +47,9 @@ public final class NotificationsDb {
     }
 
     /**
-     * Deletes a notification.
+     * Removes a notification.
      */
-    public void deleteNotification(Notification notification) {
+    public void removeNotification(Notification notification) {
         HibernateUtil.remove(notification);
     }
 

--- a/src/main/java/teammates/storage/api/ResponseInstructorCommentsDb.java
+++ b/src/main/java/teammates/storage/api/ResponseInstructorCommentsDb.java
@@ -31,8 +31,6 @@ public final class ResponseInstructorCommentsDb {
     * Gets a responseInstructorComment or null if it does not exist.
      */
     public ResponseInstructorComment getResponseInstructorComment(UUID frId) {
-        assert frId != null;
-
         return HibernateUtil.get(ResponseInstructorComment.class, frId);
     }
 
@@ -40,8 +38,6 @@ public final class ResponseInstructorCommentsDb {
     * Creates a responseInstructorComment.
      */
     public ResponseInstructorComment createResponseInstructorComment(ResponseInstructorComment responseInstructorComment) {
-        assert responseInstructorComment != null;
-
         HibernateUtil.persist(responseInstructorComment);
         return responseInstructorComment;
     }
@@ -57,8 +53,6 @@ public final class ResponseInstructorCommentsDb {
      * Gets all comments for the given feedback response IDs.
      */
     public List<ResponseInstructorComment> getResponseInstructorCommentsForResponses(List<UUID> feedbackResponseIds) {
-        assert feedbackResponseIds != null;
-
         if (feedbackResponseIds.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/teammates/storage/api/ResponseInstructorCommentsDb.java
+++ b/src/main/java/teammates/storage/api/ResponseInstructorCommentsDb.java
@@ -35,9 +35,9 @@ public final class ResponseInstructorCommentsDb {
     }
 
     /**
-    * Creates a responseInstructorComment.
+    * Persists a responseInstructorComment.
      */
-    public ResponseInstructorComment createResponseInstructorComment(ResponseInstructorComment responseInstructorComment) {
+    public ResponseInstructorComment persistResponseInstructorComment(ResponseInstructorComment responseInstructorComment) {
         HibernateUtil.persist(responseInstructorComment);
         return responseInstructorComment;
     }

--- a/src/main/java/teammates/storage/api/ResponseInstructorCommentsDb.java
+++ b/src/main/java/teammates/storage/api/ResponseInstructorCommentsDb.java
@@ -43,9 +43,9 @@ public final class ResponseInstructorCommentsDb {
     }
 
     /**
-    * Deletes a responseInstructorComment.
+    * Removes a responseInstructorComment.
      */
-    public void deleteResponseInstructorComment(ResponseInstructorComment frc) {
+    public void removeResponseInstructorComment(ResponseInstructorComment frc) {
         HibernateUtil.remove(frc);
     }
 

--- a/src/main/java/teammates/storage/api/UsageStatisticsDb.java
+++ b/src/main/java/teammates/storage/api/UsageStatisticsDb.java
@@ -46,8 +46,6 @@ public final class UsageStatisticsDb {
      * Creates a usage statistics object.
      */
     public UsageStatistics createUsageStatistics(UsageStatistics usageStatistics) {
-        assert usageStatistics != null;
-
         HibernateUtil.persist(usageStatistics);
 
         return usageStatistics;

--- a/src/main/java/teammates/storage/api/UsageStatisticsDb.java
+++ b/src/main/java/teammates/storage/api/UsageStatisticsDb.java
@@ -43,9 +43,9 @@ public final class UsageStatisticsDb {
     }
 
     /**
-     * Creates a usage statistics object.
+     * Persists a usage statistics object.
      */
-    public UsageStatistics createUsageStatistics(UsageStatistics usageStatistics) {
+    public UsageStatistics persistUsageStatistics(UsageStatistics usageStatistics) {
         HibernateUtil.persist(usageStatistics);
 
         return usageStatistics;

--- a/src/main/java/teammates/storage/api/UsersDb.java
+++ b/src/main/java/teammates/storage/api/UsersDb.java
@@ -359,9 +359,9 @@ public final class UsersDb {
     }
 
     /**
-     * Deletes a user.
+     * Removes a user.
      */
-    public <T extends User> void deleteUser(T user) {
+    public <T extends User> void removeUser(T user) {
         HibernateUtil.remove(user);
     }
 

--- a/src/main/java/teammates/storage/api/UsersDb.java
+++ b/src/main/java/teammates/storage/api/UsersDb.java
@@ -78,8 +78,6 @@ public final class UsersDb {
      * Creates an instructor.
      */
     public Instructor createInstructor(Instructor instructor) {
-        assert instructor != null;
-
         HibernateUtil.persist(instructor);
         return instructor;
     }
@@ -88,8 +86,6 @@ public final class UsersDb {
      * Creates a student.
      */
     public Student createStudent(Student student) {
-        assert student != null;
-
         HibernateUtil.persist(student);
         return student;
     }
@@ -98,8 +94,6 @@ public final class UsersDb {
      * Gets an instructor by its {@code id}.
      */
     public Instructor getInstructor(UUID id) {
-        assert id != null;
-
         return HibernateUtil.get(Instructor.class, id);
     }
 
@@ -138,8 +132,6 @@ public final class UsersDb {
      * Gets a student by its {@code id}.
      */
     public Student getStudent(UUID id) {
-        assert id != null;
-
         return HibernateUtil.get(Student.class, id);
     }
 
@@ -377,8 +369,6 @@ public final class UsersDb {
      * Deletes all students in the specified {@code courseId}.
      */
     public void deleteStudentsInCourse(String courseId) {
-        assert courseId != null && !courseId.isEmpty();
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaDelete<Student> cd = cb.createCriteriaDelete(Student.class);
         Root<Student> root = cd.from(Student.class);
@@ -392,8 +382,6 @@ public final class UsersDb {
      * Gets the list of instructors for the specified {@code courseId}.
      */
     public List<Instructor> getInstructorsForCourse(String courseId) {
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Instructor> cr = cb.createQuery(Instructor.class);
         Root<Instructor> root = cr.from(Instructor.class);
@@ -407,8 +395,6 @@ public final class UsersDb {
      * Gets the list of students for the specified {@code courseId}.
      */
     public List<Student> getStudentsForCourse(String courseId) {
-        assert courseId != null && !courseId.isEmpty();
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Student> cr = cb.createQuery(Student.class);
         Root<Student> root = cr.from(Student.class);
@@ -422,8 +408,6 @@ public final class UsersDb {
      * Gets the instructor with the specified {@code userEmail}.
      */
     public Instructor getInstructorForEmail(String courseId, String userEmail) {
-        assert courseId != null;
-        assert userEmail != null;
         String normalizedUserEmail = normalizeEmail(userEmail);
 
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
@@ -442,9 +426,6 @@ public final class UsersDb {
      * Gets instructors with the specified {@code userEmail}.
      */
     public List<Instructor> getInstructorsForEmails(String courseId, List<String> userEmails) {
-        assert courseId != null;
-        assert userEmails != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Instructor> cr = cb.createQuery(Instructor.class);
         Root<Instructor> instructorRoot = cr.from(Instructor.class);
@@ -466,8 +447,6 @@ public final class UsersDb {
      * Gets a non-soft-deleted instructor with the specified {@code email} and {@code institute}.
      */
     public Instructor getInstructorByEmailAndInstitute(String email, String institute) {
-        assert email != null;
-        assert institute != null;
         String normalizedEmail = normalizeEmail(email);
 
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
@@ -488,8 +467,6 @@ public final class UsersDb {
      * Gets the student with the specified {@code userEmail}.
      */
     public Student getStudentForEmail(String courseId, String userEmail) {
-        assert courseId != null;
-        assert userEmail != null;
         String normalizedUserEmail = normalizeEmail(userEmail);
 
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
@@ -508,9 +485,6 @@ public final class UsersDb {
      * Gets students with the specified {@code userEmail}.
      */
     public List<Student> getStudentsForEmails(String courseId, List<String> userEmails) {
-        assert courseId != null;
-        assert userEmails != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Student> cr = cb.createQuery(Student.class);
         Root<Student> studentRoot = cr.from(Student.class);
@@ -532,7 +506,6 @@ public final class UsersDb {
      * Gets list of students by email.
      */
     public List<Student> getAllStudentsForEmail(String email) {
-        assert email != null;
         String normalizedEmail = normalizeEmail(email);
 
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
@@ -553,8 +526,6 @@ public final class UsersDb {
      * Gets all instructors associated with a googleId.
      */
     public List<Instructor> getInstructorsForGoogleId(String googleId) {
-        assert googleId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Instructor> cr = cb.createQuery(Instructor.class);
         Root<Instructor> instructorRoot = cr.from(Instructor.class);
@@ -569,9 +540,6 @@ public final class UsersDb {
      * Gets all students of a section of a course.
      */
     public List<Student> getStudentsForSection(String sectionName, String courseId) {
-        assert sectionName != null;
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Student> cr = cb.createQuery(Student.class);
         Root<Student> studentRoot = cr.from(Student.class);
@@ -591,9 +559,6 @@ public final class UsersDb {
      * Gets all students of a team of a course.
      */
     public List<Student> getStudentsForTeam(String teamName, String courseId) {
-        assert teamName != null;
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Student> cr = cb.createQuery(Student.class);
         Root<Student> studentRoot = cr.from(Student.class);
@@ -612,9 +577,6 @@ public final class UsersDb {
      * Gets count of students of a team of a course.
      */
     public long getStudentCountForTeam(String teamName, String courseId) {
-        assert teamName != null;
-        assert courseId != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Long> cr = cb.createQuery(Long.class);
         Root<Student> studentRoot = cr.from(Student.class);
@@ -633,8 +595,6 @@ public final class UsersDb {
      * Gets the section with the specified {@code sectionName} and {@code courseId}.
      */
     public Section getSection(String courseId, String sectionName) {
-        assert sectionName != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Section> cr = cb.createQuery(Section.class);
         Root<Section> sectionRoot = cr.from(Section.class);
@@ -659,9 +619,6 @@ public final class UsersDb {
      * Gets a team by its {@code section} and {@code teamName}.
      */
     public Team getTeam(Section section, String teamName) {
-        assert teamName != null;
-        assert section != null;
-
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Team> cr = cb.createQuery(Team.class);
         Root<Team> teamRoot = cr.from(Team.class);

--- a/src/main/java/teammates/storage/api/UsersDb.java
+++ b/src/main/java/teammates/storage/api/UsersDb.java
@@ -75,17 +75,17 @@ public final class UsersDb {
     }
 
     /**
-     * Creates an instructor.
+     * Persists an instructor.
      */
-    public Instructor createInstructor(Instructor instructor) {
+    public Instructor persistInstructor(Instructor instructor) {
         HibernateUtil.persist(instructor);
         return instructor;
     }
 
     /**
-     * Creates a student.
+     * Persists a student.
      */
-    public Student createStudent(Student student) {
+    public Student persistStudent(Student student) {
         HibernateUtil.persist(student);
         return student;
     }

--- a/src/test/java/teammates/logic/core/AccountRequestsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountRequestsLogicTest.java
@@ -95,7 +95,7 @@ public class AccountRequestsLogicTest extends BaseTestCase {
         when(accountRequestsDb.getAccountRequest(ar.getId())).thenReturn(ar);
         accountRequestsLogic.deleteAccountRequest(ar.getId());
 
-        verify(accountRequestsDb, times(1)).deleteAccountRequest(any(AccountRequest.class));
+        verify(accountRequestsDb, times(1)).removeAccountRequest(any(AccountRequest.class));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class AccountRequestsLogicTest extends BaseTestCase {
         UUID nonexistentUuid = UUID.fromString("00000000-0000-4000-8000-000000000100");
         accountRequestsLogic.deleteAccountRequest(nonexistentUuid);
 
-        verify(accountRequestsDb, times(1)).deleteAccountRequest(nullable(AccountRequest.class));
+        verify(accountRequestsDb, times(1)).removeAccountRequest(nullable(AccountRequest.class));
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/AccountRequestsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountRequestsLogicTest.java
@@ -39,26 +39,26 @@ public class AccountRequestsLogicTest extends BaseTestCase {
     @Test
     public void testCreateAccountRequest_typicalRequest_success() throws Exception {
         AccountRequest accountRequest = getTypicalAccountRequest();
-        when(accountRequestsDb.createAccountRequest(accountRequest)).thenReturn(accountRequest);
+        when(accountRequestsDb.persistAccountRequest(accountRequest)).thenReturn(accountRequest);
         AccountRequest createdAccountRequest = accountRequestsLogic.createAccountRequest(accountRequest);
 
         assertEquals(accountRequest, createdAccountRequest);
-        verify(accountRequestsDb, times(1)).createAccountRequest(accountRequest);
+        verify(accountRequestsDb, times(1)).persistAccountRequest(accountRequest);
     }
 
     @Test
     public void testCreateAccountRequest_requestAlreadyExists_success() throws Exception {
         AccountRequest accountRequest1 = getTypicalAccountRequest();
         AccountRequest accountRequest2 = getTypicalAccountRequest();
-        when(accountRequestsDb.createAccountRequest(accountRequest1))
+        when(accountRequestsDb.persistAccountRequest(accountRequest1))
                 .thenReturn(accountRequest1);
-        when(accountRequestsDb.createAccountRequest(accountRequest2))
+        when(accountRequestsDb.persistAccountRequest(accountRequest2))
                         .thenReturn(accountRequest2);
 
         accountRequestsLogic.createAccountRequest(accountRequest1);
         accountRequestsLogic.createAccountRequest(accountRequest2);
-        verify(accountRequestsDb, times(1)).createAccountRequest(accountRequest1);
-        verify(accountRequestsDb, times(1)).createAccountRequest(accountRequest2);
+        verify(accountRequestsDb, times(1)).persistAccountRequest(accountRequest1);
+        verify(accountRequestsDb, times(1)).persistAccountRequest(accountRequest2);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class AccountRequestsLogicTest extends BaseTestCase {
         assertThrows(InvalidParametersException.class, () -> {
             accountRequestsLogic.createAccountRequest(invalidEmailAccountRequest);
         });
-        verify(accountRequestsDb, never()).createAccountRequest(invalidEmailAccountRequest);
+        verify(accountRequestsDb, never()).persistAccountRequest(invalidEmailAccountRequest);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicTest.java
@@ -47,7 +47,7 @@ public class AccountsLogicTest extends BaseTestCase {
 
         accountsLogic.deleteAccount(googleId);
 
-        verify(accountsDb, times(1)).deleteAccount(account);
+        verify(accountsDb, times(1)).removeAccount(account);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class AccountsLogicTest extends BaseTestCase {
         for (User user : users) {
             verify(usersLogic, times(1)).deleteUser(user);
         }
-        verify(accountsDb, times(1)).deleteAccount(account);
+        verify(accountsDb, times(1)).removeAccount(account);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/logic/core/CoursesLogicTest.java
@@ -112,12 +112,12 @@ public class CoursesLogicTest extends BaseTestCase {
             throws EntityAlreadyExistsException, InvalidParametersException {
         Course course = getTypicalCourse();
 
-        when(coursesDb.createCourse(any(Course.class))).thenReturn(course);
+        when(coursesDb.persistCourse(any(Course.class))).thenReturn(course);
 
         Course createdCourse = coursesLogic.createCourse(
                 course.getId(), course.getName(), course.getTimeZone(), course.getInstitute());
 
-        verify(coursesDb, times(1)).createCourse(argThat(courseToCreate ->
+        verify(coursesDb, times(1)).persistCourse(argThat(courseToCreate ->
                 courseToCreate.getId().equals(course.getId())
                         && courseToCreate.getName().equals(course.getName())
                         && courseToCreate.getTimeZone().equals(course.getTimeZone())
@@ -136,7 +136,7 @@ public class CoursesLogicTest extends BaseTestCase {
                         course.getId(), course.getName(), course.getTimeZone(), course.getInstitute()));
 
         assertEquals(String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, course.toString()), ex.getMessage());
-        verify(coursesDb, never()).createCourse(any(Course.class));
+        verify(coursesDb, never()).persistCourse(any(Course.class));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class CoursesLogicTest extends BaseTestCase {
         request.setTimeZone(Const.DEFAULT_TIME_ZONE);
         request.setInstitute("Institute");
 
-        when(coursesDb.createCourse(any(Course.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(coursesDb.persistCourse(any(Course.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         Course createdCourse = coursesLogic.createCourseAndInstructor(courseCreator, request);
 
@@ -182,7 +182,7 @@ public class CoursesLogicTest extends BaseTestCase {
         assertEquals("\"Invalid/Zone\" is not acceptable to TEAMMATES as a/an time zone because "
                 + "it is not available as a choice. "
                 + "The value must be one of the values from the time zone dropdown selector.", ex.getMessage());
-        verify(coursesDb, never()).createCourse(any(Course.class));
+        verify(coursesDb, never()).persistCourse(any(Course.class));
         verify(usersLogic, never()).createInstructor(any(Instructor.class));
     }
 
@@ -274,12 +274,12 @@ public class CoursesLogicTest extends BaseTestCase {
 
         doAnswer(invocation -> invocation.getArgument(0))
                 .when(coursesDb)
-                .createSection(any(Section.class));
+                .persistSection(any(Section.class));
         when(coursesDb.getSectionByName(course.getId(), "section-name")).thenReturn(null);
 
         Section createdSection = coursesLogic.createSection(course, "section-name");
 
-        verify(coursesDb, times(1)).createSection(any(Section.class));
+        verify(coursesDb, times(1)).persistSection(any(Section.class));
         assertNotNull(createdSection);
         assertEquals("section-name", createdSection.getName());
     }
@@ -343,12 +343,12 @@ public class CoursesLogicTest extends BaseTestCase {
 
         doAnswer(invocation -> invocation.getArgument(0))
                 .when(coursesDb)
-                .createTeam(any(Team.class));
+                .persistTeam(any(Team.class));
         when(coursesDb.getTeamByName(section.getId(), "team-name")).thenReturn(null);
 
         Team createdTeam = coursesLogic.createTeam(section, "team-name");
 
-        verify(coursesDb, times(1)).createTeam(any(Team.class));
+        verify(coursesDb, times(1)).persistTeam(any(Team.class));
         assertNotNull(createdTeam);
         assertEquals("team-name", createdTeam.getName());
     }

--- a/src/test/java/teammates/logic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/logic/core/CoursesLogicTest.java
@@ -218,7 +218,7 @@ public class CoursesLogicTest extends BaseTestCase {
 
         coursesLogic.deleteCourse(course.getId());
 
-        verify(coursesDb, times(1)).deleteCourse(course);
+        verify(coursesDb, times(1)).removeCourse(course);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/DeadlineExtensionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/DeadlineExtensionsLogicTest.java
@@ -181,12 +181,6 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testCreateDeadlineExtension_nullExtension_throwsException() {
-        assertThrows(AssertionError.class, () -> deLogic.createDeadlineExtension(null));
-        verify(deDb, never()).createDeadlineExtension(any());
-    }
-
-    @Test
     public void testDeleteDeadlineExtension_extensionExists_success() {
         Course course = getTypicalCourse();
         FeedbackSession session = getTypicalFeedbackSessionForCourse(course);

--- a/src/test/java/teammates/logic/core/DeadlineExtensionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/DeadlineExtensionsLogicTest.java
@@ -3,11 +3,8 @@ package teammates.logic.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -192,7 +189,7 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
 
         deLogic.deleteDeadlineExtension(de);
 
-        verify(deDb, times(1)).deleteDeadlineExtension(de);
+        verify(deDb, times(1)).removeDeadlineExtension(de);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/DeadlineExtensionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/DeadlineExtensionsLogicTest.java
@@ -169,7 +169,7 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
         DeadlineExtension de = new DeadlineExtension(student, extendedDeadline);
         session.addDeadlineExtension(de);
 
-        when(deDb.createDeadlineExtension(de)).thenReturn(de);
+        when(deDb.persistDeadlineExtension(de)).thenReturn(de);
 
         DeadlineExtension result = deLogic.createDeadlineExtension(de);
 
@@ -177,7 +177,7 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
         assertEquals(de, result);
         assertEquals(extendedDeadline, result.getEndTime());
         assertTrue(result.getUser() instanceof Student);
-        verify(deDb, times(1)).createDeadlineExtension(de);
+        verify(deDb, times(1)).persistDeadlineExtension(de);
     }
 
     @Test
@@ -264,7 +264,7 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
         DeadlineExtension de = new DeadlineExtension(instructor, extendedDeadline);
         session.addDeadlineExtension(de);
 
-        when(deDb.createDeadlineExtension(de)).thenReturn(de);
+        when(deDb.persistDeadlineExtension(de)).thenReturn(de);
 
         DeadlineExtension result = deLogic.createDeadlineExtension(de);
 
@@ -272,7 +272,7 @@ public class DeadlineExtensionsLogicTest extends BaseTestCase {
         assertEquals(de, result);
         assertTrue(result.getUser() instanceof Instructor);
         assertEquals(extendedDeadline, result.getEndTime());
-        verify(deDb, times(1)).createDeadlineExtension(de);
+        verify(deDb, times(1)).persistDeadlineExtension(de);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -105,7 +105,7 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
 
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
-        when(fqDb.createFeedbackQuestion(newQuestion)).thenReturn(newQuestion);
+        when(fqDb.persistFeedbackQuestion(newQuestion)).thenReturn(newQuestion);
 
         FeedbackQuestion createdQuestion = fqLogic.createFeedbackQuestion(newQuestion);
         assertEquals(newQuestion, createdQuestion);
@@ -129,7 +129,7 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         List<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
-        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
+        when(fqDb.persistFeedbackQuestion(fq5)).thenReturn(fq5);
 
         FeedbackQuestion createdQuestion = fqLogic.createFeedbackQuestion(fq5);
 
@@ -155,7 +155,7 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         List<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
-        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
+        when(fqDb.persistFeedbackQuestion(fq5)).thenReturn(fq5);
 
         fqLogic.createFeedbackQuestion(fq5);
 
@@ -183,7 +183,7 @@ public class FeedbackQuestionsLogicTest extends BaseTestCase {
         List<FeedbackQuestion> questionsBefore = new ArrayList<>(List.of(fq1, fq2, fq3, fq4));
         fs.setId(UUID.randomUUID());
         when(fqDb.getFeedbackQuestionsForSession(fs.getId())).thenReturn(questionsBefore);
-        when(fqDb.createFeedbackQuestion(fq5)).thenReturn(fq5);
+        when(fqDb.persistFeedbackQuestion(fq5)).thenReturn(fq5);
 
         fqLogic.createFeedbackQuestion(fq5);
 

--- a/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackResponsesLogicTest.java
@@ -274,7 +274,7 @@ public class FeedbackResponsesLogicTest extends BaseTestCase {
 
         frLogic.deleteFeedbackResponsesAndCommentsCascade(response);
 
-        verify(frDb, times(1)).deleteFeedbackResponse(response);
+        verify(frDb, times(1)).removeFeedbackResponse(response);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -281,7 +281,7 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
         fsLogic.deleteFeedbackSessionCascade(session.getId());
 
         verify(fsDb, times(1)).getFeedbackSession(session.getId());
-        verify(fsDb, times(1)).deleteFeedbackSession(session);
+        verify(fsDb, times(1)).removeFeedbackSession(session);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/NotificationsLogicTest.java
+++ b/src/test/java/teammates/logic/core/NotificationsLogicTest.java
@@ -62,7 +62,7 @@ public class NotificationsLogicTest extends BaseTestCase {
                 "A deprecation note", "<p>Deprecation happens in three minutes</p>");
 
         assertThrows(InvalidParametersException.class, () -> notificationsLogic.createNotification(invalidNotification));
-        verify(notificationsDb, never()).createNotification(invalidNotification);
+        verify(notificationsDb, never()).persistNotification(invalidNotification);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class NotificationsLogicTest extends BaseTestCase {
                 "", "<p>Deprecation happens in three minutes</p>");
 
         assertThrows(InvalidParametersException.class, () -> notificationsLogic.createNotification(invalidNotification));
-        verify(notificationsDb, never()).createNotification(invalidNotification);
+        verify(notificationsDb, never()).persistNotification(invalidNotification);
     }
 
     @Test
@@ -82,7 +82,7 @@ public class NotificationsLogicTest extends BaseTestCase {
                 "A deprecation note", "");
 
         assertThrows(InvalidParametersException.class, () -> notificationsLogic.createNotification(invalidNotification));
-        verify(notificationsDb, never()).createNotification(invalidNotification);
+        verify(notificationsDb, never()).persistNotification(invalidNotification);
     }
 
     @Test
@@ -213,10 +213,10 @@ public class NotificationsLogicTest extends BaseTestCase {
 
         when(accountsLogic.getAccount(account.getId())).thenReturn(account);
         when(notificationsDb.getNotification(notification.getId())).thenReturn(notification);
-        when(notificationsDb.createReadNotification(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(notificationsDb.persistReadNotification(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         ReadNotification result = notificationsLogic.createReadNotification(account.getId(), notification.getId());
-        verify(notificationsDb, times(1)).createReadNotification(any());
+        verify(notificationsDb, times(1)).persistReadNotification(any());
         assertEquals(account.getId(), result.getAccount().getId());
         assertEquals(notification.getId(), result.getNotification().getId());
     }

--- a/src/test/java/teammates/logic/core/ResponseInstructorCommentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/ResponseInstructorCommentsLogicTest.java
@@ -95,7 +95,7 @@ public class ResponseInstructorCommentsLogicTest extends BaseTestCase {
 
         frcLogic.deleteResponseInstructorComment(TYPICAL_ID);
 
-        verify(frcDb, times(1)).deleteResponseInstructorComment(comment);
+        verify(frcDb, times(1)).removeResponseInstructorComment(comment);
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/ResponseInstructorCommentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/ResponseInstructorCommentsLogicTest.java
@@ -75,13 +75,13 @@ public class ResponseInstructorCommentsLogicTest extends BaseTestCase {
         ResponseGiver giver = getRandomInstructorGiver();
 
         when(frLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
-        when(frcDb.createResponseInstructorComment(any(ResponseInstructorComment.class)))
+        when(frcDb.persistResponseInstructorComment(any(ResponseInstructorComment.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
         ResponseInstructorComment createdComment = frcLogic.createResponseInstructorComment(feedbackResponse.getId(), giver,
                 "new comment", List.of(ViewerType.STUDENTS), List.of(ViewerType.INSTRUCTORS));
 
-        verify(frcDb, times(1)).createResponseInstructorComment(createdComment);
+        verify(frcDb, times(1)).persistResponseInstructorComment(createdComment);
         assertEquals("new comment", createdComment.getCommentText());
         assertEquals(giver, createdComment.getGiver());
         assertEquals(List.of(ViewerType.STUDENTS), createdComment.getShowCommentTo());

--- a/src/test/java/teammates/logic/core/UsageStatisticsLogicTest.java
+++ b/src/test/java/teammates/logic/core/UsageStatisticsLogicTest.java
@@ -175,18 +175,6 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testCalculateEntitiesStatisticsForTimeRange_invalidTimeRange_throwsException() {
-        Instant startTime = Instant.parse("2024-01-02T00:00:00Z");
-        Instant endTime = Instant.parse("2024-01-01T00:00:00Z");
-        assertTrue(startTime.isAfter(endTime));
-
-        // Should throw AssertionError due to assertion in the method
-        assertThrows(AssertionError.class, () -> {
-            usageStatisticsLogic.calculateEntitiesStatisticsForTimeRange(startTime, endTime);
-        });
-    }
-
-    @Test
     public void testCalculateEntitiesStatisticsForTimeRange_distantPast_returnsStatistics() {
         Instant startTime = Instant.parse("2010-01-01T00:00:00Z");
         Instant endTime = Instant.parse("2010-12-31T23:59:59Z");

--- a/src/test/java/teammates/logic/core/UsageStatisticsLogicTest.java
+++ b/src/test/java/teammates/logic/core/UsageStatisticsLogicTest.java
@@ -204,7 +204,7 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
         UsageStatistics stats = new UsageStatistics(
                 startTime, 1, 100, 10, 50, 5, 2, 20, 30);
 
-        when(usageStatisticsDb.createUsageStatistics(stats)).thenReturn(stats);
+        when(usageStatisticsDb.persistUsageStatistics(stats)).thenReturn(stats);
 
         UsageStatistics result = usageStatisticsLogic.createUsageStatistics(stats);
 
@@ -220,7 +220,7 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
         assertEquals(2, result.getNumAccountRequests());
         assertEquals(20, result.getNumEmails());
         assertEquals(30, result.getNumSubmissions());
-        verify(usageStatisticsDb, times(1)).createUsageStatistics(stats);
+        verify(usageStatisticsDb, times(1)).persistUsageStatistics(stats);
     }
 
     @Test
@@ -229,7 +229,7 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
         UsageStatistics stats = new UsageStatistics(
                 startTime, 1, 0, 0, 0, 0, 0, 0, 0);
 
-        when(usageStatisticsDb.createUsageStatistics(stats)).thenReturn(stats);
+        when(usageStatisticsDb.persistUsageStatistics(stats)).thenReturn(stats);
 
         UsageStatistics result = usageStatisticsLogic.createUsageStatistics(stats);
 
@@ -252,7 +252,7 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
         UsageStatistics stats = new UsageStatistics(
                 startTime, 24, 100000, 5000, 50000, 2500, 1000, 75000, 80000);
 
-        when(usageStatisticsDb.createUsageStatistics(stats)).thenReturn(stats);
+        when(usageStatisticsDb.persistUsageStatistics(stats)).thenReturn(stats);
 
         UsageStatistics result = usageStatisticsLogic.createUsageStatistics(stats);
 
@@ -277,16 +277,16 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
         UsageStatistics stats2 = new UsageStatistics(
                 startTime2, 1, 200, 20, 100, 10, 4, 40, 60);
 
-        when(usageStatisticsDb.createUsageStatistics(stats1)).thenReturn(stats1);
-        when(usageStatisticsDb.createUsageStatistics(stats2)).thenReturn(stats2);
+        when(usageStatisticsDb.persistUsageStatistics(stats1)).thenReturn(stats1);
+        when(usageStatisticsDb.persistUsageStatistics(stats2)).thenReturn(stats2);
 
         UsageStatistics result1 = usageStatisticsLogic.createUsageStatistics(stats1);
         UsageStatistics result2 = usageStatisticsLogic.createUsageStatistics(stats2);
 
         assertEquals(stats1, result1);
         assertEquals(stats2, result2);
-        verify(usageStatisticsDb, times(1)).createUsageStatistics(stats1);
-        verify(usageStatisticsDb, times(1)).createUsageStatistics(stats2);
+        verify(usageStatisticsDb, times(1)).persistUsageStatistics(stats1);
+        verify(usageStatisticsDb, times(1)).persistUsageStatistics(stats2);
     }
 
     // ==================== EDGE CASE Tests ====================
@@ -311,21 +311,21 @@ public class UsageStatisticsLogicTest extends BaseTestCase {
         // Test with hourly time period (1 hour = 1)
         UsageStatistics hourlyStats = new UsageStatistics(
                 startTime, 1, 10, 1, 5, 1, 0, 2, 3);
-        when(usageStatisticsDb.createUsageStatistics(hourlyStats)).thenReturn(hourlyStats);
+        when(usageStatisticsDb.persistUsageStatistics(hourlyStats)).thenReturn(hourlyStats);
         UsageStatistics result1 = usageStatisticsLogic.createUsageStatistics(hourlyStats);
         assertEquals(1, result1.getTimePeriod());
 
         // Test with daily time period (24 hours = 24)
         UsageStatistics dailyStats = new UsageStatistics(
                 startTime, 24, 100, 10, 50, 5, 2, 20, 30);
-        when(usageStatisticsDb.createUsageStatistics(dailyStats)).thenReturn(dailyStats);
+        when(usageStatisticsDb.persistUsageStatistics(dailyStats)).thenReturn(dailyStats);
         UsageStatistics result2 = usageStatisticsLogic.createUsageStatistics(dailyStats);
         assertEquals(24, result2.getTimePeriod());
 
         // Test with weekly time period (168 hours = 168)
         UsageStatistics weeklyStats = new UsageStatistics(
                 startTime, 168, 700, 70, 350, 35, 14, 140, 210);
-        when(usageStatisticsDb.createUsageStatistics(weeklyStats)).thenReturn(weeklyStats);
+        when(usageStatisticsDb.persistUsageStatistics(weeklyStats)).thenReturn(weeklyStats);
         UsageStatistics result3 = usageStatisticsLogic.createUsageStatistics(weeklyStats);
         assertEquals(168, result3.getTimePeriod());
     }

--- a/src/test/java/teammates/logic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/logic/core/UsersLogicTest.java
@@ -138,7 +138,7 @@ public class UsersLogicTest extends BaseTestCase {
 
         usersLogic.deleteInstructorCascade(instructorToDelete.getId());
 
-        verify(usersDb, times(1)).deleteUser(instructorToDelete);
+        verify(usersDb, times(1)).removeUser(instructorToDelete);
     }
 
     @Test
@@ -148,7 +148,7 @@ public class UsersLogicTest extends BaseTestCase {
 
         usersLogic.deleteInstructorCascade(userId);
 
-        verify(usersDb, times(0)).deleteUser(instructor);
+        verify(usersDb, times(0)).removeUser(instructor);
     }
 
     @Test
@@ -165,7 +165,7 @@ public class UsersLogicTest extends BaseTestCase {
 
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
-        verify(usersDb, times(0)).deleteUser(instructorToDelete);
+        verify(usersDb, times(0)).removeUser(instructorToDelete);
     }
 
     @Test
@@ -182,7 +182,7 @@ public class UsersLogicTest extends BaseTestCase {
 
         assertEquals("The instructor you are trying to delete is the last instructor in the course. "
                 + "Deleting the last instructor from the course is not allowed.", ioe.getMessage());
-        verify(usersDb, times(0)).deleteUser(instructorToDelete);
+        verify(usersDb, times(0)).removeUser(instructorToDelete);
     }
 
     @Test

--- a/src/test/java/teammates/storage/api/AccountRequestSearchIT.java
+++ b/src/test/java/teammates/storage/api/AccountRequestSearchIT.java
@@ -96,15 +96,15 @@ public class AccountRequestSearchIT extends BaseTestCaseWithDatabaseAccess {
         results = inTransaction(() -> accountRequestsDb.searchAccountRequestsInWholeSystem("Instructor 1"));
         verifySearchResults(results, ins1General, ins1InCourse1, ins1InCourse2, ins1InCourse3, unregisteredInstructor1);
 
-        inTransaction(() -> accountRequestsDb.deleteAccountRequest(ins1InCourse1));
+        inTransaction(() -> accountRequestsDb.removeAccountRequest(ins1InCourse1));
         results = inTransaction(() -> accountRequestsDb.searchAccountRequestsInWholeSystem("Instructor 1"));
         verifySearchResults(results, ins1General, ins1InCourse2, ins1InCourse3, unregisteredInstructor1);
 
-        inTransaction(() -> accountRequestsDb.deleteAccountRequest(ins1InCourse2));
+        inTransaction(() -> accountRequestsDb.removeAccountRequest(ins1InCourse2));
         results = inTransaction(() -> accountRequestsDb.searchAccountRequestsInWholeSystem("Instructor 1"));
         verifySearchResults(results, ins1General, ins1InCourse3, unregisteredInstructor1);
 
-        inTransaction(() -> accountRequestsDb.deleteAccountRequest(ins1InCourse3));
+        inTransaction(() -> accountRequestsDb.removeAccountRequest(ins1InCourse3));
         results = inTransaction(() -> accountRequestsDb.searchAccountRequestsInWholeSystem("Instructor 1"));
         verifySearchResults(results, ins1General, unregisteredInstructor1);
     }

--- a/src/test/java/teammates/storage/api/AccountRequestsDbIT.java
+++ b/src/test/java/teammates/storage/api/AccountRequestsDbIT.java
@@ -21,7 +21,7 @@ public class AccountRequestsDbIT extends BaseTestCaseWithDatabaseAccess {
     private final AccountRequestsDb accountRequestDb = AccountRequestsDb.inst();
 
     @Test
-    public void testPersistReadDeleteAccountRequest() {
+    public void testPersistReadRemoveAccountRequest() {
         ______TS("Create account request, does not exists, succeeds");
 
         AccountRequest accountRequest =
@@ -69,9 +69,9 @@ public class AccountRequestsDbIT extends BaseTestCaseWithDatabaseAccess {
                         identicalAccountRequest.getRegistrationKey()));
         assertEquals(identicalAccountRequest, actualIdenticalAccountRequest);
 
-        ______TS("Delete account request that was created");
+        ______TS("Remove account request that was created");
 
-        inTransaction(() -> accountRequestDb.deleteAccountRequest(accountRequest));
+        inTransaction(() -> accountRequestDb.removeAccountRequest(accountRequest));
 
         AccountRequest actualAccountRequest =
                 inTransaction(() -> accountRequestDb.getAccountRequestByRegistrationKey(

--- a/src/test/java/teammates/storage/api/AccountRequestsDbIT.java
+++ b/src/test/java/teammates/storage/api/AccountRequestsDbIT.java
@@ -21,12 +21,12 @@ public class AccountRequestsDbIT extends BaseTestCaseWithDatabaseAccess {
     private final AccountRequestsDb accountRequestDb = AccountRequestsDb.inst();
 
     @Test
-    public void testCreateReadDeleteAccountRequest() {
+    public void testPersistReadDeleteAccountRequest() {
         ______TS("Create account request, does not exists, succeeds");
 
         AccountRequest accountRequest =
                 new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
-        inTransaction(() -> accountRequestDb.createAccountRequest(accountRequest));
+        inTransaction(() -> accountRequestDb.persistAccountRequest(accountRequest));
 
         ______TS("Read account request using the given ID");
 
@@ -63,7 +63,7 @@ public class AccountRequestsDbIT extends BaseTestCaseWithDatabaseAccess {
                 new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
         assertNotSame(accountRequest, identicalAccountRequest);
 
-        inTransaction(() -> accountRequestDb.createAccountRequest(identicalAccountRequest));
+        inTransaction(() -> accountRequestDb.persistAccountRequest(identicalAccountRequest));
         AccountRequest actualIdenticalAccountRequest =
                 inTransaction(() -> accountRequestDb.getAccountRequestByRegistrationKey(
                         identicalAccountRequest.getRegistrationKey()));
@@ -91,7 +91,7 @@ public class AccountRequestsDbIT extends BaseTestCaseWithDatabaseAccess {
         AccountRequest expectedAccountRequest =
                 new AccountRequest("test@gmail.com", "name", "institute", AccountRequestStatus.PENDING, "comments");
         UUID id = expectedAccountRequest.getId();
-        inTransaction(() -> accountRequestDb.createAccountRequest(expectedAccountRequest));
+        inTransaction(() -> accountRequestDb.persistAccountRequest(expectedAccountRequest));
         AccountRequest actualAccountRequest = inTransaction(() -> accountRequestDb.getAccountRequest(id));
         assertEquals(expectedAccountRequest, actualAccountRequest);
     }

--- a/src/test/java/teammates/storage/api/AccountsDbIT.java
+++ b/src/test/java/teammates/storage/api/AccountsDbIT.java
@@ -63,13 +63,13 @@ public class AccountsDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testDeleteAccount() {
+    public void testRemoveAccount() {
         Account account = getTypicalAccount();
         inTransaction(() -> accountsDb.persistAccount(account));
 
-        ______TS("Delete existing account, success");
+        ______TS("Remove existing account, success");
 
-        inTransaction(() -> accountsDb.deleteAccount(account));
+        inTransaction(() -> accountsDb.removeAccount(account));
 
         Account actual = inTransaction(() -> accountsDb.getAccount(account.getId()));
         assertNull(actual);

--- a/src/test/java/teammates/storage/api/CoursesDbIT.java
+++ b/src/test/java/teammates/storage/api/CoursesDbIT.java
@@ -44,11 +44,11 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testDeleteCourse() {
+    public void testRemoveCourse() {
         Course course = getTypicalCourse();
         inTransaction(() -> coursesDb.persistCourse(course));
 
-        inTransaction(() -> coursesDb.deleteCourse(course));
+        inTransaction(() -> coursesDb.removeCourse(course));
         Course actualCourse = inTransaction(() -> coursesDb.getCourse(course.getId()));
         assertNull(actualCourse);
     }

--- a/src/test/java/teammates/storage/api/CoursesDbIT.java
+++ b/src/test/java/teammates/storage/api/CoursesDbIT.java
@@ -27,9 +27,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         Course actual = inTransaction(() -> coursesDb.getCourse("non-existent-course-id"));
         assertNull(actual);
 
-        ______TS("failure: null assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.getCourse(null));
-
         ______TS("success: get course that already exists");
         Course expected = getTypicalCourse();
         inTransaction(() -> coursesDb.createCourse(expected));
@@ -45,9 +42,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         inTransaction(() -> coursesDb.createCourse(course));
         Course actualCourse = inTransaction(() -> coursesDb.getCourse("course-id"));
         assertEquals(course, actualCourse);
-
-        ______TS("failure: null course assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.createCourse(null));
     }
 
     @Test
@@ -70,9 +64,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         inTransaction(() -> coursesDb.createSection(section));
         Section actualSection = inTransaction(() -> coursesDb.getSectionByName(course.getId(), section.getName()));
         assertEquals(section, actualSection);
-
-        ______TS("failure: null section assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.createSection(null));
     }
 
     @Test
@@ -83,12 +74,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
             coursesDb.createCourse(course);
             coursesDb.createSection(section);
         });
-
-        ______TS("failure: null courseId assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.getSectionByName(null, section.getName()));
-
-        ______TS("failure: null sectionName assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.getSectionByName(course.getId(), null));
 
         ______TS("success: get section that already exists");
         Section actualSection = inTransaction(() -> coursesDb.getSectionByName(course.getId(), section.getName()));
@@ -112,14 +97,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
             coursesDb.createTeam(team);
             section.addTeam(team);
         });
-
-        ______TS("failure: null courseId assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class,
-                () -> coursesDb.getSectionByCourseIdAndTeam(null, team.getName()));
-
-        ______TS("failure: null teamName assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class,
-                () -> coursesDb.getSectionByCourseIdAndTeam(course.getId(), null));
 
         ______TS("success: typical case");
         Section actualSection =
@@ -156,9 +133,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
 
         List<Team> expectedTeams = List.of(team1, team2, team3, team4);
 
-        ______TS("failure: null courseId assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.getTeamsForCourse(null));
-
         ______TS("success: typical case");
         List<Team> actualTeams = inTransaction(() -> coursesDb.getTeamsForCourse(course.getId()));
         assertEquals(expectedTeams.size(), actualTeams.size());
@@ -177,9 +151,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         });
 
         assertNotNull(inTransaction(() -> coursesDb.getSectionByName(course.getId(), section.getName())));
-
-        ______TS("failure: null team assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.createTeam(null));
 
         ______TS("success: create team that does not exist");
         inTransaction(() -> coursesDb.createTeam(team));
@@ -202,12 +173,6 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         ______TS("success: get team that already exists");
         Team actualTeam = inTransaction(() -> coursesDb.getTeamByName(section.getId(), team.getName()));
         assertEquals(team, actualTeam);
-
-        ______TS("failure: null sectionId assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.getTeamByName(null, team.getName()));
-
-        ______TS("failure: null teamName assertion exception thrown");
-        assertThrowsInTransaction(AssertionError.class, () -> coursesDb.getTeamByName(section.getId(), null));
 
         ______TS("success: null return");
         Team nonExistentTeam =

--- a/src/test/java/teammates/storage/api/CoursesDbIT.java
+++ b/src/test/java/teammates/storage/api/CoursesDbIT.java
@@ -29,17 +29,16 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: get course that already exists");
         Course expected = getTypicalCourse();
-        inTransaction(() -> coursesDb.createCourse(expected));
+        inTransaction(() -> coursesDb.persistCourse(expected));
 
         actual = inTransaction(() -> coursesDb.getCourse(expected.getId()));
         assertEquals(expected, actual);
     }
 
     @Test
-    public void testCreateCourse() {
-        ______TS("success: create course that does not exist");
+    public void testPersistCourse() {
         Course course = getTypicalCourse();
-        inTransaction(() -> coursesDb.createCourse(course));
+        inTransaction(() -> coursesDb.persistCourse(course));
         Course actualCourse = inTransaction(() -> coursesDb.getCourse("course-id"));
         assertEquals(course, actualCourse);
     }
@@ -47,7 +46,7 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
     @Test
     public void testDeleteCourse() {
         Course course = getTypicalCourse();
-        inTransaction(() -> coursesDb.createCourse(course));
+        inTransaction(() -> coursesDb.persistCourse(course));
 
         inTransaction(() -> coursesDb.deleteCourse(course));
         Course actualCourse = inTransaction(() -> coursesDb.getCourse(course.getId()));
@@ -55,13 +54,13 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testCreateSection() {
+    public void testPersistSection() {
         Course course = getTypicalCourse();
         Section section = getTypicalSection();
-        inTransaction(() -> coursesDb.createCourse(course));
+        inTransaction(() -> coursesDb.persistCourse(course));
 
         ______TS("success: create section that does not exist");
-        inTransaction(() -> coursesDb.createSection(section));
+        inTransaction(() -> coursesDb.persistSection(section));
         Section actualSection = inTransaction(() -> coursesDb.getSectionByName(course.getId(), section.getName()));
         assertEquals(section, actualSection);
     }
@@ -71,8 +70,8 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         Course course = getTypicalCourse();
         Section section = getTypicalSection();
         inTransaction(() -> {
-            coursesDb.createCourse(course);
-            coursesDb.createSection(section);
+            coursesDb.persistCourse(course);
+            coursesDb.persistSection(section);
         });
 
         ______TS("success: get section that already exists");
@@ -91,10 +90,10 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         Section section = new Section("section-name");
         Team team = new Team("team-name");
         inTransaction(() -> {
-            coursesDb.createCourse(course);
-            coursesDb.createSection(section);
+            coursesDb.persistCourse(course);
+            coursesDb.persistSection(section);
             course.addSection(section);
-            coursesDb.createTeam(team);
+            coursesDb.persistTeam(team);
             section.addTeam(team);
         });
 
@@ -115,19 +114,19 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         Team team3 = new Team("team-name3");
         Team team4 = new Team("team-name4");
         inTransaction(() -> {
-            coursesDb.createCourse(course);
-            coursesDb.createSection(section1);
+            coursesDb.persistCourse(course);
+            coursesDb.persistSection(section1);
             course.addSection(section1);
-            coursesDb.createTeam(team1);
+            coursesDb.persistTeam(team1);
             section1.addTeam(team1);
-            coursesDb.createTeam(team2);
+            coursesDb.persistTeam(team2);
             section1.addTeam(team2);
 
-            coursesDb.createSection(section2);
+            coursesDb.persistSection(section2);
             course.addSection(section2);
-            coursesDb.createTeam(team3);
+            coursesDb.persistTeam(team3);
             section2.addTeam(team3);
-            coursesDb.createTeam(team4);
+            coursesDb.persistTeam(team4);
             section2.addTeam(team4);
         });
 
@@ -146,14 +145,14 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         Team team = new Team("team-name1");
         section.addTeam(team);
         inTransaction(() -> {
-            coursesDb.createCourse(course);
-            coursesDb.createSection(section);
+            coursesDb.persistCourse(course);
+            coursesDb.persistSection(section);
         });
 
         assertNotNull(inTransaction(() -> coursesDb.getSectionByName(course.getId(), section.getName())));
 
         ______TS("success: create team that does not exist");
-        inTransaction(() -> coursesDb.createTeam(team));
+        inTransaction(() -> coursesDb.persistTeam(team));
         Team actualTeam = inTransaction(() -> coursesDb.getTeamByName(section.getId(), team.getName()));
         assertEquals(team, actualTeam);
     }
@@ -165,9 +164,9 @@ public class CoursesDbIT extends BaseTestCaseWithDatabaseAccess {
         Team team = new Team("team-name1");
         section.addTeam(team);
         inTransaction(() -> {
-            coursesDb.createCourse(course);
-            coursesDb.createSection(section);
-            coursesDb.createTeam(team);
+            coursesDb.persistCourse(course);
+            coursesDb.persistSection(section);
+            coursesDb.persistTeam(team);
         });
 
         ______TS("success: get team that already exists");

--- a/src/test/java/teammates/storage/api/FeedbackQuestionsDbIT.java
+++ b/src/test/java/teammates/storage/api/FeedbackQuestionsDbIT.java
@@ -113,12 +113,11 @@ public class FeedbackQuestionsDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testDeleteFeedbackQuestion() {
-        ______TS("success: typical case");
+    public void testRemoveFeedbackQuestion() {
         FeedbackQuestion fq = typicalDataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
         verifyPresentInDatabase(fq);
 
-        inTransaction(() -> fqDb.deleteFeedbackQuestion(fq));
+        inTransaction(() -> fqDb.removeFeedbackQuestion(fq));
         assertNull(inTransaction(() -> fqDb.getFeedbackQuestion(fq.getId())));
     }
 

--- a/src/test/java/teammates/storage/api/FeedbackQuestionsDbIT.java
+++ b/src/test/java/teammates/storage/api/FeedbackQuestionsDbIT.java
@@ -46,9 +46,6 @@ public class FeedbackQuestionsDbIT extends BaseTestCaseWithDatabaseAccess {
         ______TS("failure: does not exist, returns null");
         actualFq = inTransaction(() -> fqDb.getFeedbackQuestion(UUID.randomUUID()));
         assertNull(actualFq);
-
-        ______TS("failure: null parameter, assertion error");
-        assertThrowsInTransaction(AssertionError.class, () -> fqDb.getFeedbackQuestion(null));
     }
 
     @Test
@@ -65,9 +62,6 @@ public class FeedbackQuestionsDbIT extends BaseTestCaseWithDatabaseAccess {
             return fq;
         });
         verifyPresentInDatabase(expectedFq);
-
-        ______TS("failure: null parameter, assertion error");
-        assertThrowsInTransaction(AssertionError.class, () -> fqDb.createFeedbackQuestion(null));
     }
 
     @Test

--- a/src/test/java/teammates/storage/api/FeedbackQuestionsDbIT.java
+++ b/src/test/java/teammates/storage/api/FeedbackQuestionsDbIT.java
@@ -49,16 +49,15 @@ public class FeedbackQuestionsDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testCreateFeedbackQuestion() {
-        ______TS("success: typical case");
+    public void testPersistFeedbackQuestion() {
         Course course = getTypicalCourse();
         FeedbackSession fs = getTypicalFeedbackSessionForCourse(course);
 
         FeedbackQuestion expectedFq = inTransaction(() -> {
-            coursesDb.createCourse(course);
-            fsDb.createFeedbackSession(fs);
+            coursesDb.persistCourse(course);
+            fsDb.persistFeedbackSession(fs);
             FeedbackQuestion fq = getTypicalFeedbackQuestionForSession(fs);
-            fqDb.createFeedbackQuestion(fq);
+            fqDb.persistFeedbackQuestion(fq);
             return fq;
         });
         verifyPresentInDatabase(expectedFq);

--- a/src/test/java/teammates/storage/api/FeedbackResponsesDbIT.java
+++ b/src/test/java/teammates/storage/api/FeedbackResponsesDbIT.java
@@ -59,11 +59,10 @@ public class FeedbackResponsesDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testDeleteFeedback() {
-        ______TS("success: typical case");
+    public void testRemoveFeedback() {
         FeedbackResponse fr1 = testDataBundle.feedbackResponses.get("response1ForQ1");
 
-        inTransaction(() -> frDb.deleteFeedbackResponse(fr1));
+        inTransaction(() -> frDb.removeFeedbackResponse(fr1));
 
         assertNull(inTransaction(() -> frDb.getFeedbackResponse(fr1.getId())));
     }

--- a/src/test/java/teammates/storage/api/FeedbackSessionLogsDbIT.java
+++ b/src/test/java/teammates/storage/api/FeedbackSessionLogsDbIT.java
@@ -33,7 +33,7 @@ public class FeedbackSessionLogsDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void test_createFeedbackSessionLog_success() {
+    public void test_persistFeedbackSessionLog_success() {
         Course course = typicalDataBundle.courses.get("course1");
         FeedbackSession feedbackSession = typicalDataBundle.feedbackSessions.get("session1InCourse1");
         Student student = typicalDataBundle.students.get("student1InCourse1");
@@ -42,7 +42,7 @@ public class FeedbackSessionLogsDbIT extends BaseTestCaseWithDatabaseAccess {
         FeedbackSessionLog expected = new FeedbackSessionLog(student, feedbackSession, FeedbackSessionLogType.ACCESS,
                 logTimestamp);
 
-        inTransaction(() -> fslDb.createFeedbackSessionLog(expected));
+        inTransaction(() -> fslDb.persistFeedbackSessionLog(expected));
 
         List<FeedbackSessionLog> actualLogs = inTransaction(() -> fslDb.getOrderedFeedbackSessionLogs(
                 course.getId(), student.getId(), feedbackSession.getId(), logTimestamp, logTimestamp.plusSeconds(1)));

--- a/src/test/java/teammates/storage/api/FeedbackSessionsDbIT.java
+++ b/src/test/java/teammates/storage/api/FeedbackSessionsDbIT.java
@@ -33,11 +33,11 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithDatabaseAccess {
                 Instant.now().plus(Duration.ofDays(1)), Instant.now().plus(Duration.ofDays(7)), Instant.now(),
                 Instant.now().plus(Duration.ofDays(7)), Duration.ofMinutes(10), true, true);
         inTransaction(() -> {
-            coursesDb.createCourse(course1);
+            coursesDb.persistCourse(course1);
             course1.addFeedbackSession(fs1);
             course1.addFeedbackSession(fs2);
-            fsDb.createFeedbackSession(fs1);
-            fsDb.createFeedbackSession(fs2);
+            fsDb.persistFeedbackSession(fs1);
+            fsDb.persistFeedbackSession(fs2);
         });
 
         FeedbackSession actualFs = inTransaction(() -> fsDb.getFeedbackSession(fs2.getName(), fs2.getCourseId()));
@@ -72,19 +72,19 @@ public class FeedbackSessionsDbIT extends BaseTestCaseWithDatabaseAccess {
                 instantNow.minus(Duration.ofDays(7L)), instantNow.plus(Duration.ofDays(7L)), Duration.ofMinutes(10L),
                 true, true);
         inTransaction(() -> {
-            coursesDb.createCourse(course1);
+            coursesDb.persistCourse(course1);
             course1.addFeedbackSession(c1Fs1);
-            fsDb.createFeedbackSession(c1Fs1);
+            fsDb.persistFeedbackSession(c1Fs1);
             course1.addFeedbackSession(c1Fs2);
-            fsDb.createFeedbackSession(c1Fs2);
-            coursesDb.createCourse(course2);
+            fsDb.persistFeedbackSession(c1Fs2);
+            coursesDb.persistCourse(course2);
             course2.addFeedbackSession(c2Fs1);
-            fsDb.createFeedbackSession(c2Fs1);
+            fsDb.persistFeedbackSession(c2Fs1);
             course2.addFeedbackSession(c2Fs2);
-            fsDb.createFeedbackSession(c2Fs2);
-            coursesDb.createCourse(course3);
+            fsDb.persistFeedbackSession(c2Fs2);
+            coursesDb.persistCourse(course3);
             course3.addFeedbackSession(c3Fs1);
-            fsDb.createFeedbackSession(c3Fs1);
+            fsDb.persistFeedbackSession(c3Fs1);
         });
         Set<FeedbackSession> expectedUniqueOngoingSessions = new HashSet<>();
         expectedUniqueOngoingSessions.add(c1Fs2);

--- a/src/test/java/teammates/storage/api/InstructorSearchIT.java
+++ b/src/test/java/teammates/storage/api/InstructorSearchIT.java
@@ -94,15 +94,15 @@ public class InstructorSearchIT extends BaseTestCaseWithDatabaseAccess {
         List<Instructor> results = inTransaction(() -> usersDb.searchInstructorsInWholeSystem("course-1"));
         verifySearchResults(results, ins1InCourse1, ins2InCourse1, unregisteredInsInCourse1);
 
-        inTransaction(() -> usersDb.deleteUser(ins1InCourse1));
+        inTransaction(() -> usersDb.removeUser(ins1InCourse1));
         results = inTransaction(() -> usersDb.searchInstructorsInWholeSystem("course-1"));
         verifySearchResults(results, ins2InCourse1, unregisteredInsInCourse1);
 
-        inTransaction(() -> usersDb.deleteUser(ins2InCourse1));
+        inTransaction(() -> usersDb.removeUser(ins2InCourse1));
         results = inTransaction(() -> usersDb.searchInstructorsInWholeSystem("course-1"));
         verifySearchResults(results, unregisteredInsInCourse1);
 
-        inTransaction(() -> usersDb.deleteUser(unregisteredInsInCourse1));
+        inTransaction(() -> usersDb.removeUser(unregisteredInsInCourse1));
         results = inTransaction(() -> usersDb.searchInstructorsInWholeSystem("course-1"));
         verifySearchResults(results);
     }

--- a/src/test/java/teammates/storage/api/NotificationDbIT.java
+++ b/src/test/java/teammates/storage/api/NotificationDbIT.java
@@ -24,11 +24,10 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
     private final NotificationsDb notificationsDb = NotificationsDb.inst();
 
     @Test
-    public void testCreateNotification() {
-        ______TS("success: create notification that does not exist");
+    public void testPersistNotification() {
         Notification newNotification = generateTypicalNotification();
 
-        inTransaction(() -> notificationsDb.createNotification(newNotification));
+        inTransaction(() -> notificationsDb.persistNotification(newNotification));
 
         UUID notificationId = newNotification.getId();
         Notification actualNotification = inTransaction(() -> notificationsDb.getNotification(notificationId));
@@ -40,7 +39,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
         ______TS("success: get a notification that already exists");
         Notification newNotification = generateTypicalNotification();
 
-        inTransaction(() -> notificationsDb.createNotification(newNotification));
+        inTransaction(() -> notificationsDb.persistNotification(newNotification));
 
         UUID notificationId = newNotification.getId();
         Notification actualNotification = inTransaction(() -> notificationsDb.getNotification(notificationId));
@@ -57,7 +56,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
         ______TS("success: delete a notification that already exists");
         Notification notification = generateTypicalNotification();
 
-        inTransaction(() -> notificationsDb.createNotification(notification));
+        inTransaction(() -> notificationsDb.persistNotification(notification));
         UUID notificationId = notification.getId();
         assertNotNull(inTransaction(() -> notificationsDb.getNotification(notificationId)));
 
@@ -113,7 +112,7 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
         List<Notification> allNotifications = List.of(n1, n2, n3, n4, n5, n6);
         inTransaction(() -> {
             for (Notification n : allNotifications) {
-                notificationsDb.createNotification(n);
+                notificationsDb.persistNotification(n);
             }
         });
 

--- a/src/test/java/teammates/storage/api/NotificationDbIT.java
+++ b/src/test/java/teammates/storage/api/NotificationDbIT.java
@@ -52,15 +52,14 @@ public class NotificationDbIT extends BaseTestCaseWithDatabaseAccess {
     }
 
     @Test
-    public void testDeleteNotification() {
-        ______TS("success: delete a notification that already exists");
+    public void testRemoveNotification() {
         Notification notification = generateTypicalNotification();
 
         inTransaction(() -> notificationsDb.persistNotification(notification));
         UUID notificationId = notification.getId();
         assertNotNull(inTransaction(() -> notificationsDb.getNotification(notificationId)));
 
-        inTransaction(() -> notificationsDb.deleteNotification(notification));
+        inTransaction(() -> notificationsDb.removeNotification(notification));
         assertNull(inTransaction(() -> notificationsDb.getNotification(notificationId)));
     }
 

--- a/src/test/java/teammates/storage/api/StudentSearchIT.java
+++ b/src/test/java/teammates/storage/api/StudentSearchIT.java
@@ -96,7 +96,7 @@ public class StudentSearchIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: search for students in whole system; deleted students no longer searchable");
 
-        inTransaction(() -> usersDb.deleteUser(stu1InCourse1));
+        inTransaction(() -> usersDb.removeUser(stu1InCourse1));
         results = inTransaction(() -> usersDb.searchStudentsInWholeSystem("student1"));
         verifySearchResults(results, stu1InCourse2, stu1InCourse3, stu1InCourse4);
     }
@@ -111,11 +111,11 @@ public class StudentSearchIT extends BaseTestCaseWithDatabaseAccess {
         List<Student> studentList = inTransaction(() -> usersDb.searchStudentsInWholeSystem("student1"));
         verifySearchResults(studentList, stu1InCourse1, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
-        inTransaction(() -> usersDb.deleteUser(stu1InCourse1));
+        inTransaction(() -> usersDb.removeUser(stu1InCourse1));
         studentList = inTransaction(() -> usersDb.searchStudentsInWholeSystem("student1"));
         verifySearchResults(studentList, stu1InCourse2, stu1InCourse3, stu1InCourse4);
 
-        inTransaction(() -> usersDb.deleteUser(stu1InCourse2));
+        inTransaction(() -> usersDb.removeUser(stu1InCourse2));
         studentList = inTransaction(() -> usersDb.searchStudentsInWholeSystem("student1"));
         verifySearchResults(studentList, stu1InCourse3, stu1InCourse4);
     }

--- a/src/test/java/teammates/storage/api/UsageStatisticsDbIT.java
+++ b/src/test/java/teammates/storage/api/UsageStatisticsDbIT.java
@@ -38,8 +38,8 @@ public class UsageStatisticsDbIT extends BaseTestCaseWithDatabaseAccess {
                 startTimeTwo, 1, 0, 0, 0, 0, 0, 0, 0);
 
         inTransaction(() -> {
-            usageStatisticsDb.createUsageStatistics(usageStatisticsOne);
-            usageStatisticsDb.createUsageStatistics(usageStatisticsTwo);
+            usageStatisticsDb.persistUsageStatistics(usageStatisticsOne);
+            usageStatisticsDb.persistUsageStatistics(usageStatisticsTwo);
         });
 
         List<UsageStatistics> actulUsageStatisticsOne = inTransaction(() -> usageStatisticsDb
@@ -58,7 +58,7 @@ public class UsageStatisticsDbIT extends BaseTestCaseWithDatabaseAccess {
         UsageStatistics newUsageStatistics = new UsageStatistics(
                 startTime, 1, 0, 0, 0, 0, 0, 0, 0);
 
-        inTransaction(() -> usageStatisticsDb.createUsageStatistics(newUsageStatistics));
+        inTransaction(() -> usageStatisticsDb.persistUsageStatistics(newUsageStatistics));
 
         List<UsageStatistics> actualUsageStatistics = inTransaction(() -> usageStatisticsDb
                 .getUsageStatisticsForTimeRange(startTime, startTime.plus(1, ChronoUnit.SECONDS)));

--- a/src/test/java/teammates/storage/api/UsersDbIT.java
+++ b/src/test/java/teammates/storage/api/UsersDbIT.java
@@ -50,21 +50,21 @@ public class UsersDbIT extends BaseTestCaseWithDatabaseAccess {
                 "typicalTenantId", "student-name", "valid-student@email.tmt");
         student = getTypicalStudent();
         inTransaction(() -> {
-            coursesDb.createCourse(course);
-            coursesDb.createSection(section);
+            coursesDb.persistCourse(course);
+            coursesDb.persistSection(section);
             course.addSection(section);
-            coursesDb.createTeam(team);
+            coursesDb.persistTeam(team);
             section.addTeam(team);
 
             accountsDb.persistAccount(instructorAccount);
             instructor.setCourse(course);
-            usersDb.createInstructor(instructor);
+            usersDb.persistInstructor(instructor);
             instructor.setAccount(instructorAccount);
 
             accountsDb.persistAccount(studentAccount);
             student.setCourse(course);
             student.setTeam(team);
-            usersDb.createStudent(student);
+            usersDb.persistStudent(student);
             student.setAccount(studentAccount);
         });
     }
@@ -155,22 +155,22 @@ public class UsersDbIT extends BaseTestCaseWithDatabaseAccess {
         inTransaction(() -> {
             accountsDb.persistAccount(userSharedAccount);
 
-            usersDb.createInstructor(firstInstructor);
+            usersDb.persistInstructor(firstInstructor);
             firstInstructor.setAccount(userSharedAccount);
-            usersDb.createInstructor(secondInstructor);
+            usersDb.persistInstructor(secondInstructor);
             secondInstructor.setAccount(userSharedAccount);
 
-            coursesDb.createSection(section);
+            coursesDb.persistSection(section);
             course.addSection(section);
-            coursesDb.createTeam(team);
+            coursesDb.persistTeam(team);
             section.addTeam(team);
 
             team.addUser(firstStudent);
-            usersDb.createStudent(firstStudent);
+            usersDb.persistStudent(firstStudent);
             firstStudent.setAccount(userSharedAccount);
 
             team.addUser(secondStudent);
-            usersDb.createStudent(secondStudent);
+            usersDb.persistStudent(secondStudent);
             secondStudent.setAccount(userSharedAccount);
         });
 
@@ -214,19 +214,19 @@ public class UsersDbIT extends BaseTestCaseWithDatabaseAccess {
         thirdStudent.setEmail("valid-student-3@email.tmt");
         thirdStudent.setTeam(secondTeam);
         inTransaction(() -> {
-            coursesDb.createSection(firstSection);
+            coursesDb.persistSection(firstSection);
             course.addSection(firstSection);
-            coursesDb.createTeam(firstTeam);
+            coursesDb.persistTeam(firstTeam);
             firstSection.addTeam(firstTeam);
 
-            coursesDb.createSection(secondSection);
+            coursesDb.persistSection(secondSection);
             course.addSection(secondSection);
-            coursesDb.createTeam(secondTeam);
+            coursesDb.persistTeam(secondTeam);
             secondSection.addTeam(secondTeam);
 
-            usersDb.createStudent(firstStudent);
-            usersDb.createStudent(secondStudent);
-            usersDb.createStudent(thirdStudent);
+            usersDb.persistStudent(firstStudent);
+            usersDb.persistStudent(secondStudent);
+            usersDb.persistStudent(thirdStudent);
         });
 
         List<Student> expectedStudents = List.of(firstStudent, secondStudent);
@@ -259,19 +259,19 @@ public class UsersDbIT extends BaseTestCaseWithDatabaseAccess {
         thirdStudent.setEmail("valid-student-3@email.tmt");
         thirdStudent.setTeam(secondTeam);
         inTransaction(() -> {
-            coursesDb.createSection(firstSection);
+            coursesDb.persistSection(firstSection);
             course.addSection(firstSection);
-            coursesDb.createTeam(firstTeam);
+            coursesDb.persistTeam(firstTeam);
             firstSection.addTeam(firstTeam);
 
-            coursesDb.createSection(secondSection);
+            coursesDb.persistSection(secondSection);
             course.addSection(secondSection);
-            coursesDb.createTeam(secondTeam);
+            coursesDb.persistTeam(secondTeam);
             secondSection.addTeam(secondTeam);
 
-            usersDb.createStudent(firstStudent);
-            usersDb.createStudent(secondStudent);
-            usersDb.createStudent(thirdStudent);
+            usersDb.persistStudent(firstStudent);
+            usersDb.persistStudent(secondStudent);
+            usersDb.persistStudent(thirdStudent);
         });
 
         List<Student> expectedStudents = List.of(firstStudent, secondStudent);
@@ -295,10 +295,10 @@ public class UsersDbIT extends BaseTestCaseWithDatabaseAccess {
                 "typicalTenantId", student.getName(), student.getEmail());
 
         inTransaction(() -> {
-            coursesDb.createCourse(course2);
-            coursesDb.createSection(section);
+            coursesDb.persistCourse(course2);
+            coursesDb.persistSection(section);
             course2.addSection(section);
-            coursesDb.createTeam(team);
+            coursesDb.persistTeam(team);
             section.addTeam(team);
 
             team.addUser(student2);
@@ -307,7 +307,7 @@ public class UsersDbIT extends BaseTestCaseWithDatabaseAccess {
             student.setAccount(account);
             student2.setAccount(account);
             student2.setCourse(course2);
-            usersDb.createStudent(student2);
+            usersDb.persistStudent(student2);
         });
 
         List<Student> expectedStudents = List.of(student, student2);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Rename createXX -> persistXX and deleteXX to removeXX. This is better aligned with JPA primitives.

Also removed unnecessary assertions (and tests that test assertions) from the DB layer.