### PR TITLE
Move InvalidHttpRequestBodyException to teammates.ui.exception

### DIFF
--- a/src/main/java/teammates/ui/exception/InvalidHttpRequestBodyException.java
+++ b/src/main/java/teammates/ui/exception/InvalidHttpRequestBodyException.java
@@ -1,4 +1,4 @@
-package teammates.ui.request;
+package teammates.ui.exception;
 
 import teammates.common.exception.InvalidParametersException;
 

--- a/src/main/java/teammates/ui/servlets/WebApiServlet.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServlet.java
@@ -11,7 +11,7 @@ import teammates.common.util.HibernateUtil;
 import teammates.common.util.Logger;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.Action;
 import teammates.ui.webapi.ActionFactory;
 import teammates.ui.webapi.ActionResult;

--- a/src/main/java/teammates/ui/servlets/WebApiServletExceptionHandler.java
+++ b/src/main/java/teammates/ui/servlets/WebApiServletExceptionHandler.java
@@ -14,7 +14,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.webapi.JsonResult;
 
 /**

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -28,7 +28,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * An "action" to be performed by the system.

--- a/src/main/java/teammates/ui/webapi/ApproveAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/ApproveAccountRequestAction.java
@@ -10,7 +10,7 @@ import teammates.storage.entity.AccountRequest;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Approves an account request.

--- a/src/main/java/teammates/ui/webapi/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountAction.java
@@ -26,7 +26,7 @@ import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnexpectedServerException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Creates a new instructor account with sample courses.

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -7,7 +7,7 @@ import teammates.storage.entity.AccountRequest;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Creates a new account request.

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -12,7 +12,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.CourseData;
 import teammates.ui.request.CourseCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Create a new course for an instructor.

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -15,7 +15,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionData;
 import teammates.ui.request.FeedbackQuestionCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Creates a feedback question.

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -19,7 +19,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.request.FeedbackSessionCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Create a feedback session.

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -17,7 +17,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Action: adds another instructor to a course that already exists.

--- a/src/main/java/teammates/ui/webapi/CreateNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateNotificationAction.java
@@ -9,7 +9,7 @@ import teammates.storage.entity.Notification;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationCreateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -18,7 +18,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.ResponseInstructorCommentData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.ResponseInstructorCommentCreateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/DeleteDataBundleAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteDataBundleAction.java
@@ -5,7 +5,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Deletes a data bundle from the DB.

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -11,7 +11,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.EnrollStudentsData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.StudentEnrollRequest;
 import teammates.ui.request.StudentsEnrollRequest;
 

--- a/src/main/java/teammates/ui/webapi/GetNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationAction.java
@@ -6,7 +6,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Action: Gets a notification by ID.

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -8,7 +8,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.User;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.RegKeyRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.ReadNotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.MarkNotificationAsReadRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/PutDataBundleAction.java
+++ b/src/main/java/teammates/ui/webapi/PutDataBundleAction.java
@@ -6,7 +6,7 @@ import teammates.common.util.Config;
 import teammates.common.util.JsonUtils;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Persists a data bundle into the DB.

--- a/src/main/java/teammates/ui/webapi/RejectAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/RejectAccountRequestAction.java
@@ -11,7 +11,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestRejectionRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Rejects an account request.

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -16,7 +16,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.FeedbackSessionRespondentRemindRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Remind the student about the published result of a feedback session.

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -15,7 +15,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.FeedbackSessionRespondentRemindRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Remind students about the feedback submission.

--- a/src/main/java/teammates/ui/webapi/SendEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/webapi/SendEmailWorkerAction.java
@@ -4,7 +4,7 @@ import org.apache.http.HttpStatus;
 
 import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailWrapper;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.SendEmailRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
+++ b/src/main/java/teammates/ui/webapi/SendErrorReportAction.java
@@ -2,7 +2,7 @@ package teammates.ui.webapi;
 
 import teammates.common.util.Logger;
 import teammates.ui.request.ErrorReportRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Actions: sends an error report to the system admin.

--- a/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/SubmitFeedbackResponsesAction.java
@@ -19,7 +19,7 @@ import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionResponsesData;
 import teammates.ui.request.FeedbackResponsesRequest;
 import teammates.ui.request.Intent;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Submits feedback responses for one or more feedback questions in a feedback session.

--- a/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateAccountRequestAction.java
@@ -9,7 +9,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates an account request.

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.CourseData;
 import teammates.ui.request.CourseUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates a course.

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -14,7 +14,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
 import teammates.ui.request.DeadlineExtensionsUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates the deadline extensions for a feedback session.

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionData;
 import teammates.ui.request.FeedbackQuestionUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates a feedback question.

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
 import teammates.ui.request.FeedbackSessionUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates a feedback session.

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Edits an instructor in a course.

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -10,7 +10,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.InstructorPrivilegeData;
 import teammates.ui.request.InstructorPrivilegeUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Updates an instructor's privileges.

--- a/src/main/java/teammates/ui/webapi/UpdateNotificationAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateNotificationAction.java
@@ -9,7 +9,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationUpdateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -13,7 +13,7 @@ import teammates.storage.entity.ResponseInstructorComment;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.ResponseInstructorCommentData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.ResponseInstructorCommentUpdateRequest;
 
 /**

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -15,7 +15,7 @@ import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.StudentUpdateRequest;
 
 /**

--- a/src/test/java/teammates/ui/servlets/WebApiServletExceptionHandlerTest.java
+++ b/src/test/java/teammates/ui/servlets/WebApiServletExceptionHandlerTest.java
@@ -17,7 +17,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.exception.UnexpectedServerException;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link WebApiServletExceptionHandler}.

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -46,7 +46,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Base class for all action tests.

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -47,7 +47,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * Base class for all action tests.

--- a/src/test/java/teammates/ui/webapi/CreateAccountRequestActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateAccountRequestActionIT.java
@@ -14,7 +14,7 @@ import teammates.storage.entity.AccountRequest;
 import teammates.test.GroupNames;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link CreateAccountRequestAction}.

--- a/src/test/java/teammates/ui/webapi/CreateAccountRequestActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateAccountRequestActionTest.java
@@ -16,7 +16,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.AccountRequest;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link CreateAccountRequestAction}.

--- a/src/test/java/teammates/ui/webapi/CreateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateNotificationActionTest.java
@@ -14,7 +14,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationCreateRequest;
 
 /**

--- a/src/test/java/teammates/ui/webapi/RejectAccountRequestActionIT.java
+++ b/src/test/java/teammates/ui/webapi/RejectAccountRequestActionIT.java
@@ -24,7 +24,7 @@ import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestRejectionRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link RejectAccountRequestAction}.

--- a/src/test/java/teammates/ui/webapi/SendErrorReportActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SendErrorReportActionTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 import teammates.common.util.Const;
 import teammates.ui.output.MessageOutput;
 import teammates.ui.request.ErrorReportRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link SendErrorReportAction}.

--- a/src/test/java/teammates/ui/webapi/UpdateAccountRequestActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateAccountRequestActionIT.java
@@ -21,7 +21,7 @@ import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.output.AccountRequestData;
 import teammates.ui.request.AccountRequestUpdateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link UpdateAccountRequestAction}.

--- a/src/test/java/teammates/ui/webapi/UpdateInstructorActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateInstructorActionIT.java
@@ -16,7 +16,7 @@ import teammates.test.GroupNames;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.InstructorData;
 import teammates.ui.request.InstructorCreateRequest;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
  * SUT: {@link UpdateInstructorAction}.

--- a/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateNotificationActionTest.java
@@ -16,7 +16,7 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Notification;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.output.NotificationData;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.NotificationUpdateRequest;
 
 /**

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
@@ -23,7 +23,7 @@ import teammates.test.GroupNames;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.output.MessageOutput;
-import teammates.ui.request.InvalidHttpRequestBodyException;
+import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.request.StudentUpdateRequest;
 
 /**


### PR DESCRIPTION
[#14075] Move InvalidHttpRequestBodyException to teammates.ui.exception

**Outline of Solution**

Moved `InvalidHttpRequestBodyException` from `teammates.ui.request` to `teammates.ui.exception` to better reflect its purpose as an exception class.

Updated the package declaration in `InvalidHttpRequestBodyException` and modified all affected imports to reference the new package location.

Verified that the project builds successfully after the change.
