### PR TITLE
[#13721] Restrict giver type on instructor comment entity to instructors only

### DIFF
--- a/src/client/resources/SeedingDatabundle.json
+++ b/src/client/resources/SeedingDatabundle.json
@@ -3232,96 +3232,64 @@
   },
   "responseInstructorComments": {
     "comment1ToResp1ForQ1InSession1InCourse1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Excellent self-awareness, Mei Lin. Your identification of closures as a growth area is spot on. I recommend working through the supplementary exercises on environment model diagrams.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000901"
     },
     "comment1ToResp2ForQ1InSession1InCourse1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Good progress, Carlos. Consider pairing up with a classmate to practice environment model walkthroughs before the midterm.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000902"
     },
     "comment1ToResp1ForQ2InSession1InCourse1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Thank you for this evaluation. The peer feedback process is important for team development.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000904"
     },
     "comment1ToResp1ForQ1InSession1InCourse2": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000503"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000503"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000503",
+      "lastEditedById": "00000000-0000-4000-8000-000000000503",
       "commentText": "Great summary, Liam. Setting up the CI/CD pipeline early was a strong strategic decision. Keep documenting your design rationale in the developer guide.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000934"
     },
     "comment1ToResp1ForQ1InSession1InCourse3": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000505"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000505"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000505",
+      "lastEditedById": "00000000-0000-4000-8000-000000000505",
       "commentText": "Thoughtful feedback, Amara. Encouraging your partner to consider edge cases earlier is exactly the kind of constructive observation we value.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000961"
     },
     "comment1ToResp1ForQ1InSession4InCourse1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Thank you for the positive feedback. I will continue to incorporate more interactive examples in my teaching.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000925"
     },
     "comment1ToResp1ForQ2InSession2InCourse1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "This rubric evaluation aligns well with my own observations. Carlos has been steadily improving his communication in team settings.",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000919"
     },
     "comment1ToResp1ForQ1InSession2InCourse2": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000503"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000503"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000503",
+      "lastEditedById": "00000000-0000-4000-8000-000000000503",
       "commentText": "Good evaluation. I notice Anya has been very consistent in following coding standards. Encourage her to also share her documentation practices with the team.",
       "showCommentTo": [],
       "showGiverNameTo": [],

--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -433,6 +433,14 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         return getIdentifier(currentStudent, recipient.getIdentifier());
     }
 
+    private String getIdentifier(Student currentStudent, Instructor instructor) {
+        if (instructor == null) {
+            return "";
+        }
+
+        return getIdentifier(currentStudent, instructor.getEmail());
+    }
+
     private String getIdentifier(Student currentStudent, String user) {
         if (currentStudent.getEmail().equals(user)) {
             return "You";

--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -93,8 +93,8 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         resultsPage.verifyContributionStatistics(11, expectedContribStats);
 
         ______TS("verify comments");
-        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment1"), student);
-        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment2"), student);
+        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment1"));
+        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment2"));
         verifyParticipantCommentDetails(3, testData.feedbackResponses.get("qn3response1").getGiverComment());
         verifyParticipantCommentDetails(4, testData.feedbackResponses.get("qn4response1").getGiverComment());
 
@@ -129,8 +129,8 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
                 .forEach(question -> verifyResponseDetails(student, question));
 
         ______TS("preview results as student: visible comments shown");
-        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment1"), student);
-        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment2"), student);
+        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment1"));
+        verifyCommentDetails(2, testData.responseInstructorComments.get("qn2Comment2"));
         verifyParticipantCommentDetails(3, testData.feedbackResponses.get("qn3response1").getGiverComment());
         verifyParticipantCommentDetails(4, testData.feedbackResponses.get("qn4response1").getGiverComment());
 
@@ -201,15 +201,14 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
                 visibleRecipients);
     }
 
-    private void verifyCommentDetails(int questionNum, ResponseInstructorComment comment,
-            Student currentStudent) {
+    private void verifyCommentDetails(int questionNum, ResponseInstructorComment comment) {
         String editor = "";
         String giver = "";
 
         if (!Objects.equals(comment.getLastEditedBy(), comment.getGiver())) {
-            editor = getIdentifier(currentStudent, comment.getLastEditedBy());
+            editor = comment.getLastEditedBy().getDisplayName();
         }
-        giver = getIdentifier(currentStudent, comment.getGiver());
+        giver = comment.getGiver().getDisplayName();
         resultsPage.verifyCommentDetails(questionNum, giver, editor, comment.getCommentText());
     }
 
@@ -431,14 +430,6 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         }
 
         return getIdentifier(currentStudent, recipient.getIdentifier());
-    }
-
-    private String getIdentifier(Student currentStudent, Instructor instructor) {
-        if (instructor == null) {
-            return "";
-        }
-
-        return getIdentifier(currentStudent, instructor.getEmail());
     }
 
     private String getIdentifier(Student currentStudent, String user) {

--- a/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
@@ -1240,12 +1240,8 @@
   "responseInstructorComments": {
     "qn2Comment1": {
       "id": "00000000-0000-4000-8000-000000000961",
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor first comment to Alice",
       "showCommentTo": ["STUDENTS", "INSTRUCTORS"],
       "showGiverNameTo": ["STUDENTS", "INSTRUCTORS"],
@@ -1254,12 +1250,8 @@
     },
     "qn2Comment2": {
       "id": "00000000-0000-4000-8000-000000000962",
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor second comment to Alice",
       "showCommentTo": ["STUDENTS", "INSTRUCTORS"],
       "showGiverNameTo": ["STUDENTS", "INSTRUCTORS"],

--- a/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
@@ -508,12 +508,8 @@
   "responseInstructorComments": {
     "qn2Comment1": {
       "id": "00000000-0000-4000-8000-000000000971",
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor first comment to Alice",
       "showCommentTo": ["STUDENTS"],
       "showGiverNameTo": ["STUDENTS"],
@@ -521,12 +517,8 @@
     },
     "qn2Comment2": {
       "id": "00000000-0000-4000-8000-000000000972",
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor second comment to Alice",
       "showCommentTo": ["STUDENTS"],
       "showGiverNameTo": ["STUDENTS"],

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1291,7 +1291,7 @@ public class Logic {
      * @throws EntityDoesNotExistException if the comment does not exist
      */
     public ResponseInstructorComment updateResponseInstructorComment(UUID frcId,
-            ResponseInstructorCommentUpdateRequest updateRequest, ResponseGiver updater)
+            ResponseInstructorCommentUpdateRequest updateRequest, Instructor updater)
             throws EntityDoesNotExistException {
         return responseInstructorCommentsLogic.updateResponseInstructorComment(frcId, updateRequest, updater);
     }
@@ -1316,7 +1316,7 @@ public class Logic {
      * @throws EntityDoesNotExistException if the feedback response does not exist
      * @throws InvalidParametersException   if the comment is invalid
      */
-    public ResponseInstructorComment createResponseInstructorComment(UUID feedbackResponseId, ResponseGiver giver,
+    public ResponseInstructorComment createResponseInstructorComment(UUID feedbackResponseId, Instructor giver,
             String commentText, List<ViewerType> showCommentTo, List<ViewerType> showGiverNameTo)
             throws InvalidParametersException, EntityDoesNotExistException {
         return responseInstructorCommentsLogic.createResponseInstructorComment(

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -254,26 +254,20 @@ public final class DataBundleLogic {
             FeedbackResponse fr = responseMap.get(responseComment.getResponseId());
             fr.addResponseInstructorComment(responseComment);
 
-            ResponseGiver giver = responseComment.getGiver();
-            if (giver != null) {
-                if (giver.getGiverTeamId() != null) {
-                    Team team = teamsMap.get(giver.getGiverTeamId());
-                    responseComment.setGiver(new ResponseGiver(team));
-                } else if (giver.getGiverUserId() != null) {
-                    User user = usersMap.get(giver.getGiverUserId());
-                    responseComment.setGiver(new ResponseGiver(user));
+            if (responseComment.getGiverId() != null) {
+                User userGiver = usersMap.get(responseComment.getGiverId());
+                if (!(userGiver instanceof Instructor)) {
+                    throw new IllegalArgumentException("ResponseInstructorComment giver must be an instructor");
                 }
+                responseComment.setGiver((Instructor) userGiver);
             }
 
-            ResponseGiver lastEditedBy = responseComment.getLastEditedBy();
-            if (lastEditedBy.getGiverTeamId() != null) {
-                Team team = teamsMap.get(lastEditedBy.getGiverTeamId());
-                responseComment.setLastEditedBy(new ResponseGiver(team));
-            } else if (lastEditedBy.getGiverUserId() != null) {
-                User user = usersMap.get(lastEditedBy.getGiverUserId());
-                responseComment.setLastEditedBy(new ResponseGiver(user));
-            } else {
-                responseComment.setLastEditedBy(responseComment.getGiver());
+            if (responseComment.getLastEditedById() != null) {
+                User userLastEditedBy = usersMap.get(responseComment.getLastEditedById());
+                if (!(userLastEditedBy instanceof Instructor)) {
+                    throw new IllegalArgumentException("ResponseInstructorComment last editor must be an instructor");
+                }
+                responseComment.setLastEditedBy((Instructor) userLastEditedBy);
             }
         }
 

--- a/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
@@ -64,7 +64,7 @@ public final class ResponseInstructorCommentsLogic {
      * @throws EntityDoesNotExistException if the feedback response does not exist
      * @throws InvalidParametersException if the comment is invalid
      */
-    public ResponseInstructorComment createResponseInstructorComment(UUID feedbackResponseId, ResponseGiver giver,
+    public ResponseInstructorComment createResponseInstructorComment(UUID feedbackResponseId, Instructor giver,
             String commentText, List<ViewerType> showCommentTo, List<ViewerType> showGiverNameTo)
             throws InvalidParametersException, EntityDoesNotExistException {
         FeedbackResponse feedbackResponse = frLogic.getFeedbackResponse(feedbackResponseId);
@@ -111,7 +111,7 @@ public final class ResponseInstructorCommentsLogic {
      * @throws EntityDoesNotExistException if the comment does not exist
      */
     public ResponseInstructorComment updateResponseInstructorComment(UUID frcId,
-            ResponseInstructorCommentUpdateRequest updateRequest, ResponseGiver updater)
+            ResponseInstructorCommentUpdateRequest updateRequest, Instructor updater)
             throws EntityDoesNotExistException {
         ResponseInstructorComment comment = frcDb.getResponseInstructorComment(frcId);
         if (comment == null) {
@@ -216,14 +216,7 @@ public final class ResponseInstructorCommentsLogic {
                 Objects.equals(response.getGiver().getGiverUser(), user) && isVisibleToGiver;
 
         boolean isUserRelatedResponseCommentGiver = false;
-        ResponseGiver commentGiver = relatedComment.getGiver();
-        if (commentGiver.isGiverTeam() && user instanceof Student student) {
-            isUserRelatedResponseCommentGiver = student.getTeamId().equals(commentGiver.getGiverTeamId());
-        } else if (commentGiver.isGiverUser() && user instanceof Student student) {
-            isUserRelatedResponseCommentGiver = student.getId().equals(commentGiver.getGiverUserId());
-        } else if (commentGiver.isGiverUser() && user instanceof Instructor instructor) {
-            isUserRelatedResponseCommentGiver = instructor.getId().equals(commentGiver.getGiverUserId());
-        }
+        isUserRelatedResponseCommentGiver = Objects.equals(user, relatedComment.getGiver());
 
         boolean isUserStudentAndRelatedResponseCommentVisibleToStudents =
                 !isUserInstructor && checkIsResponseCommentVisibleTo(relatedComment, ViewerType.STUDENTS);
@@ -246,10 +239,8 @@ public final class ResponseInstructorCommentsLogic {
      */
     public boolean checkIsNameVisibleToUser(ResponseInstructorComment comment, FeedbackResponse response, User user) {
         //comment giver can always see
-        ResponseGiver commentGiver = comment.getGiver();
-        if (Objects.equals(user, commentGiver.getGiverUser()) || user instanceof Student student
-                && commentGiver.isGiverTeam()
-                && student.getTeam().equals(commentGiver.getGiverTeam())) {
+        Instructor commentGiver = comment.getGiver();
+        if (Objects.equals(user, commentGiver)) {
             return true;
         }
 

--- a/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/ResponseInstructorCommentsLogic.java
@@ -215,8 +215,7 @@ public final class ResponseInstructorCommentsLogic {
         boolean isUserResponseGiverAndRelatedResponseCommentVisibleToGivers =
                 Objects.equals(response.getGiver().getGiverUser(), user) && isVisibleToGiver;
 
-        boolean isUserRelatedResponseCommentGiver = false;
-        isUserRelatedResponseCommentGiver = Objects.equals(user, relatedComment.getGiver());
+        boolean isUserResponseCommentGiver = Objects.equals(user, relatedComment.getGiver());
 
         boolean isUserStudentAndRelatedResponseCommentVisibleToStudents =
                 !isUserInstructor && checkIsResponseCommentVisibleTo(relatedComment, ViewerType.STUDENTS);
@@ -224,7 +223,7 @@ public final class ResponseInstructorCommentsLogic {
         return isUserInstructorAndRelatedResponseCommentVisibleToInstructors
                 || isUserResponseRecipientAndRelatedResponseCommentVisibleToRecipients
                 || isUserResponseGiverAndRelatedResponseCommentVisibleToGivers
-                || isUserRelatedResponseCommentGiver
+                || isUserResponseCommentGiver
                 || isUserStudentAndRelatedResponseCommentVisibleToStudents;
     }
 

--- a/src/main/java/teammates/storage/entity/ResponseInstructorComment.java
+++ b/src/main/java/teammates/storage/entity/ResponseInstructorComment.java
@@ -4,13 +4,9 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.persistence.AssociationOverride;
-import jakarta.persistence.AssociationOverrides;
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.AttributeOverrides;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -41,27 +37,21 @@ public class ResponseInstructorComment extends BaseEntity {
     @Column(insertable = false, updatable = false)
     private UUID responseId;
 
-    @Embedded
-    private ResponseGiver giver;
+    @Column(nullable = false, insertable = false, updatable = false)
+    private UUID giverId;
 
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(
-                    name = "giverUserId",
-                    column = @Column(name = "lastEditedByUserId", insertable = false, updatable = false)),
-            @AttributeOverride(
-                    name = "giverTeamId",
-                    column = @Column(name = "lastEditedByTeamId", insertable = false, updatable = false))
-    })
-    @AssociationOverrides({
-            @AssociationOverride(
-                    name = "giverUser",
-                    joinColumns = @JoinColumn(name = "lastEditedByUserId")),
-            @AssociationOverride(
-                    name = "giverTeam",
-                    joinColumns = @JoinColumn(name = "lastEditedByTeamId"))
-    })
-    private ResponseGiver lastEditedBy;
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "giverId", nullable = false)
+    private Instructor giver;
+
+    @Column(insertable = false, updatable = false)
+    private UUID lastEditedById;
+
+    @ManyToOne
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @JoinColumn(name = "lastEditedById")
+    private Instructor lastEditedBy;
 
     @Column(nullable = false)
     private String commentText;
@@ -82,9 +72,9 @@ public class ResponseInstructorComment extends BaseEntity {
     }
 
     public ResponseInstructorComment(
-            ResponseGiver giver, String commentText,
+            Instructor giver, String commentText,
             List<ViewerType> showCommentTo, List<ViewerType> showGiverNameTo,
-            ResponseGiver lastEditedBy
+            @Nullable Instructor lastEditedBy
     ) {
         this.setGiver(giver);
         this.setCommentText(commentText);
@@ -118,12 +108,20 @@ public class ResponseInstructorComment extends BaseEntity {
         this.responseId = feedbackResponse == null ? null : feedbackResponse.getId();
     }
 
-    public ResponseGiver getGiver() {
+    public UUID getGiverId() {
+        return giverId;
+    }
+
+    public Instructor getGiver() {
         return giver;
     }
 
-    public void setGiver(ResponseGiver giver) {
+    /**
+     * Sets the giver of the response comment.
+     */
+    public void setGiver(Instructor giver) {
         this.giver = giver;
+        this.giverId = giver == null ? null : giver.getId();
     }
 
     public String getCommentText() {
@@ -159,17 +157,22 @@ public class ResponseInstructorComment extends BaseEntity {
     }
 
     /**
-     * Gets the last editor of the response comment. If the last editor is not set, returns an empty ResponseGiver.
+     * Gets the last editor of the response comment.
      */
-    public ResponseGiver getLastEditedBy() {
-        if (lastEditedBy == null) {
-            return new ResponseGiver();
-        }
+    public @Nullable Instructor getLastEditedBy() {
         return lastEditedBy;
     }
 
-    public void setLastEditedBy(ResponseGiver lastEditedBy) {
+    public UUID getLastEditedById() {
+        return lastEditedById;
+    }
+
+    /**
+     * Sets the last editor of the response comment.
+     */
+    public void setLastEditedBy(@Nullable Instructor lastEditedBy) {
         this.lastEditedBy = lastEditedBy;
+        this.lastEditedById = lastEditedBy == null ? null : lastEditedBy.getId();
     }
 
     /**

--- a/src/main/java/teammates/ui/output/ResponseInstructorCommentData.java
+++ b/src/main/java/teammates/ui/output/ResponseInstructorCommentData.java
@@ -28,8 +28,9 @@ public class ResponseInstructorCommentData implements ApiOutput {
     }
 
     public ResponseInstructorCommentData(ResponseInstructorComment frc) {
-        this.commentGiverName = frc.getGiver().getName();
-        this.lastEditorName = frc.getLastEditedBy() == null ? Const.UNKNOWN_USER : frc.getLastEditedBy().getName();
+        this.commentGiverName = frc.getGiver().getDisplayName();
+        this.lastEditorName = frc.getLastEditedBy() == null
+                ? Const.UNKNOWN_USER : frc.getLastEditedBy().getDisplayName();
         this.responseInstructorCommentId = frc.getId();
         this.commentText = frc.getCommentText();
         this.showGiverNameTo = convertToFeedbackVisibilityType(frc.getShowGiverNameTo());

--- a/src/main/java/teammates/ui/output/ResponseInstructorCommentData.java
+++ b/src/main/java/teammates/ui/output/ResponseInstructorCommentData.java
@@ -28,8 +28,8 @@ public class ResponseInstructorCommentData implements ApiOutput {
     }
 
     public ResponseInstructorCommentData(ResponseInstructorComment frc) {
-        this.commentGiverName = frc.getGiver().getDisplayName();
-        this.lastEditorName = frc.getLastEditedBy().getDisplayName();
+        this.commentGiverName = frc.getGiver().getName();
+        this.lastEditorName = frc.getLastEditedBy() == null ? Const.UNKNOWN_USER : frc.getLastEditedBy().getName();
         this.responseInstructorCommentId = frc.getId();
         this.commentText = frc.getCommentText();
         this.showGiverNameTo = convertToFeedbackVisibilityType(frc.getShowGiverNameTo());

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -72,11 +72,9 @@ public class CreateResponseInstructorCommentAction extends Action {
 
         String courseId = feedbackResponse.getFeedbackQuestion().getCourseId();
         Instructor instructor = getInstructorFromRequest(courseId);
-        ResponseGiver giverRg = new ResponseGiver(instructor);
-
         try {
             ResponseInstructorComment createdComment = logic.createResponseInstructorComment(
-                    feedbackResponseId, giverRg, comment.getCommentText(),
+                    feedbackResponseId, instructor, comment.getCommentText(),
                     comment.getShowCommentTo(), comment.getShowGiverNameTo());
             HibernateUtil.flushSession();
             return new JsonResult(new ResponseInstructorCommentData(createdComment));

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -38,7 +38,7 @@ public class DeleteResponseInstructorCommentAction extends Action {
             throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
         }
 
-        if (comment.getGiver().equals(new ResponseGiver(instructor))) {
+        if (comment.getGiver().equals(instructor)) {
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -6,7 +6,6 @@ import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -220,20 +219,20 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that comment is created by feedback participant.
+     * Verifies that comment is created by instructor.
      *
      * @param frc comment to be accessed
-     * @param participant the response giver who is trying to access the comment
+     * @param instructor the instructor who is trying to access the comment
      */
-    void verifyOwnership(ResponseInstructorComment frc, ResponseGiver participant)
+    void verifyOwnership(ResponseInstructorComment frc, Instructor instructor)
             throws UnauthorizedAccessException {
         verifyNotNull(frc, "feedback response comment");
         verifyNotNull(frc.getGiver(), "feedback response comment giver");
-        verifyNotNull(participant, "comment giver");
+        verifyNotNull(instructor, "comment giver");
 
-        if (!frc.getGiver().equals(participant)) {
+        if (!frc.getGiver().equals(instructor)) {
             throw new UnauthorizedAccessException("Comment [" + frc.getId() + "] is not accessible to "
-                    + participant);
+                    + instructor);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -8,7 +8,6 @@ import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -45,7 +44,7 @@ public class UpdateResponseInstructorCommentAction extends Action {
         if (instructor == null) {
             throw new UnauthorizedAccessException("Trying to access system using a non-existent instructor entity");
         }
-        if (comment.getGiver().equals(new ResponseGiver(instructor))) {
+        if (comment.getGiver().equals(instructor)) {
             return;
         }
         gateKeeper.verifyAccessible(instructor, session, response.getGiver().getSectionName(),
@@ -67,11 +66,10 @@ public class UpdateResponseInstructorCommentAction extends Action {
 
         String courseId = comment.getFeedbackResponse().getFeedbackQuestion().getCourseId();
         Instructor instructor = getInstructorFromRequest(courseId);
-        ResponseGiver updater = new ResponseGiver(instructor);
 
         try {
             ResponseInstructorComment updatedResponseInstructorComment =
-                    logic.updateResponseInstructorComment(responseInstructorCommentId, updateRequest, updater);
+                    logic.updateResponseInstructorComment(responseInstructorCommentId, updateRequest, instructor);
             return new JsonResult(new ResponseInstructorCommentData(updatedResponseInstructorComment));
         } catch (EntityDoesNotExistException e) {
             throw new EntityNotFoundException(e);

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -4229,12 +4229,8 @@
   },
   "responseInstructorComments": {
     "comment1FromT1C1ToR1Q2S1C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Alice, good to know that you liked applying software engineering skills in the project. Don't forget to use the project to practice communication skills too.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "INSTRUCTORS"],
@@ -4243,12 +4239,8 @@
       "responseId": "00000000-0000-4000-8000-000000000701"
     },
     "comment1FromT1C1ToR1Q5S1C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Completely agree, the application does look pretty.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "INSTRUCTORS"],
@@ -4257,12 +4249,8 @@
       "responseId": "00000000-0000-4000-8000-000000000702"
     },
     "comment1FromT1C1ToR3Q5S1C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Alice, He's one of the best designers in our institute and always amazes everyone with his work.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "INSTRUCTORS"],
@@ -4271,12 +4259,8 @@
       "responseId": "00000000-0000-4000-8000-000000000703"
     },
     "comment1FromT1C1ToR2Q2S1C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Hoping you keep using them on future projects.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "INSTRUCTORS"],
@@ -4285,12 +4269,8 @@
       "responseId": "00000000-0000-4000-8000-000000000704"
     },
     "comment1FromT1C1ToR1Q2S2C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Nice work Alice, Impressed by clean, portable and well-documented code.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
@@ -4299,12 +4279,8 @@
       "responseId": "00000000-0000-4000-8000-000000000705"
     },
     "comment1FromT1C1ToR2Q2S2C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Although there are some loopholes in UI, But overall looks good.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
@@ -4313,12 +4289,8 @@
       "responseId": "00000000-0000-4000-8000-000000000706"
     },
     "comment1FromT1C1ToR5Q2S2C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Well, Being your first team project always takes some time. I hope you had nice experience working with the team.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
@@ -4327,12 +4299,8 @@
       "responseId": "00000000-0000-4000-8000-000000000707"
     },
     "comment1FromT1C1ToR6Q2S2C1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000101"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000101",
+      "lastEditedById": "00000000-0000-4000-8000-000000000101",
       "commentText": "<p>Design could have been more interactive.</p>",
       "showCommentTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],
       "showGiverNameTo": ["GIVER", "RECEIVER", "RECEIVER_TEAM_MEMBERS", "OWN_TEAM_MEMBERS", "INSTRUCTORS"],

--- a/src/main/resources/db/changelog/migrations/20260605-frc-instructor-giver-editor.xml
+++ b/src/main/resources/db/changelog/migrations/20260605-frc-instructor-giver-editor.xml
@@ -1,0 +1,124 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="codex" id="20260605-frc-instructor-giver-editor-1">
+        <sql>
+            DELETE FROM response_instructor_comments ric
+            WHERE ric.giver_team_id IS NOT NULL
+                OR NOT EXISTS (
+                    SELECT 1
+                    FROM instructors i
+                    WHERE i.id = ric.giver_user_id
+                )
+        </sql>
+
+        <sql>
+            UPDATE response_instructor_comments ric
+            SET last_edited_by_user_id = NULL
+            WHERE ric.last_edited_by_user_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM instructors i
+                    WHERE i.id = ric.last_edited_by_user_id
+                )
+        </sql>
+
+        <dropForeignKeyConstraint baseTableName="response_instructor_comments"
+            constraintName="fk_frc_giver_user"/>
+        <dropForeignKeyConstraint baseTableName="response_instructor_comments"
+            constraintName="fk_frc_giver_team"/>
+        <dropForeignKeyConstraint baseTableName="response_instructor_comments"
+            constraintName="fk_frc_last_edited_by_user"/>
+        <dropForeignKeyConstraint baseTableName="response_instructor_comments"
+            constraintName="fk_frc_last_edited_by_team"/>
+
+        <dropColumn tableName="response_instructor_comments" columnName="giver_team_id"/>
+        <dropColumn tableName="response_instructor_comments" columnName="last_edited_by_team_id"/>
+        <renameColumn tableName="response_instructor_comments"
+            oldColumnName="giver_user_id"
+            newColumnName="giver_id"
+            columnDataType="UUID"/>
+        <renameColumn tableName="response_instructor_comments"
+            oldColumnName="last_edited_by_user_id"
+            newColumnName="last_edited_by_id"
+            columnDataType="UUID"/>
+
+        <addNotNullConstraint tableName="response_instructor_comments"
+            columnName="giver_id"
+            columnDataType="UUID"/>
+
+        <addForeignKeyConstraint baseColumnNames="giver_id"
+            baseTableName="response_instructor_comments"
+            constraintName="fk_ric_giver"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="CASCADE"
+            referencedColumnNames="id"
+            referencedTableName="instructors"
+            validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="last_edited_by_id"
+            baseTableName="response_instructor_comments"
+            constraintName="fk_ric_last_edited_by"
+            deferrable="false"
+            initiallyDeferred="false"
+            onDelete="SET NULL"
+            referencedColumnNames="id"
+            referencedTableName="instructors"
+            validate="true"/>
+
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="response_instructor_comments"
+                constraintName="fk_ric_giver"/>
+            <dropForeignKeyConstraint baseTableName="response_instructor_comments"
+                constraintName="fk_ric_last_edited_by"/>
+
+            <dropNotNullConstraint tableName="response_instructor_comments"
+                columnName="giver_id"
+                columnDataType="UUID"/>
+
+            <renameColumn tableName="response_instructor_comments"
+                oldColumnName="giver_id"
+                newColumnName="giver_user_id"
+                columnDataType="UUID"/>
+            <renameColumn tableName="response_instructor_comments"
+                oldColumnName="last_edited_by_id"
+                newColumnName="last_edited_by_user_id"
+                columnDataType="UUID"/>
+            <addColumn tableName="response_instructor_comments">
+                <column name="giver_team_id" type="UUID"/>
+            </addColumn>
+            <addColumn tableName="response_instructor_comments">
+                <column name="last_edited_by_team_id" type="UUID"/>
+            </addColumn>
+
+            <addForeignKeyConstraint constraintName="fk_frc_giver_user"
+                baseTableName="response_instructor_comments"
+                baseColumnNames="giver_user_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                onDelete="CASCADE"/>
+            <addForeignKeyConstraint constraintName="fk_frc_giver_team"
+                baseTableName="response_instructor_comments"
+                baseColumnNames="giver_team_id"
+                referencedTableName="teams"
+                referencedColumnNames="id"
+                onDelete="CASCADE"/>
+            <addForeignKeyConstraint constraintName="fk_frc_last_edited_by_user"
+                baseTableName="response_instructor_comments"
+                baseColumnNames="last_edited_by_user_id"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                onDelete="SET NULL"/>
+            <addForeignKeyConstraint constraintName="fk_frc_last_edited_by_team"
+                baseTableName="response_instructor_comments"
+                baseColumnNames="last_edited_by_team_id"
+                referencedTableName="teams"
+                referencedColumnNames="id"
+                onDelete="SET NULL"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/teammates/logic/core/DataBundleLogicIT.java
+++ b/src/test/java/teammates/logic/core/DataBundleLogicIT.java
@@ -210,10 +210,9 @@ public class DataBundleLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("verify feedback response comments deserialized correctly");
         ResponseInstructorComment actualComment1 = dataBundle.responseInstructorComments.get("comment1ToResponse1ForQ1");
-        ResponseGiver commentGiver = new ResponseGiver(actualInstructor1);
-        ResponseInstructorComment expectedComment1 = new ResponseInstructorComment(commentGiver,
+        ResponseInstructorComment expectedComment1 = new ResponseInstructorComment(actualInstructor1,
                 "Instructor 1 comment to student 1 self feedback",
-                new ArrayList<>(), new ArrayList<>(), commentGiver);
+                new ArrayList<>(), new ArrayList<>(), actualInstructor1);
         expectedResponse1.addResponseInstructorComment(expectedComment1);
         expectedComment1.setId(actualComment1.getId());
         assertEquals(expectedComment1, actualComment1);

--- a/src/test/java/teammates/logic/core/ResponseInstructorCommentsLogicTest.java
+++ b/src/test/java/teammates/logic/core/ResponseInstructorCommentsLogicTest.java
@@ -22,7 +22,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.storage.api.ResponseInstructorCommentsDb;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.test.BaseTestCase;
 import teammates.ui.output.CommentVisibilityType;
@@ -72,7 +71,7 @@ public class ResponseInstructorCommentsLogicTest extends BaseTestCase {
             throws InvalidParametersException, EntityDoesNotExistException {
         ResponseInstructorComment comment = getTypicalResponseComment(TYPICAL_ID);
         FeedbackResponse feedbackResponse = comment.getFeedbackResponse();
-        ResponseGiver giver = getRandomInstructorGiver();
+        Instructor giver = getRandomInstructor();
 
         when(frLogic.getFeedbackResponse(feedbackResponse.getId())).thenReturn(feedbackResponse);
         when(frcDb.persistResponseInstructorComment(any(ResponseInstructorComment.class)))
@@ -115,7 +114,7 @@ public class ResponseInstructorCommentsLogicTest extends BaseTestCase {
         ResponseInstructorCommentUpdateRequest updateRequest = new ResponseInstructorCommentUpdateRequest(
                 updatedCommentText, showCommentTo, showGiverNameTo);
         ResponseInstructorComment updatedComment = frcLogic.updateResponseInstructorComment(TYPICAL_ID, updateRequest,
-                getRandomInstructorGiver());
+                getRandomInstructor());
 
         verify(frcDb, times(1)).getResponseInstructorComment(TYPICAL_ID);
 
@@ -150,7 +149,7 @@ public class ResponseInstructorCommentsLogicTest extends BaseTestCase {
 
         EntityDoesNotExistException ex = assertThrows(EntityDoesNotExistException.class,
                 () -> frcLogic.updateResponseInstructorComment(nonExistentId, updateRequest,
-                        getRandomInstructorGiver()
+                        getRandomInstructor()
                 ));
 
         assertEquals("Trying to update a feedback response comment that does not exist.", ex.getMessage());
@@ -162,9 +161,9 @@ public class ResponseInstructorCommentsLogicTest extends BaseTestCase {
         return comment;
     }
 
-    private ResponseGiver getRandomInstructorGiver() {
+    private Instructor getRandomInstructor() {
         Instructor instructor = getTypicalInstructor();
         instructor.setId(UUID.randomUUID());
-        return new ResponseGiver(instructor);
+        return instructor;
     }
 }

--- a/src/test/java/teammates/storage/api/ResponseInstructorCommentsDbTest.java
+++ b/src/test/java/teammates/storage/api/ResponseInstructorCommentsDbTest.java
@@ -11,7 +11,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.test.GroupNames;
 
@@ -94,13 +93,12 @@ public class ResponseInstructorCommentsDbTest extends BaseDbTestcase {
             FeedbackResponse feedbackResponse, Instructor instructor, UUID responseInstructorCommentId) {
         assertNotNull(feedbackResponse);
         assertNotNull(instructor);
-        ResponseGiver giver = new ResponseGiver(instructor);
         ResponseInstructorComment comment = new ResponseInstructorComment(
-                giver,
+                instructor,
                 "Comment",
                 List.of(ViewerType.GIVER, ViewerType.RECEIVER, ViewerType.INSTRUCTORS),
                 List.of(ViewerType.GIVER, ViewerType.RECEIVER, ViewerType.INSTRUCTORS),
-                giver);
+                instructor);
         comment.setId(responseInstructorCommentId);
         feedbackResponse.addResponseInstructorComment(comment);
         return comment;

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -161,7 +161,7 @@ public class BaseTestCase {
         FeedbackSession typicalFeedbackSession = getTypicalFeedbackSessionForCourse(getTypicalCourse());
         FeedbackQuestion typicalFeedbackQuestion = getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
         FeedbackResponse typicalFeedbackResponse = getTypicalFeedbackResponseForQuestion(typicalFeedbackQuestion);
-        ResponseGiver commentGiver = new ResponseGiver(getTypicalStudent());
+        Instructor commentGiver = getTypicalInstructor();
         ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(commentGiver,
                 "typical-comment", List.of(ViewerType.GIVER, ViewerType.INSTRUCTORS),
                 List.of(ViewerType.RECEIVER, ViewerType.INSTRUCTORS), commentGiver);

--- a/src/test/java/teammates/test/scenariobuilder/GivenResponseInstructorComment.java
+++ b/src/test/java/teammates/test/scenariobuilder/GivenResponseInstructorComment.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 
 /**
@@ -39,7 +38,7 @@ public final class GivenResponseInstructorComment extends GivenBase<ResponseInst
         Instructor instructor = given.getOrCreate(
                 instructorAlias, given.dataBundle.instructors, (String iAlias) -> given.instructor(iAlias,
                         i -> i.course(getFeedbackResponseCourseAlias())));
-        entity.setGiver(new ResponseGiver(instructor));
+        entity.setGiver(instructor);
         return this;
     }
 
@@ -47,11 +46,11 @@ public final class GivenResponseInstructorComment extends GivenBase<ResponseInst
      * Sets an instructor as the last editor.
      */
     public GivenResponseInstructorComment lastEditedBy(String instructorAlias) {
-        assert isLastEditedByEmpty() : "Last editor has already been set for this comment";
+        assert entity.getLastEditedBy() == null : "Last editor has already been set for this comment";
         Instructor instructor = given.getOrCreate(
                 instructorAlias, given.dataBundle.instructors, (String iAlias) -> given.instructor(iAlias,
                         i -> i.course(getFeedbackResponseCourseAlias())));
-        entity.setLastEditedBy(new ResponseGiver(instructor));
+        entity.setLastEditedBy(instructor);
         return this;
     }
 
@@ -89,7 +88,7 @@ public final class GivenResponseInstructorComment extends GivenBase<ResponseInst
             this.giver("default:response-instructor-comment-giver:" + entity.getId());
         }
 
-        if (isLastEditedByEmpty()) {
+        if (entity.getLastEditedBy() == null) {
             entity.setLastEditedBy(entity.getGiver());
         }
 
@@ -110,10 +109,6 @@ public final class GivenResponseInstructorComment extends GivenBase<ResponseInst
 
     private static List<ViewerType> viewerTypesList(ViewerType... viewerTypes) {
         return new ArrayList<>(Arrays.asList(viewerTypes));
-    }
-
-    private boolean isLastEditedByEmpty() {
-        return !entity.getLastEditedBy().isGiverUser() && !entity.getLastEditedBy().isGiverTeam();
     }
 
     private ResponseInstructorComment defaultResponseInstructorComment(UUID responseInstructorCommentId) {

--- a/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionIT.java
@@ -59,7 +59,7 @@ public class CreateResponseInstructorCommentActionIT extends BaseActionIT<Create
                 .filter(frc -> "Instructor result comment".equals(frc.getCommentText()))
                 .findFirst()
                 .orElseThrow());
-        assertEquals(instructor, comment.getGiver().getGiverUser());
+        assertEquals(instructor, comment.getGiver());
     }
 
     @Test(groups = GroupNames.INTEGRATION)

--- a/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionTest.java
@@ -515,18 +515,17 @@ public class CreateResponseInstructorCommentActionTest extends BaseActionTest<Cr
 
     private void mockCreateResponseInstructorComment(ResponseInstructorComment comment) throws Exception {
         when(mockLogic.createResponseInstructorComment(
-                any(UUID.class), any(ResponseGiver.class), any(String.class), any(), any()))
+                any(UUID.class), any(Instructor.class), any(String.class), any(), any()))
                 .thenReturn(comment);
     }
 
     private ResponseInstructorComment getTypicalCommentForInstructorResult() {
-        ResponseGiver giver = new ResponseGiver(typicalInstructor);
         ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(
-                giver,
+                typicalInstructor,
                 typicalRequestBody.getCommentText(),
                 typicalRequestBody.getShowCommentTo(),
                 typicalRequestBody.getShowGiverNameTo(),
-                giver);
+                typicalInstructor);
         typicalFeedbackResponse.addResponseInstructorComment(responseInstructorComment);
         responseInstructorComment.setId(UUID.fromString("00000000-0000-4000-8000-000000000001"));
         responseInstructorComment.setCreatedAt(Instant.EPOCH);

--- a/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionIT.java
@@ -62,14 +62,14 @@ public class DeleteResponseInstructorCommentActionIT extends BaseActionIT<Delete
         };
         Instructor instructorWhoGiveComment = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        assertEquals(instructorWhoGiveComment, frc.getGiver().getGiverUser());
+        assertEquals(instructorWhoGiveComment, frc.getGiver());
         loginAsInstructor(instructorWhoGiveComment.getGoogleId());
         verifyCanAccess(submissionParams);
 
         ______TS("Different instructor of same course cannot delete comment");
 
         Instructor differentInstructorInSameCourse = typicalBundle.instructors.get("instructor2OfCourse1");
-        assertNotEquals(differentInstructorInSameCourse, frc.getGiver().getGiverUser());
+        assertNotEquals(differentInstructorInSameCourse, frc.getGiver());
         loginAsInstructor(differentInstructorInSameCourse.getGoogleId());
         verifyCannotAccess(submissionParams);
     }

--- a/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionTest.java
@@ -21,12 +21,8 @@ import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
-import teammates.storage.entity.ResponseRecipient;
-import teammates.storage.entity.Section;
 import teammates.storage.entity.Student;
-import teammates.storage.entity.Team;
 import teammates.ui.output.MessageOutput;
 
 /**
@@ -37,8 +33,6 @@ public class DeleteResponseInstructorCommentActionTest extends BaseActionTest<De
     private Course typicalCourse;
     private Instructor typicalInstructor;
     private Student typicalStudent;
-    private FeedbackQuestion typicalFeedbackQuestion;
-    private FeedbackResponse typicalFeedbackResponse;
 
     @Override
     String getActionUri() {
@@ -55,12 +49,6 @@ public class DeleteResponseInstructorCommentActionTest extends BaseActionTest<De
         typicalCourse = getTypicalCourse();
         typicalInstructor = getTypicalInstructor();
         typicalStudent = getTypicalStudent();
-        FeedbackSession typicalFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
-        typicalFeedbackSession.setStartTime(Instant.now().minusSeconds(100));
-        typicalFeedbackSession.setEndTime(Instant.now());
-        typicalFeedbackSession.setSessionVisibleFromTime(Instant.now());
-        typicalFeedbackQuestion = getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
-        typicalFeedbackResponse = getTypicalFeedbackResponseForQuestion(typicalFeedbackQuestion);
     }
 
     @Test
@@ -262,119 +250,21 @@ public class DeleteResponseInstructorCommentActionTest extends BaseActionTest<De
         verifyCannotAccess(params);
     }
 
-    @Test
-    void testAccessControl_instructorWithCorrectPrivilege_canAccessCrossSectionComment() {
-        ResponseInstructorComment typicalResponseInstructorComment = getTypicalCommentFromTeam(typicalStudent.getTeam());
-
-        Instructor instructorWithPrivilege = getTypicalInstructor();
-        instructorWithPrivilege.setEmail("instructorWithPrivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section A",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        privileges.updatePrivilege("Section B",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        instructorWithPrivilege.setPrivileges(privileges);
-
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalResponseInstructorComment.getId().toString(),
-        };
-
-        when(mockLogic.getResponseInstructorComment(typicalResponseInstructorComment.getId()))
-                .thenReturn(typicalResponseInstructorComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
-                .thenReturn(instructorWithPrivilege);
-
-        loginAsInstructor(instructorWithPrivilege.getGoogleId());
-
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testAccessControl_instructorWithoutGiverSectionPrivilege_cannotAccessCrossSectionComment() {
-        ResponseInstructorComment typicalResponseInstructorComment = getTypicalCommentFromTeam(typicalStudent.getTeam());
-
-        Instructor instructorWithoutPrivilege = getTypicalInstructor();
-        instructorWithoutPrivilege.setEmail("instructorWithPrivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section B",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        instructorWithoutPrivilege.setPrivileges(privileges);
-
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalResponseInstructorComment.getId().toString(),
-        };
-
-        when(mockLogic.getResponseInstructorComment(typicalResponseInstructorComment.getId()))
-                .thenReturn(typicalResponseInstructorComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
-                .thenReturn(instructorWithoutPrivilege);
-
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testAccessControl_instructorWithoutRecipientSectionPrivilege_cannotAccessCrossSectionComment() {
-        ResponseInstructorComment typicalResponseInstructorComment = getTypicalCommentFromTeam(typicalStudent.getTeam());
-
-        Instructor instructorWithoutPrivilege = getTypicalInstructor();
-        instructorWithoutPrivilege.setEmail("instructorWithPrivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section A",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        instructorWithoutPrivilege.setPrivileges(privileges);
-
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalResponseInstructorComment.getId().toString(),
-        };
-
-        when(mockLogic.getResponseInstructorComment(typicalResponseInstructorComment.getId()))
-                .thenReturn(typicalResponseInstructorComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
-                .thenReturn(instructorWithoutPrivilege);
-
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
-
-        verifyCannotAccess(params);
-    }
-
     private ResponseInstructorComment getTypicalCommentFromInstructor() {
-        ResponseGiver giver = new ResponseGiver(typicalInstructor);
         ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(
-                giver,
+                typicalInstructor,
                 "typical comment",
                 Arrays.asList(ViewerType.INSTRUCTORS),
                 Arrays.asList(ViewerType.INSTRUCTORS),
-                giver);
+                typicalInstructor);
+        FeedbackSession typicalFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
+        typicalFeedbackSession.setStartTime(Instant.now().minusSeconds(100));
+        typicalFeedbackSession.setEndTime(Instant.now());
+        typicalFeedbackSession.setSessionVisibleFromTime(Instant.now());
+        FeedbackQuestion typicalFeedbackQuestion = getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
+        FeedbackResponse typicalFeedbackResponse = getTypicalFeedbackResponseForQuestion(typicalFeedbackQuestion);
         typicalFeedbackResponse.addResponseInstructorComment(responseInstructorComment);
         responseInstructorComment.setId(UUID.fromString("00000000-0000-4000-8000-000000000002"));
-        responseInstructorComment.setCreatedAt(Instant.EPOCH);
-        responseInstructorComment.setUpdatedAt(Instant.EPOCH);
-        return responseInstructorComment;
-    }
-
-    private ResponseInstructorComment getTypicalCommentFromTeam(Team team) {
-        Section sectionA = new Section("Section A");
-        typicalCourse.addSection(sectionA);
-        Section sectionB = new Section("Section B");
-        typicalCourse.addSection(sectionB);
-        Team giverTeam = new Team("Section A");
-        giverTeam.setSection(sectionA);
-        Team recipientTeam = new Team("Section B");
-        recipientTeam.setSection(sectionB);
-        typicalFeedbackResponse = FeedbackResponse.makeResponse(
-                new ResponseGiver(giverTeam), new ResponseRecipient(recipientTeam), getTypicalFeedbackResponseDetails());
-        typicalFeedbackQuestion.addFeedbackResponse(typicalFeedbackResponse);
-        ResponseGiver giver = new ResponseGiver(team);
-        ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(
-                giver,
-                "typical comment",
-                Arrays.asList(ViewerType.INSTRUCTORS),
-                Arrays.asList(ViewerType.INSTRUCTORS),
-                giver);
-        typicalFeedbackResponse.addResponseInstructorComment(responseInstructorComment);
-        responseInstructorComment.setId(UUID.fromString("00000000-0000-4000-8000-000000000004"));
         responseInstructorComment.setCreatedAt(Instant.EPOCH);
         responseInstructorComment.setUpdatedAt(Instant.EPOCH);
         return responseInstructorComment;

--- a/src/test/java/teammates/ui/webapi/UpdateResponseInstructorCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateResponseInstructorCommentActionTest.java
@@ -23,12 +23,7 @@ import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
-import teammates.storage.entity.ResponseRecipient;
-import teammates.storage.entity.Section;
-import teammates.storage.entity.Student;
-import teammates.storage.entity.Team;
 import teammates.ui.output.CommentVisibilityType;
 import teammates.ui.output.ResponseInstructorCommentData;
 import teammates.ui.request.ResponseInstructorCommentUpdateRequest;
@@ -40,9 +35,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
 
     private Course typicalCourse;
     private Instructor typicalInstructor;
-    private Student typicalStudent;
     private FeedbackSession typicalFeedbackSession;
-    private FeedbackQuestion typicalFeedbackQuestion;
     private FeedbackResponse typicalFeedbackResponse;
 
     @Override
@@ -59,12 +52,11 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
     void setUpMethod() {
         typicalCourse = getTypicalCourse();
         typicalInstructor = getTypicalInstructor();
-        typicalStudent = getTypicalStudent();
         typicalFeedbackSession = getTypicalFeedbackSessionForCourse(typicalCourse);
         typicalFeedbackSession.setStartTime(Instant.now().minusSeconds(100));
         typicalFeedbackSession.setEndTime(Instant.now());
         typicalFeedbackSession.setSessionVisibleFromTime(Instant.now());
-        typicalFeedbackQuestion = getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
+        FeedbackQuestion typicalFeedbackQuestion = getTypicalFeedbackQuestionForSession(typicalFeedbackSession);
         typicalFeedbackResponse = getTypicalFeedbackResponseForQuestion(typicalFeedbackQuestion);
     }
 
@@ -90,7 +82,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateResponseInstructorComment(any(UUID.class), any(ResponseInstructorCommentUpdateRequest.class),
-                any(ResponseGiver.class))).thenReturn(updatedComment);
+                any(Instructor.class))).thenReturn(updatedComment);
 
         UpdateResponseInstructorCommentAction action = getAction(updateRequest, params);
         JsonResult r = getJsonResult(action);
@@ -119,7 +111,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateResponseInstructorComment(any(UUID.class), any(ResponseInstructorCommentUpdateRequest.class),
-                any(ResponseGiver.class))).thenReturn(updatedComment);
+                any(Instructor.class))).thenReturn(updatedComment);
 
         UpdateResponseInstructorCommentAction action = getAction(updateRequest, params);
         JsonResult r = getJsonResult(action);
@@ -148,7 +140,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateResponseInstructorComment(any(UUID.class), any(ResponseInstructorCommentUpdateRequest.class),
-                any(ResponseGiver.class))).thenReturn(updatedComment);
+                any(Instructor.class))).thenReturn(updatedComment);
 
         UpdateResponseInstructorCommentAction action = getAction(updateRequest, params);
         JsonResult r = getJsonResult(action);
@@ -190,7 +182,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), differentInstructor.getGoogleId()))
                 .thenReturn(differentInstructor);
         when(mockLogic.updateResponseInstructorComment(any(UUID.class), any(ResponseInstructorCommentUpdateRequest.class),
-                any(ResponseGiver.class))).thenReturn(updatedComment);
+                any(Instructor.class))).thenReturn(updatedComment);
 
         UpdateResponseInstructorCommentAction action = getAction(updateRequest, params);
         JsonResult r = getJsonResult(action);
@@ -219,7 +211,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
         when(mockLogic.updateResponseInstructorComment(any(UUID.class), any(ResponseInstructorCommentUpdateRequest.class),
-                any(ResponseGiver.class))).thenReturn(updatedComment);
+                any(Instructor.class))).thenReturn(updatedComment);
 
         UpdateResponseInstructorCommentAction action = getAction(updateRequest, params);
         JsonResult r = getJsonResult(action);
@@ -313,88 +305,13 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         verifyEntityNotFoundAcl(params);
     }
 
-    @Test
-    void testAccessControl_instructorWithCorrectPrivilege_canAccessCrossSectionComment() {
-        ResponseInstructorComment typicalComment = getTypicalCommentFromTeam(typicalStudent.getTeam());
-
-        Instructor instructorWithPrivilege = getTypicalInstructor();
-        instructorWithPrivilege.setEmail("instructorwithprivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section A",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        privileges.updatePrivilege("Section B",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        instructorWithPrivilege.setPrivileges(privileges);
-
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalComment.getId().toString(),
-        };
-
-        when(mockLogic.getResponseInstructorComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithPrivilege.getGoogleId()))
-                .thenReturn(instructorWithPrivilege);
-
-        loginAsInstructor(instructorWithPrivilege.getGoogleId());
-
-        verifyCanAccess(params);
-    }
-
-    @Test
-    void testAccessControl_instructorWithoutGiverSectionPrivilege_cannotAccessCrossSectionComment() {
-        ResponseInstructorComment typicalComment = getTypicalCommentFromTeam(typicalStudent.getTeam());
-
-        Instructor instructorWithoutPrivilege = getTypicalInstructor();
-        instructorWithoutPrivilege.setEmail("instructorwithprivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section B",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        instructorWithoutPrivilege.setPrivileges(privileges);
-
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalComment.getId().toString(),
-        };
-
-        when(mockLogic.getResponseInstructorComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
-                .thenReturn(instructorWithoutPrivilege);
-
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
-
-        verifyCannotAccess(params);
-    }
-
-    @Test
-    void testAccessControl_instructorWithoutRecipientSectionPrivilege_cannotAccessCrossSectionComment() {
-        ResponseInstructorComment typicalComment = getTypicalCommentFromTeam(typicalStudent.getTeam());
-
-        Instructor instructorWithoutPrivilege = getTypicalInstructor();
-        instructorWithoutPrivilege.setEmail("instructorwithprivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section A",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
-        instructorWithoutPrivilege.setPrivileges(privileges);
-
-        String[] params = new String[] {
-                Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalComment.getId().toString(),
-        };
-
-        when(mockLogic.getResponseInstructorComment(typicalComment.getId())).thenReturn(typicalComment);
-        when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), instructorWithoutPrivilege.getGoogleId()))
-                .thenReturn(instructorWithoutPrivilege);
-
-        loginAsInstructor(instructorWithoutPrivilege.getGoogleId());
-
-        verifyCannotAccess(params);
-    }
-
     private ResponseInstructorComment getTypicalCommentFromInstructor() {
-        ResponseGiver giver = new ResponseGiver(typicalInstructor);
         ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(
-                giver,
+                typicalInstructor,
                 "typical comment",
                 Arrays.asList(ViewerType.INSTRUCTORS),
                 Arrays.asList(ViewerType.INSTRUCTORS),
-                giver);
+                typicalInstructor);
         typicalFeedbackResponse.addResponseInstructorComment(responseInstructorComment);
         responseInstructorComment.setId(UUID.fromString("00000000-0000-4000-8000-000000000002"));
         responseInstructorComment.setCreatedAt(Instant.EPOCH);
@@ -403,41 +320,14 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
     }
 
     private ResponseInstructorComment getUpdatedCommentFromInstructor() {
-        ResponseGiver giver = new ResponseGiver(typicalInstructor);
         ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(
-                giver,
+                typicalInstructor,
                 "updated comment",
                 Arrays.asList(ViewerType.GIVER, ViewerType.INSTRUCTORS),
                 Arrays.asList(ViewerType.GIVER, ViewerType.INSTRUCTORS),
-                giver);
+                typicalInstructor);
         typicalFeedbackResponse.addResponseInstructorComment(responseInstructorComment);
         responseInstructorComment.setId(UUID.fromString("00000000-0000-4000-8000-000000000002"));
-        responseInstructorComment.setCreatedAt(Instant.EPOCH);
-        responseInstructorComment.setUpdatedAt(Instant.EPOCH);
-        return responseInstructorComment;
-    }
-
-    private ResponseInstructorComment getTypicalCommentFromTeam(Team team) {
-        Section sectionA = new Section("Section A");
-        typicalCourse.addSection(sectionA);
-        Section sectionB = new Section("Section B");
-        typicalCourse.addSection(sectionB);
-        Team giverTeam = new Team("Section A");
-        giverTeam.setSection(sectionA);
-        Team recipientTeam = new Team("Section B");
-        recipientTeam.setSection(sectionB);
-        typicalFeedbackResponse = FeedbackResponse.makeResponse(
-                new ResponseGiver(giverTeam), new ResponseRecipient(recipientTeam), getTypicalFeedbackResponseDetails());
-        typicalFeedbackQuestion.addFeedbackResponse(typicalFeedbackResponse);
-        ResponseGiver giver = new ResponseGiver(team);
-        ResponseInstructorComment responseInstructorComment = new ResponseInstructorComment(
-                giver,
-                "typical comment",
-                Arrays.asList(ViewerType.INSTRUCTORS),
-                Arrays.asList(ViewerType.INSTRUCTORS),
-                giver);
-        typicalFeedbackResponse.addResponseInstructorComment(responseInstructorComment);
-        responseInstructorComment.setId(UUID.fromString("00000000-0000-4000-8000-000000000004"));
         responseInstructorComment.setCreatedAt(Instant.EPOCH);
         responseInstructorComment.setUpdatedAt(Instant.EPOCH);
         return responseInstructorComment;

--- a/src/test/resources/data/DataBundleLogicIT.json
+++ b/src/test/resources/data/DataBundleLogicIT.json
@@ -211,12 +211,8 @@
   },
   "responseInstructorComments": {
     "comment1ToResponse1ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],

--- a/src/test/resources/data/FeedbackResponsesITBundle.json
+++ b/src/test/resources/data/FeedbackResponsesITBundle.json
@@ -985,72 +985,48 @@
   },
   "responseInstructorComments": {
     "comment1ToResponse1ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000901"
     },
     "comment2ToResponse2ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Instructor 2 comment to student 2 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000902"
     },
     "comment1ToResponse1ForQ2s": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Instructor 2 comment to student 2 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000903"
     },
     "comment1ToResponse1ForQ3": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000905"
     },
     "comment1ToResponse4ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 4 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000908"
     },
     "comment1ToResponse1ForQ1InSession2": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],

--- a/src/test/resources/data/FeedbackSessionResultsBundleTest.json
+++ b/src/test/resources/data/FeedbackSessionResultsBundleTest.json
@@ -895,48 +895,32 @@
   },
   "responseInstructorComments": {
     "comment1ToResponse1ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000901"
     },
     "comment2ToResponse2ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Instructor 2 comment to student 2 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000902"
     },
     "comment1ToResponse1ForQ2s": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Instructor 2 comment to student 2 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000903"
     },
     "comment1ToResponse1ForQ3": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -988,48 +988,32 @@
   },
   "responseInstructorComments": {
     "comment1ToResponse1ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000901"
     },
     "comment2ToResponse2ForQ1": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Instructor 2 comment to student 2 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000902"
     },
     "comment1ToResponse1ForQ2s": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000502"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000502",
+      "lastEditedById": "00000000-0000-4000-8000-000000000502",
       "commentText": "Instructor 2 comment to student 2 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],
       "responseId": "00000000-0000-4000-8000-000000000903"
     },
     "comment1ToResponse1ForQ3": {
-      "giver": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
-      "lastEditedBy": {
-        "giverUserId": "00000000-0000-4000-8000-000000000501"
-      },
+      "giverId": "00000000-0000-4000-8000-000000000501",
+      "lastEditedById": "00000000-0000-4000-8000-000000000501",
       "commentText": "Instructor 1 comment to student 1 self feedback",
       "showCommentTo": [],
       "showGiverNameTo": [],


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

The ResponseInstructorComment entity now only support instructor givers. The entity model has been updated to reflect this. 
