### PR TITLE
[#13721] Refactor GateKeeper methods to use RequestContext

### DIFF
--- a/src/main/java/teammates/common/datatransfer/RequestContext.java
+++ b/src/main/java/teammates/common/datatransfer/RequestContext.java
@@ -1,0 +1,65 @@
+package teammates.common.datatransfer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import teammates.storage.entity.Account;
+import teammates.storage.entity.Instructor;
+import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
+import teammates.ui.webapi.AuthType;
+
+/**
+ * Encapsulates the context of a web API request, including the authentication
+ * context and cached data for instructors and students.
+ */
+public class RequestContext {
+    private final AuthContext authContext;
+    private final Map<String, Instructor> instructorsByCourseId = new HashMap<>();
+    private final Map<String, Student> studentsByCourseId = new HashMap<>();
+
+    public RequestContext(AuthContext authContext) {
+        this.authContext = authContext;
+    }
+
+    public AuthContext getAuthContext() {
+        return authContext;
+    }
+
+    public AuthType getAuthType() {
+        return authContext.authType();
+    }
+
+    public boolean isMaintainer() {
+        return authContext.isMaintainer();
+    }
+
+    public boolean isAdmin() {
+        return authContext.isAdmin();
+    }
+
+    public Account getAccount() {
+        return authContext.account();
+    }
+
+    public User getRegKeyUser() {
+        return authContext.regKeyUser();
+    }
+
+    /**
+     * Returns the instructor for the specified course ID, using the provided loader
+     * function if not already cached.
+     */
+    public Instructor getInstructorForCourse(String courseId, BiFunction<AuthContext, String, Instructor> loader) {
+        return instructorsByCourseId.computeIfAbsent(courseId, cId -> loader.apply(authContext, cId));
+    }
+
+    /**
+     * Returns the student for the specified course ID, using the provided loader
+     * function if not already cached.
+     */
+    public Student getStudentForCourse(String courseId, BiFunction<AuthContext, String, Student> loader) {
+        return studentsByCourseId.computeIfAbsent(courseId, cId -> loader.apply(authContext, cId));
+    }
+}

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.RequestContext;
 import teammates.common.datatransfer.logs.RequestLogUser;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
@@ -47,7 +48,7 @@ public abstract class Action {
     LogsProcessor logsProcessor = LogsProcessor.inst();
 
     HttpServletRequest req;
-    AuthContext authContext;
+    RequestContext requestContext;
 
     // buffer to store the request body
     private String requestBody;
@@ -57,7 +58,8 @@ public abstract class Action {
      */
     public void init(HttpServletRequest req) throws UnauthorizedAccessException {
         this.req = req;
-        this.authContext = userProvision.getAuthContextFromRequest(req);
+        AuthContext authContext = userProvision.getAuthContextFromRequest(req);
+        this.requestContext = new RequestContext(authContext);
     }
 
     /**
@@ -95,12 +97,12 @@ public abstract class Action {
      * Checks if the requesting user has sufficient authority to access the resource.
      */
     public void checkAccessControl() throws InvalidHttpRequestBodyException, UnauthorizedAccessException {
-        if (authContext.authType().getLevel() < getMinAuthLevel().getLevel()) {
+        if (requestContext.getAuthType().getLevel() < getMinAuthLevel().getLevel()) {
             // Access control level lower than required
             throw new UnauthorizedAccessException("Not authorized to access this resource.");
         }
 
-        if (authContext.authType() == AuthType.ALL_ACCESS) {
+        if (requestContext.getAuthType() == AuthType.ALL_ACCESS) {
             // All-access auth type is allowed to access all resources without further checks
             return;
         }
@@ -116,7 +118,7 @@ public abstract class Action {
         RequestLogUser user = new RequestLogUser();
 
         Account account = getCurrentAccount();
-        User regKeyUser = authContext.regKeyUser();
+        User regKeyUser = requestContext.getRegKeyUser();
 
         if (account != null) {
             user.setEmail(account.getEmail());
@@ -129,7 +131,7 @@ public abstract class Action {
     }
 
     Account getCurrentAccount() {
-        return authContext.account();
+        return requestContext.getAccount();
     }
 
     String getCurrentUserGoogleId() {
@@ -261,11 +263,11 @@ public abstract class Action {
     }
 
     Instructor getInstructorFromRequest(String courseId) {
-        return logic.getInstructorFromAuthContext(authContext, courseId);
+        return requestContext.getInstructorForCourse(courseId, logic::getInstructorFromAuthContext);
     }
 
     Student getStudentFromRequest(String courseId) {
-        return logic.getStudentFromAuthContext(authContext, courseId);
+        return requestContext.getStudentForCourse(courseId, logic::getStudentFromAuthContext);
     }
 
     InstructorPermissionSet constructInstructorPrivileges(Instructor instructor, String feedbackSessionName) {

--- a/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
+++ b/src/main/java/teammates/ui/webapi/AdminOnlyAction.java
@@ -14,7 +14,7 @@ abstract class AdminOnlyAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isAdmin()) {
+        if (!requestContext.isAdmin()) {
             throw new UnauthorizedAccessException("Admin privilege is required to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
+++ b/src/main/java/teammates/ui/webapi/AutomatedServiceAction.java
@@ -26,8 +26,8 @@ abstract class AutomatedServiceAction extends Action {
     }
 
     boolean canAccessAsAdminOrAutomatedService() {
-        return authContext.authType() == AuthType.AUTOMATED_SERVICE
-                || authContext.isAdmin();
+        return requestContext.getAuthType() == AuthType.AUTOMATED_SERVICE
+                || requestContext.isAdmin();
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -178,8 +178,19 @@ abstract class BasicFeedbackSubmissionAction extends Action {
             gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
-            gateKeeper.verifySessionSubmissionPrivilegeForInstructor(feedbackSession, instructor);
+            verifyInstructorCanSubmitToSession(feedbackSession, instructor);
         }
+    }
+
+    private void verifyInstructorCanSubmitToSession(FeedbackSession feedbackSession, Instructor instructor)
+            throws UnauthorizedAccessException {
+        if (instructor.isAllowedForPrivilegeAnySection(feedbackSession.getName(),
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)) {
+            return;
+        }
+
+        gateKeeper.verifyInstructorHasPrivilege(instructor,
+                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -122,16 +122,16 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            gateKeeper.verifyLoggedInUserPrivileges(requestContext);
             Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             checkAccessControlForPreview(feedbackSession);
         } else {
-            gateKeeper.verifyStudentInCourse(authContext, feedbackSession.getCourseId());
+            gateKeeper.verifyStudentInCourse(requestContext, feedbackSession.getCourseId());
             if (!feedbackSession.isVisible()) {
                 throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
             }
@@ -150,7 +150,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyStudentInCourse(authContext, feedbackSession.getCourseId());
+            gateKeeper.verifyStudentInCourse(requestContext, feedbackSession.getCourseId());
             if (!feedbackSession.isVisible()) {
                 throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
             }
@@ -172,13 +172,13 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+            gateKeeper.verifyLoggedInUserPrivileges(requestContext);
+            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+            gateKeeper.verifyLoggedInUserPrivileges(requestContext);
+            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
@@ -198,7 +198,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         } else {
             checkAccessControlForPreview(feedbackSession);
@@ -207,9 +207,9 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
     private void checkAccessControlForPreview(FeedbackSession feedbackSession)
             throws UnauthorizedAccessException {
-        gateKeeper.verifyLoggedInUserPrivileges(authContext);
+        gateKeeper.verifyLoggedInUserPrivileges(requestContext);
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -130,7 +130,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             checkAccessControlForPreview(feedbackSession);
         } else {
-            gateKeeper.verifyAccessible(student, feedbackSession);
+            gateKeeper.verifyStudentCanAccessSession(student, feedbackSession);
         }
     }
 
@@ -146,7 +146,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyAccessible(student, feedbackSession);
+            gateKeeper.verifyStudentCanAccessSession(student, feedbackSession);
         } else {
             checkAccessControlForPreview(feedbackSession);
         }

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -123,9 +123,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(requestContext);
-            Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorHasPrivilege(instructor,
+            gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, feedbackSession.getCourseId(),
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
@@ -173,13 +171,11 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(requestContext);
-            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorHasPrivilege(instructor,
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(requestContext);
-            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorHasPrivilege(instructor,
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifySessionSubmissionPrivilegeForInstructor(feedbackSession, instructor);
@@ -198,8 +194,8 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                    Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         } else {
             checkAccessControlForPreview(feedbackSession);
         }
@@ -208,9 +204,8 @@ abstract class BasicFeedbackSubmissionAction extends Action {
     private void checkAccessControlForPreview(FeedbackSession feedbackSession)
             throws UnauthorizedAccessException {
         gateKeeper.verifyLoggedInUserPrivileges(requestContext);
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -125,7 +125,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
             gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-            gateKeeper.verifyAccessible(instructor,
+            gateKeeper.verifyInstructorHasPrivilege(instructor,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
@@ -168,11 +168,13 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
+            gateKeeper.verifyInstructorHasPrivilege(instructor,
+                    Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+            gateKeeper.verifyInstructorHasPrivilege(instructor,
+                    Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifySessionSubmissionPrivilegeForInstructor(feedbackSession, instructor);
         }
@@ -191,7 +193,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         } else {
             checkAccessControlForPreview(feedbackSession);
         }
@@ -202,7 +204,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         gateKeeper.verifyLoggedInUserPrivileges(authContext);
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -124,14 +124,14 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             checkAccessControlForPreview(feedbackSession);
         } else {
-            gateKeeper.verifyStudentCanAccessSession(student, feedbackSession);
+            gateKeeper.verifyStudentInCourse(authContext, feedbackSession.getCourseId());
             if (!feedbackSession.isVisible()) {
                 throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
             }
@@ -150,7 +150,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyStudentCanAccessSession(student, feedbackSession);
+            gateKeeper.verifyStudentInCourse(authContext, feedbackSession.getCourseId());
             if (!feedbackSession.isVisible()) {
                 throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
             }
@@ -173,12 +173,12 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
@@ -198,7 +198,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         } else {
             checkAccessControlForPreview(feedbackSession);
@@ -209,7 +209,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
             throws UnauthorizedAccessException {
         gateKeeper.verifyLoggedInUserPrivileges(authContext);
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -123,8 +123,9 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(
-                    getInstructorFromRequest(feedbackSession.getCourseId()), feedbackSession,
+            Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyAccessible(instructor,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
@@ -166,14 +167,12 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(
-                    getInstructorFromRequest(feedbackSession.getCourseId()),
-                    feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
+            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(
-                    getInstructorFromRequest(feedbackSession.getCourseId()),
-                    feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         } else {
             gateKeeper.verifySessionSubmissionPrivilegeForInstructor(feedbackSession, instructor);
         }
@@ -191,8 +190,8 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 
         if (StringHelper.isEmpty(previewAsPerson)) {
-            gateKeeper.verifyAccessible(instructor, feedbackSession,
-                    Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         } else {
             checkAccessControlForPreview(feedbackSession);
         }
@@ -201,9 +200,9 @@ abstract class BasicFeedbackSubmissionAction extends Action {
     private void checkAccessControlForPreview(FeedbackSession feedbackSession)
             throws UnauthorizedAccessException {
         gateKeeper.verifyLoggedInUserPrivileges(authContext);
-        gateKeeper.verifyAccessible(
-                getInstructorFromRequest(feedbackSession.getCourseId()), feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -132,6 +132,9 @@ abstract class BasicFeedbackSubmissionAction extends Action {
             checkAccessControlForPreview(feedbackSession);
         } else {
             gateKeeper.verifyStudentCanAccessSession(student, feedbackSession);
+            if (!feedbackSession.isVisible()) {
+                throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
+            }
         }
     }
 
@@ -148,6 +151,9 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
         if (StringHelper.isEmpty(previewAsPerson)) {
             gateKeeper.verifyStudentCanAccessSession(student, feedbackSession);
+            if (!feedbackSession.isVisible()) {
+                throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
+            }
         } else {
             checkAccessControlForPreview(feedbackSession);
         }

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -21,8 +21,7 @@ public class BinCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToBin = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(requestContext, idOfCourseToBin);
-        gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToBin),
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, idOfCourseToBin,
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -21,8 +21,7 @@ public class BinCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToBin = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Course course = logic.getCourse(idOfCourseToBin);
-        gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToBin), course);
+        gateKeeper.verifyInstructorInCourse(authContext, idOfCourseToBin);
         gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToBin),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -21,7 +21,7 @@ public class BinCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToBin = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(authContext, idOfCourseToBin);
+        gateKeeper.verifyInstructorInCourse(requestContext, idOfCourseToBin);
         gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToBin),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -22,8 +22,9 @@ public class BinCourseAction extends Action {
         String idOfCourseToBin = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Course course = logic.getCourse(idOfCourseToBin);
+        gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToBin), course);
         gateKeeper.verifyAccessible(getInstructorFromRequest(idOfCourseToBin),
-                course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
+                Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/BinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/BinCourseAction.java
@@ -23,7 +23,7 @@ public class BinCourseAction extends Action {
 
         Course course = logic.getCourse(idOfCourseToBin);
         gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToBin), course);
-        gateKeeper.verifyAccessible(getInstructorFromRequest(idOfCourseToBin),
+        gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToBin),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -29,7 +29,7 @@ public class BinFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
+import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
@@ -27,10 +28,9 @@ public class BinFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        gateKeeper.verifyAccessible(
-                getInstructorFromRequest(feedbackSession.getCourseId()),
-                feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
@@ -28,9 +27,8 @@ public class BinFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -29,7 +29,7 @@ public class BinFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -30,7 +30,7 @@ public class BinFeedbackSessionAction extends Action {
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountRequestAction.java
@@ -19,7 +19,7 @@ public class CreateAccountRequestAction extends PublicAction {
             throws InvalidHttpRequestBodyException, InvalidOperationException {
         AccountCreateRequest createRequest = getAndValidateRequestBody(AccountCreateRequest.class);
 
-        if (!authContext.isAdmin()) {
+        if (!requestContext.isAdmin()) {
             String userCaptchaResponse = createRequest.getCaptchaResponse();
             if (!recaptchaVerifier.isVerificationSuccessful(userCaptchaResponse)) {
                 throw new InvalidHttpRequestBodyException("Something went wrong with "
@@ -45,7 +45,7 @@ public class CreateAccountRequestAction extends PublicAction {
 
         assert accountRequest != null;
 
-        if (!authContext.isAdmin()) {
+        if (!requestContext.isAdmin()) {
             EmailWrapper adminAlertEmail = emailGenerator.generateNewAccountRequestAdminAlertEmail(accountRequest);
             EmailWrapper userAcknowledgementEmail = emailGenerator
                     .generateNewAccountRequestAcknowledgementEmail(accountRequest);

--- a/src/main/java/teammates/ui/webapi/CreateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateCourseAction.java
@@ -29,7 +29,7 @@ public class CreateCourseAction extends Action {
         CourseCreateRequest courseCreateRequest = getAndValidateRequestBody(CourseCreateRequest.class);
 
         String institute = courseCreateRequest.getInstitute().trim();
-        List<Instructor> existingInstructors = logic.getInstructorsByAccountId(authContext.account().getId());
+        List<Instructor> existingInstructors = logic.getInstructorsByAccountId(requestContext.getAccount().getId());
         boolean canCreateCourse = existingInstructors.stream()
                 .filter(Instructor::hasCoownerPrivileges)
                 .map(instructor -> logic.getCourse(instructor.getCourseId()))

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -37,7 +37,7 @@ public class CreateFeedbackQuestionAction extends Action {
 
         Instructor instructorDetailForCourse =
                 getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructorDetailForCourse, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructorDetailForCourse,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -38,7 +38,7 @@ public class CreateFeedbackQuestionAction extends Action {
         Instructor instructorDetailForCourse =
                 getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructorDetailForCourse, feedbackSession);
-        gateKeeper.verifyAccessible(instructorDetailForCourse,
+        gateKeeper.verifyInstructorHasPrivilege(instructorDetailForCourse,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -37,8 +37,8 @@ public class CreateFeedbackQuestionAction extends Action {
 
         Instructor instructorDetailForCourse =
                 getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructorDetailForCourse, feedbackSession);
         gateKeeper.verifyAccessible(instructorDetailForCourse,
-                feedbackSession,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -9,7 +9,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -35,10 +34,7 @@ public class CreateFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructorDetailForCourse =
-                getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructorDetailForCourse,
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -37,7 +37,7 @@ public class CreateFeedbackQuestionAction extends Action {
 
         Instructor instructorDetailForCourse =
                 getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructorDetailForCourse,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -39,7 +39,7 @@ public class CreateFeedbackSessionAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
 
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -37,10 +37,8 @@ public class CreateFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -40,7 +40,8 @@ public class CreateFeedbackSessionAction extends Action {
         Instructor instructor = getInstructorFromRequest(courseId);
         Course course = logic.getCourse(courseId);
 
-        gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -38,9 +38,8 @@ public class CreateFeedbackSessionAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        Course course = logic.getCourse(courseId);
 
-        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackSessionAction.java
@@ -41,7 +41,7 @@ public class CreateFeedbackSessionAction extends Action {
         Course course = logic.getCourse(courseId);
 
         gateKeeper.verifyInstructorInCourse(instructor, course);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -35,7 +35,7 @@ public class CreateInstructorAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -34,7 +34,7 @@ public class CreateInstructorAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -33,9 +33,8 @@ public class CreateInstructorAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -34,8 +34,8 @@ public class CreateInstructorAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -34,7 +34,7 @@ public class CreateInstructorAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -49,7 +49,7 @@ public class CreateResponseInstructorCommentAction extends Action {
         String giverSectionName = giver.getSectionName();
         ResponseRecipient recipient = feedbackResponse.getRecipient();
         String recipientSectionName = recipient.getSectionName();
-        gateKeeper.verifyInstructorInCourse(authContext, session.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, session.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -50,9 +50,9 @@ public class CreateResponseInstructorCommentAction extends Action {
         ResponseRecipient recipient = feedbackResponse.getRecipient();
         String recipientSectionName = recipient.getSectionName();
         gateKeeper.verifyInstructorCanAccessSession(instructor, session);
-        gateKeeper.verifyAccessible(instructor, giverSectionName,
+        gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
-        gateKeeper.verifyAccessible(instructor, recipientSectionName,
+        gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         if (!feedbackQuestion.getQuestionDetailsCopy().isInstructorCommentsOnResponsesAllowed()) {
             throw new InvalidHttpParameterException("Invalid question type for instructor comment");

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -49,9 +49,10 @@ public class CreateResponseInstructorCommentAction extends Action {
         String giverSectionName = giver.getSectionName();
         ResponseRecipient recipient = feedbackResponse.getRecipient();
         String recipientSectionName = recipient.getSectionName();
-        gateKeeper.verifyAccessible(instructor, session, giverSectionName,
+        gateKeeper.verifyInstructorCanAccessSession(instructor, session);
+        gateKeeper.verifyAccessible(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
-        gateKeeper.verifyAccessible(instructor, session, recipientSectionName,
+        gateKeeper.verifyAccessible(instructor, recipientSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         if (!feedbackQuestion.getQuestionDetailsCopy().isInstructorCommentsOnResponsesAllowed()) {
             throw new InvalidHttpParameterException("Invalid question type for instructor comment");

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -40,19 +40,16 @@ public class CreateResponseInstructorCommentAction extends Action {
             throw new EntityNotFoundException("The feedback response does not exist.");
         }
 
-        String courseId = feedbackResponse.getFeedbackQuestion().getCourseId();
         FeedbackQuestion feedbackQuestion = feedbackResponse.getFeedbackQuestion();
         FeedbackSession session = feedbackQuestion.getFeedbackSession();
 
-        Instructor instructor = getInstructorFromRequest(courseId);
         ResponseGiver giver = feedbackResponse.getGiver();
         String giverSectionName = giver.getSectionName();
         ResponseRecipient recipient = feedbackResponse.getRecipient();
         String recipientSectionName = recipient.getSectionName();
-        gateKeeper.verifyInstructorInCourse(requestContext, session.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), giverSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         if (!feedbackQuestion.getQuestionDetailsCopy().isInstructorCommentsOnResponsesAllowed()) {
             throw new InvalidHttpParameterException("Invalid question type for instructor comment");

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -49,7 +49,7 @@ public class CreateResponseInstructorCommentAction extends Action {
         String giverSectionName = giver.getSectionName();
         ResponseRecipient recipient = feedbackResponse.getRecipient();
         String recipientSectionName = recipient.getSectionName();
-        gateKeeper.verifyInstructorCanAccessSession(instructor, session);
+        gateKeeper.verifyInstructorInCourse(authContext, session.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -20,8 +20,9 @@ public class DeleteCourseAction extends Action {
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(idOfCourseToDelete);
 
+        gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToDelete), course);
         gateKeeper.verifyAccessible(getInstructorFromRequest(idOfCourseToDelete),
-                course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
+                Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -18,7 +18,7 @@ public class DeleteCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(authContext, idOfCourseToDelete);
+        gateKeeper.verifyInstructorInCourse(requestContext, idOfCourseToDelete);
         gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToDelete),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -21,7 +21,7 @@ public class DeleteCourseAction extends Action {
         Course course = logic.getCourse(idOfCourseToDelete);
 
         gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToDelete), course);
-        gateKeeper.verifyAccessible(getInstructorFromRequest(idOfCourseToDelete),
+        gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToDelete),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -18,8 +18,7 @@ public class DeleteCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(requestContext, idOfCourseToDelete);
-        gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToDelete),
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, idOfCourseToDelete,
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteCourseAction.java
@@ -1,7 +1,6 @@
 package teammates.ui.webapi;
 
 import teammates.common.util.Const;
-import teammates.storage.entity.Course;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.MessageOutput;
 
@@ -18,9 +17,8 @@ public class DeleteCourseAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(idOfCourseToDelete);
 
-        gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToDelete), course);
+        gateKeeper.verifyInstructorInCourse(authContext, idOfCourseToDelete);
         gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToDelete),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -35,7 +35,7 @@ public class DeleteFeedbackQuestionAction extends Action {
         FeedbackSession feedbackSession = getNonNullFeedbackSession(question.getFeedbackSession().getName(),
                 question.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
 
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -31,11 +30,10 @@ public class DeleteFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        Instructor instructor = getInstructorFromRequest(question.getCourseId());
         FeedbackSession feedbackSession = getNonNullFeedbackSession(question.getFeedbackSession().getName(),
                 question.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
 
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -34,7 +34,7 @@ public class DeleteFeedbackQuestionAction extends Action {
         Instructor instructor = getInstructorFromRequest(question.getCourseId());
         FeedbackSession feedbackSession = getNonNullFeedbackSession(question.getFeedbackSession().getName(),
                 question.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
 
     }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -34,7 +34,7 @@ public class DeleteFeedbackQuestionAction extends Action {
         Instructor instructor = getInstructorFromRequest(question.getCourseId());
         FeedbackSession feedbackSession = getNonNullFeedbackSession(question.getFeedbackSession().getName(),
                 question.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
 
     }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
+import teammates.storage.entity.FeedbackSession;
+import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -29,9 +31,11 @@ public class DeleteFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        gateKeeper.verifyAccessible(getInstructorFromRequest(question.getCourseId()),
-                getNonNullFeedbackSession(question.getFeedbackSession().getName(), question.getCourseId()),
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(question.getCourseId());
+        FeedbackSession feedbackSession = getNonNullFeedbackSession(question.getFeedbackSession().getName(),
+                question.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
 
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.UnauthorizedAccessException;
 
 /**
@@ -25,9 +24,8 @@ public class DeleteFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -26,7 +26,8 @@ public class DeleteFeedbackSessionAction extends Action {
             throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -26,7 +26,7 @@ public class DeleteFeedbackSessionAction extends Action {
             throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -27,7 +27,7 @@ public class DeleteFeedbackSessionAction extends Action {
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -26,7 +26,7 @@ public class DeleteFeedbackSessionAction extends Action {
             throw new UnauthorizedAccessException("The feedback session does not exist.");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -27,12 +27,12 @@ public class DeleteInstructorAction extends Action {
         }
 
         //allow access to admins or instructor with modify permission
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
         Instructor instructor = getInstructorFromRequest(instructorToDelete.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, instructorToDelete.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, instructorToDelete.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -32,7 +32,7 @@ public class DeleteInstructorAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(instructorToDelete.getCourseId());
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(instructorToDelete.getCourseId()));
+        gateKeeper.verifyInstructorInCourse(authContext, instructorToDelete.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -31,9 +31,8 @@ public class DeleteInstructorAction extends Action {
             return;
         }
 
-        Instructor instructor = getInstructorFromRequest(instructorToDelete.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, instructorToDelete.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, instructorToDelete.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -32,9 +32,8 @@ public class DeleteInstructorAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(instructorToDelete.getCourseId());
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(instructorToDelete.getCourseId()),
-                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(instructorToDelete.getCourseId()));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteInstructorAction.java
@@ -33,7 +33,7 @@ public class DeleteInstructorAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(instructorToDelete.getCourseId());
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(instructorToDelete.getCourseId()));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -46,7 +46,7 @@ public class DeleteResponseInstructorCommentAction extends Action {
         ResponseGiver giver = response.getGiver();
         String giverSectionName = giver.getSectionName();
         String recipientSectionName = response.getRecipient().getSectionName();
-        gateKeeper.verifyInstructorCanAccessSession(instructor, session);
+        gateKeeper.verifyInstructorInCourse(authContext, session.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -46,9 +46,10 @@ public class DeleteResponseInstructorCommentAction extends Action {
         ResponseGiver giver = response.getGiver();
         String giverSectionName = giver.getSectionName();
         String recipientSectionName = response.getRecipient().getSectionName();
-        gateKeeper.verifyAccessible(instructor, session, giverSectionName,
+        gateKeeper.verifyInstructorCanAccessSession(instructor, session);
+        gateKeeper.verifyAccessible(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyAccessible(instructor, session, recipientSectionName,
+        gateKeeper.verifyAccessible(instructor, recipientSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -47,9 +47,9 @@ public class DeleteResponseInstructorCommentAction extends Action {
         String giverSectionName = giver.getSectionName();
         String recipientSectionName = response.getRecipient().getSectionName();
         gateKeeper.verifyInstructorCanAccessSession(instructor, session);
-        gateKeeper.verifyAccessible(instructor, giverSectionName,
+        gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyAccessible(instructor, recipientSectionName,
+        gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -46,10 +46,9 @@ public class DeleteResponseInstructorCommentAction extends Action {
         ResponseGiver giver = response.getGiver();
         String giverSectionName = giver.getSectionName();
         String recipientSectionName = response.getRecipient().getSectionName();
-        gateKeeper.verifyInstructorInCourse(requestContext, session.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), giverSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -46,7 +46,7 @@ public class DeleteResponseInstructorCommentAction extends Action {
         ResponseGiver giver = response.getGiver();
         String giverSectionName = giver.getSectionName();
         String recipientSectionName = response.getRecipient().getSectionName();
-        gateKeeper.verifyInstructorInCourse(authContext, session.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, session.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, giverSectionName,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         gateKeeper.verifyInstructorHasPrivilege(instructor, recipientSectionName,

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -31,8 +31,8 @@ public class DeleteStudentAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(student.getCourseId());
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(student.getCourseId()), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(student.getCourseId()));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -32,7 +32,7 @@ public class DeleteStudentAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(student.getCourseId());
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(student.getCourseId()));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -31,7 +31,7 @@ public class DeleteStudentAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(student.getCourseId());
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(student.getCourseId()));
+        gateKeeper.verifyInstructorInCourse(authContext, student.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -3,7 +3,6 @@ package teammates.ui.webapi;
 import java.util.UUID;
 
 import teammates.common.util.Const;
-import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -30,9 +29,8 @@ public class DeleteStudentAction extends Action {
             return;
         }
 
-        Instructor instructor = getInstructorFromRequest(student.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, student.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, student.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentAction.java
@@ -26,12 +26,12 @@ public class DeleteStudentAction extends Action {
             throw new EntityNotFoundException("Student with user ID " + userId + " does not exist.");
         }
 
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
         Instructor instructor = getInstructorFromRequest(student.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, student.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, student.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -20,7 +20,7 @@ public class DeleteStudentsAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -19,8 +19,8 @@ public class DeleteStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyAccessible(
-                    instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -19,7 +19,7 @@ public class DeleteStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -1,7 +1,6 @@
 package teammates.ui.webapi;
 
 import teammates.common.util.Const;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.UnauthorizedAccessException;
 
 /**
@@ -18,9 +17,7 @@ public class DeleteStudentsAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteStudentsAction.java
@@ -19,7 +19,7 @@ public class DeleteStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -36,8 +36,8 @@ public class EnrollStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyAccessible(
-                    instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -36,7 +36,7 @@ public class EnrollStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -36,7 +36,7 @@ public class EnrollStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -6,7 +6,6 @@ import teammates.common.datatransfer.EnrollResults;
 import teammates.common.exception.EnrollException;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -35,9 +34,7 @@ public class EnrollStudentsAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/EnrollStudentsAction.java
@@ -37,7 +37,7 @@ public class EnrollStudentsAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -101,29 +101,35 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies the instructor is not null and has the privilege specified by privilegeName.
+     * Verifies the instructor for the specified course has the privileges specified by privilegeNames.
      */
-    void verifyInstructorHasPrivilege(Instructor instructor, String privilegeName)
+    void verifyInstructorHasPrivilege(RequestContext requestContext, String courseId, String... privilegeNames)
             throws UnauthorizedAccessException {
-        boolean instructorIsAllowedCoursePrivilege = instructor.isAllowedForPrivilege(privilegeName);
-        boolean instructorIsAllowedSectionPrivilege = !instructor.getSectionsWithPrivilege(privilegeName).isEmpty();
-        if (!instructorIsAllowedCoursePrivilege && !instructorIsAllowedSectionPrivilege) {
-            throw new UnauthorizedAccessException("Instructor [" + instructor.getEmail()
-                                                  + "] does not have privilege [" + privilegeName + "]");
+        Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
+        for (String privilegeName : privilegeNames) {
+            boolean instructorIsAllowedCoursePrivilege =
+                    instructor != null && instructor.isAllowedForPrivilege(privilegeName);
+            boolean instructorIsAllowedSectionPrivilege =
+                    instructor != null && !instructor.getSectionsWithPrivilege(privilegeName).isEmpty();
+            if (!instructorIsAllowedCoursePrivilege && !instructorIsAllowedSectionPrivilege) {
+                throw new UnauthorizedAccessException("Instructor does not have privilege [" + privilegeName + "]");
+            }
         }
     }
 
     /**
-     * Verifies the instructor is not null and has the privilege specified by privilegeName for sectionName.
+     * Verifies the instructor for the specified course has the privileges specified by privilegeNames for sectionName.
      */
-    void verifyInstructorHasPrivilege(Instructor instructor, String sectionName, String privilegeName)
-            throws UnauthorizedAccessException {
+    void verifyInstructorHasPrivilegeForSection(RequestContext requestContext, String courseId, String sectionName,
+            String... privilegeNames) throws UnauthorizedAccessException {
         verifyNotNull(sectionName, "section name");
 
-        if (!instructor.isAllowedForPrivilege(sectionName, privilegeName)) {
-            throw new UnauthorizedAccessException("Instructor [" + instructor.getEmail()
-                                                  + "] does not have privilege [" + privilegeName
-                                                  + "] on section [" + sectionName + "]");
+        Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
+        for (String privilegeName : privilegeNames) {
+            if (instructor == null || !instructor.isAllowedForPrivilege(sectionName, privilegeName)) {
+                throw new UnauthorizedAccessException("Instructor does not have privilege [" + privilegeName
+                                                      + "] on section [" + sectionName + "]");
+            }
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -1,6 +1,6 @@
 package teammates.ui.webapi;
 
-import teammates.common.datatransfer.AuthContext;
+import teammates.common.datatransfer.RequestContext;
 import teammates.common.util.Const;
 import teammates.logic.core.AuthLogic;
 import teammates.logic.core.UsersLogic;
@@ -30,16 +30,19 @@ final class GateKeeper {
     /**
      * Verifies the user is logged in.
      */
-    void verifyLoggedInUserPrivileges(AuthContext authContext) throws UnauthorizedAccessException {
-        if (authContext.account() != null) {
+    void verifyLoggedInUserPrivileges(RequestContext requestContext) throws UnauthorizedAccessException {
+        if (requestContext.getAccount() != null) {
             return;
         }
 
         throw new UnauthorizedAccessException("User is not logged in");
     }
 
-    void verifyAdminPrivileges(AuthContext authContext) throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+    /**
+     * Verifies that the user has admin privileges.
+     */
+    void verifyAdminPrivileges(RequestContext requestContext) throws UnauthorizedAccessException {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -47,11 +50,11 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified auth context has student privileges in any course.
+     * Verifies that the user has student privileges in any course.
      */
-    void verifyStudentInAnyCourse(AuthContext authContext) throws UnauthorizedAccessException {
-        if (authContext.account() != null
-                && !usersLogic.getStudentsByAccountId(authContext.account().getId()).isEmpty()) {
+    void verifyStudentInAnyCourse(RequestContext requestContext) throws UnauthorizedAccessException {
+        if (requestContext.getAccount() != null
+                && !usersLogic.getStudentsByAccountId(requestContext.getAccount().getId()).isEmpty()) {
             return;
         }
 
@@ -59,11 +62,11 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified auth context has instructor privileges in any course.
+     * Verifies that the user has instructor privileges in any course.
      */
-    void verifyInstructorInAnyCourse(AuthContext authContext) throws UnauthorizedAccessException {
-        if (authContext.account() != null
-                && !usersLogic.getInstructorsByAccountId(authContext.account().getId()).isEmpty()) {
+    void verifyInstructorInAnyCourse(RequestContext requestContext) throws UnauthorizedAccessException {
+        if (requestContext.getAccount() != null
+                && !usersLogic.getInstructorsByAccountId(requestContext.getAccount().getId()).isEmpty()) {
             return;
         }
 
@@ -71,10 +74,10 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified auth context has student privileges in the specified course.
+     * Verifies that the user has student privileges in the specified course.
      */
-    void verifyStudentInCourse(AuthContext authContext, String courseId) throws UnauthorizedAccessException {
-        Student student = authLogic.getStudentFromAuthContext(authContext, courseId);
+    void verifyStudentInCourse(RequestContext requestContext, String courseId) throws UnauthorizedAccessException {
+        Student student = requestContext.getStudentForCourse(courseId, authLogic::getStudentFromAuthContext);
         verifyNotNull(student, "student");
 
         if (!student.getCourseId().equals(courseId)) {
@@ -84,11 +87,11 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified auth context has instructor privileges in the specified course.
+     * Verifies that the user has instructor privileges in the specified course.
      */
-    void verifyInstructorInCourse(AuthContext authContext, String courseId)
+    void verifyInstructorInCourse(RequestContext requestContext, String courseId)
             throws UnauthorizedAccessException {
-        Instructor instructor = authLogic.getInstructorFromAuthContext(authContext, courseId);
+        Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
         verifyNotNull(instructor, "instructor");
 
         if (!instructor.getCourseId().equals(courseId)) {

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -95,7 +95,7 @@ final class GateKeeper {
     /**
      * Verifies that the specified student can access the specified feedback session.
      */
-    void verifyAccessible(Student student, FeedbackSession feedbackSession)
+    void verifyStudentCanAccessSession(Student student, FeedbackSession feedbackSession)
             throws UnauthorizedAccessException {
         verifyNotNull(student, "student");
         verifyNotNull(feedbackSession, "feedback session");
@@ -107,6 +107,20 @@ final class GateKeeper {
 
         if (!feedbackSession.isVisible()) {
             throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
+        }
+    }
+
+    /**
+     * Verifies that the specified instructor can access the specified feedback session.
+     */
+    void verifyInstructorCanAccessSession(Instructor instructor, FeedbackSession feedbackSession)
+            throws UnauthorizedAccessException {
+        verifyNotNull(instructor, "instructor");
+        verifyNotNull(feedbackSession, "feedback session");
+
+        if (!instructor.getCourse().equals(feedbackSession.getCourse())) {
+            throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
+                                                  + "] is not accessible to instructor [" + instructor.getEmail() + "]");
         }
     }
 
@@ -138,27 +152,13 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified instructor can access the specified feedback session.
-     */
-    void verifyAccessible(Instructor instructor, FeedbackSession feedbackSession)
-            throws UnauthorizedAccessException {
-        verifyNotNull(instructor, "instructor");
-        verifyNotNull(feedbackSession, "feedback session");
-
-        if (!instructor.getCourse().equals(feedbackSession.getCourse())) {
-            throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
-                                                  + "] is not accessible to instructor [" + instructor.getEmail() + "]");
-        }
-    }
-
-    /**
      * Verifies the instructor and course are not null, the instructor belongs to
      * the course and the instructor has the privilege specified by
      * privilegeName for feedbackSession.
      */
     void verifyAccessible(Instructor instructor, FeedbackSession feedbacksession, String privilegeName)
             throws UnauthorizedAccessException {
-        verifyAccessible(instructor, feedbacksession);
+        verifyInstructorCanAccessSession(instructor, feedbacksession);
 
         if (!instructor.isAllowedForPrivilege(privilegeName)
                 && !instructor.isAllowedForPrivilegeAnySection(feedbacksession.getName(), privilegeName)) {
@@ -173,7 +173,7 @@ final class GateKeeper {
      */
     void verifyAccessible(Instructor instructor, FeedbackSession feedbackSession, String sectionName, String privilegeName)
             throws UnauthorizedAccessException {
-        verifyAccessible(instructor, feedbackSession);
+        verifyInstructorCanAccessSession(instructor, feedbackSession);
 
         if (!instructor.isAllowedForPrivilege(sectionName, feedbackSession.getName(), privilegeName)) {
             throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -152,38 +152,6 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies the instructor and course are not null, the instructor belongs to
-     * the course and the instructor has the privilege specified by
-     * privilegeName for feedbackSession.
-     */
-    void verifyAccessible(Instructor instructor, FeedbackSession feedbacksession, String privilegeName)
-            throws UnauthorizedAccessException {
-        verifyInstructorCanAccessSession(instructor, feedbacksession);
-
-        if (!instructor.isAllowedForPrivilege(privilegeName)
-                && !instructor.isAllowedForPrivilegeAnySection(feedbacksession.getName(), privilegeName)) {
-            throw new UnauthorizedAccessException("Feedback session [" + feedbacksession.getName()
-                                                  + "] is not accessible to instructor [" + instructor.getEmail()
-                                                  + "] for privilege [" + privilegeName + "]");
-        }
-    }
-
-    /**
-     * Verifies that the specified instructor has specified privilege for a section in the specified feedback session.
-     */
-    void verifyAccessible(Instructor instructor, FeedbackSession feedbackSession, String sectionName, String privilegeName)
-            throws UnauthorizedAccessException {
-        verifyInstructorCanAccessSession(instructor, feedbackSession);
-
-        if (!instructor.isAllowedForPrivilege(sectionName, feedbackSession.getName(), privilegeName)) {
-            throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
-                                                  + "] is not accessible to instructor [" + instructor.getEmail()
-                                                  + "] for privilege [" + privilegeName + "] on section ["
-                                                  + sectionName + "]");
-        }
-    }
-
-    /**
      * Verifies that an instructor has submission privilege for a feedback session.
      */
     void verifySessionSubmissionPrivilegeForInstructor(FeedbackSession session, Instructor instructor)

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -2,8 +2,8 @@ package teammates.ui.webapi;
 
 import teammates.common.datatransfer.AuthContext;
 import teammates.common.util.Const;
+import teammates.logic.core.AuthLogic;
 import teammates.logic.core.UsersLogic;
-import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -17,6 +17,7 @@ final class GateKeeper {
     private static final GateKeeper instance = new GateKeeper();
 
     private final UsersLogic usersLogic = UsersLogic.inst();
+    private final AuthLogic authLogic = AuthLogic.inst();
 
     private GateKeeper() {
         // prevent initialization
@@ -70,28 +71,28 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified student can access the specified course.
+     * Verifies that the specified auth context has student privileges in the specified course.
      */
-    void verifyStudentInCourse(Student student, Course course) throws UnauthorizedAccessException {
+    void verifyStudentInCourse(AuthContext authContext, String courseId) throws UnauthorizedAccessException {
+        Student student = authLogic.getStudentFromAuthContext(authContext, courseId);
         verifyNotNull(student, "student");
-        verifyNotNull(course, "course");
 
-        if (!course.equals(student.getCourse())) {
-            throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to student ["
+        if (!student.getCourseId().equals(courseId)) {
+            throw new UnauthorizedAccessException("Course [" + courseId + "] is not accessible to student ["
                     + student.getEmail() + "]");
         }
     }
 
     /**
-     * Verifies that the specified instructor can access the specified course.
+     * Verifies that the specified auth context has instructor privileges in the specified course.
      */
-    void verifyInstructorInCourse(Instructor instructor, Course course)
+    void verifyInstructorInCourse(AuthContext authContext, String courseId)
             throws UnauthorizedAccessException {
+        Instructor instructor = authLogic.getInstructorFromAuthContext(authContext, courseId);
         verifyNotNull(instructor, "instructor");
-        verifyNotNull(course, "course");
 
-        if (!course.equals(instructor.getCourse())) {
-            throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to instructor ["
+        if (!instructor.getCourseId().equals(courseId)) {
+            throw new UnauthorizedAccessException("Course [" + courseId + "] is not accessible to instructor ["
                     + instructor.getEmail() + "]");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -84,7 +84,6 @@ final class GateKeeper {
     void verifyInstructorInCourse(Instructor instructor, Course course)
             throws UnauthorizedAccessException {
         verifyNotNull(instructor, "instructor");
-        verifyNotNull(instructor.getCourse(), "instructor's course");
         verifyNotNull(course, "course");
 
         if (!course.equals(instructor.getCourse())) {
@@ -99,9 +98,7 @@ final class GateKeeper {
     void verifyAccessible(Student student, FeedbackSession feedbackSession)
             throws UnauthorizedAccessException {
         verifyNotNull(student, "student");
-        verifyNotNull(student.getCourse(), "student's course");
         verifyNotNull(feedbackSession, "feedback session");
-        verifyNotNull(feedbackSession.getCourse(), "feedback session's course");
 
         if (!student.getCourse().equals(feedbackSession.getCourse())) {
             throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
@@ -146,9 +143,7 @@ final class GateKeeper {
     void verifyAccessible(Instructor instructor, FeedbackSession feedbackSession)
             throws UnauthorizedAccessException {
         verifyNotNull(instructor, "instructor");
-        verifyNotNull(instructor.getCourse(), "instructor's course");
         verifyNotNull(feedbackSession, "feedback session");
-        verifyNotNull(feedbackSession.getCourse(), "feedback session's course");
 
         if (!instructor.getCourse().equals(feedbackSession.getCourse())) {
             throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -109,10 +109,6 @@ final class GateKeeper {
             throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
                                                   + "] is not accessible to student [" + student.getEmail() + "]");
         }
-
-        if (!feedbackSession.isVisible()) {
-            throw new UnauthorizedAccessException("This feedback session is not yet visible.", true);
-        }
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -127,7 +127,7 @@ final class GateKeeper {
     /**
      * Verifies the instructor is not null and has the privilege specified by privilegeName.
      */
-    void verifyAccessible(Instructor instructor, String privilegeName)
+    void verifyInstructorHasPrivilege(Instructor instructor, String privilegeName)
             throws UnauthorizedAccessException {
         boolean instructorIsAllowedCoursePrivilege = instructor.isAllowedForPrivilege(privilegeName);
         boolean instructorIsAllowedSectionPrivilege = !instructor.getSectionsWithPrivilege(privilegeName).isEmpty();
@@ -140,7 +140,7 @@ final class GateKeeper {
     /**
      * Verifies the instructor is not null and has the privilege specified by privilegeName for sectionName.
      */
-    void verifyAccessible(Instructor instructor, String sectionName, String privilegeName)
+    void verifyInstructorHasPrivilege(Instructor instructor, String sectionName, String privilegeName)
             throws UnauthorizedAccessException {
         verifyNotNull(sectionName, "section name");
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -69,13 +69,28 @@ final class GateKeeper {
     /**
      * Verifies that the specified student can access the specified course.
      */
-    void verifyAccessible(Student student, Course course) throws UnauthorizedAccessException {
+    void verifyStudentInCourse(Student student, Course course) throws UnauthorizedAccessException {
         verifyNotNull(student, "student");
         verifyNotNull(course, "course");
 
         if (!course.equals(student.getCourse())) {
             throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to student ["
                     + student.getEmail() + "]");
+        }
+    }
+
+    /**
+     * Verifies that the specified instructor can access the specified course.
+     */
+    void verifyInstructorInCourse(Instructor instructor, Course course)
+            throws UnauthorizedAccessException {
+        verifyNotNull(instructor, "instructor");
+        verifyNotNull(instructor.getCourse(), "instructor's course");
+        verifyNotNull(course, "course");
+
+        if (!course.equals(instructor.getCourse())) {
+            throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to instructor ["
+                    + instructor.getEmail() + "]");
         }
     }
 
@@ -100,28 +115,13 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified instructor can access the specified course.
-     */
-    void verifyAccessible(Instructor instructor, Course course)
-            throws UnauthorizedAccessException {
-        verifyNotNull(instructor, "instructor");
-        verifyNotNull(instructor.getCourse(), "instructor's course");
-        verifyNotNull(course, "course");
-
-        if (!course.equals(instructor.getCourse())) {
-            throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to instructor ["
-                    + instructor.getEmail() + "]");
-        }
-    }
-
-    /**
      * Verifies the instructor and course are not null, the instructor belongs to
      * the course and the instructor has the privilege specified by
      * privilegeName.
      */
     void verifyAccessible(Instructor instructor, Course course, String privilegeName)
             throws UnauthorizedAccessException {
-        verifyAccessible(instructor, course);
+        verifyInstructorInCourse(instructor, course);
 
         boolean instructorIsAllowedCoursePrivilege = instructor.isAllowedForPrivilege(privilegeName);
         boolean instructorIsAllowedSectionPrivilege = !instructor.getSectionsWithPrivilege(privilegeName).isEmpty();
@@ -138,7 +138,7 @@ final class GateKeeper {
      */
     void verifyAccessible(Instructor instructor, Course course, String sectionName, String privilegeName)
             throws UnauthorizedAccessException {
-        verifyAccessible(instructor, course);
+        verifyInstructorInCourse(instructor, course);
 
         verifyNotNull(sectionName, "section name");
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -98,34 +98,6 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies that the specified student can access the specified feedback session.
-     */
-    void verifyStudentCanAccessSession(Student student, FeedbackSession feedbackSession)
-            throws UnauthorizedAccessException {
-        verifyNotNull(student, "student");
-        verifyNotNull(feedbackSession, "feedback session");
-
-        if (!student.getCourse().equals(feedbackSession.getCourse())) {
-            throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
-                                                  + "] is not accessible to student [" + student.getEmail() + "]");
-        }
-    }
-
-    /**
-     * Verifies that the specified instructor can access the specified feedback session.
-     */
-    void verifyInstructorCanAccessSession(Instructor instructor, FeedbackSession feedbackSession)
-            throws UnauthorizedAccessException {
-        verifyNotNull(instructor, "instructor");
-        verifyNotNull(feedbackSession, "feedback session");
-
-        if (!instructor.getCourse().equals(feedbackSession.getCourse())) {
-            throw new UnauthorizedAccessException("Feedback session [" + feedbackSession.getName()
-                                                  + "] is not accessible to instructor [" + instructor.getEmail() + "]");
-        }
-    }
-
-    /**
      * Verifies the instructor is not null and has the privilege specified by privilegeName.
      */
     void verifyInstructorHasPrivilege(Instructor instructor, String privilegeName)

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -6,7 +6,6 @@ import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseInstructorComment;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -115,36 +114,28 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies the instructor and course are not null, the instructor belongs to
-     * the course and the instructor has the privilege specified by
-     * privilegeName.
+     * Verifies the instructor is not null and has the privilege specified by privilegeName.
      */
-    void verifyAccessible(Instructor instructor, Course course, String privilegeName)
+    void verifyAccessible(Instructor instructor, String privilegeName)
             throws UnauthorizedAccessException {
-        verifyInstructorInCourse(instructor, course);
-
         boolean instructorIsAllowedCoursePrivilege = instructor.isAllowedForPrivilege(privilegeName);
         boolean instructorIsAllowedSectionPrivilege = !instructor.getSectionsWithPrivilege(privilegeName).isEmpty();
         if (!instructorIsAllowedCoursePrivilege && !instructorIsAllowedSectionPrivilege) {
-            throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to instructor ["
-                                                  + instructor.getEmail() + "] for privilege [" + privilegeName + "]");
+            throw new UnauthorizedAccessException("Instructor [" + instructor.getEmail()
+                                                  + "] does not have privilege [" + privilegeName + "]");
         }
     }
 
     /**
-     * Verifies the instructor and course are not null, the instructor belongs to
-     * the course and the instructor has the privilege specified by
-     * privilegeName for sectionName.
+     * Verifies the instructor is not null and has the privilege specified by privilegeName for sectionName.
      */
-    void verifyAccessible(Instructor instructor, Course course, String sectionName, String privilegeName)
+    void verifyAccessible(Instructor instructor, String sectionName, String privilegeName)
             throws UnauthorizedAccessException {
-        verifyInstructorInCourse(instructor, course);
-
         verifyNotNull(sectionName, "section name");
 
         if (!instructor.isAllowedForPrivilege(sectionName, privilegeName)) {
-            throw new UnauthorizedAccessException("Course [" + course.getId() + "] is not accessible to instructor ["
-                                                  + instructor.getEmail() + "] for privilege [" + privilegeName
+            throw new UnauthorizedAccessException("Instructor [" + instructor.getEmail()
+                                                  + "] does not have privilege [" + privilegeName
                                                   + "] on section [" + sectionName + "]");
         }
     }
@@ -217,26 +208,6 @@ final class GateKeeper {
             throw new UnauthorizedAccessException("You don't have submission privilege");
         }
     }
-
-    /**
-     * Verifies that comment is created by instructor.
-     *
-     * @param frc comment to be accessed
-     * @param instructor the instructor who is trying to access the comment
-     */
-    void verifyOwnership(ResponseInstructorComment frc, Instructor instructor)
-            throws UnauthorizedAccessException {
-        verifyNotNull(frc, "feedback response comment");
-        verifyNotNull(frc.getGiver(), "feedback response comment giver");
-        verifyNotNull(instructor, "comment giver");
-
-        if (!frc.getGiver().equals(instructor)) {
-            throw new UnauthorizedAccessException("Comment [" + frc.getId() + "] is not accessible to "
-                    + instructor);
-        }
-    }
-
-    // These methods ensures that the nominal user specified can perform the specified action on a given entity.
 
     private void verifyNotNull(Object object, String typeName)
             throws UnauthorizedAccessException {

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -1,10 +1,8 @@
 package teammates.ui.webapi;
 
 import teammates.common.datatransfer.RequestContext;
-import teammates.common.util.Const;
 import teammates.logic.core.AuthLogic;
 import teammates.logic.core.UsersLogic;
-import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -106,6 +104,14 @@ final class GateKeeper {
     void verifyInstructorHasPrivilege(RequestContext requestContext, String courseId, String... privilegeNames)
             throws UnauthorizedAccessException {
         Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
+        verifyInstructorHasPrivilege(instructor, privilegeNames);
+    }
+
+    /**
+     * Verifies the instructor has the privileges specified by privilegeNames.
+     */
+    void verifyInstructorHasPrivilege(Instructor instructor, String... privilegeNames)
+            throws UnauthorizedAccessException {
         for (String privilegeName : privilegeNames) {
             boolean instructorIsAllowedCoursePrivilege =
                     instructor != null && instructor.isAllowedForPrivilege(privilegeName);
@@ -122,35 +128,22 @@ final class GateKeeper {
      */
     void verifyInstructorHasPrivilegeForSection(RequestContext requestContext, String courseId, String sectionName,
             String... privilegeNames) throws UnauthorizedAccessException {
+        Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
+        verifyInstructorHasPrivilegeForSection(instructor, sectionName, privilegeNames);
+    }
+
+    /**
+     * Verifies the instructor has the privileges specified by privilegeNames for sectionName.
+     */
+    void verifyInstructorHasPrivilegeForSection(Instructor instructor, String sectionName, String... privilegeNames)
+            throws UnauthorizedAccessException {
         verifyNotNull(sectionName, "section name");
 
-        Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
         for (String privilegeName : privilegeNames) {
             if (instructor == null || !instructor.isAllowedForPrivilege(sectionName, privilegeName)) {
                 throw new UnauthorizedAccessException("Instructor does not have privilege [" + privilegeName
                                                       + "] on section [" + sectionName + "]");
             }
-        }
-    }
-
-    /**
-     * Verifies that an instructor has submission privilege for a feedback session.
-     */
-    void verifySessionSubmissionPrivilegeForInstructor(FeedbackSession session, Instructor instructor)
-            throws UnauthorizedAccessException {
-        verifyNotNull(session, "feedback session");
-        verifyNotNull(instructor, "instructor");
-
-        boolean shouldEnableSubmit =
-                instructor.isAllowedForPrivilege(Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
-
-        if (!shouldEnableSubmit && instructor.isAllowedForPrivilegeAnySection(session.getName(),
-                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)) {
-            shouldEnableSubmit = true;
-        }
-
-        if (!shouldEnableSubmit) {
-            throw new UnauthorizedAccessException("You don't have submission privilege");
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GetActionClassesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetActionClassesAction.java
@@ -17,7 +17,7 @@ public class GetActionClassesAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isMaintainer() && !authContext.isAdmin()) {
+        if (!requestContext.isMaintainer() && !requestContext.isAdmin()) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAuthInfoAction.java
@@ -30,9 +30,9 @@ public class GetAuthInfoAction extends PublicAction {
             nextUrl = "";
         }
 
-        UserInfo userInfo = userProvision.getUserInfo(authContext);
+        UserInfo userInfo = userProvision.getUserInfo(requestContext.getAuthContext());
         AuthInfo output = new AuthInfo(
-                createLoginUrl(frontendUrl, nextUrl), userInfo, authContext.authType() == AuthType.MASQUERADE);
+                createLoginUrl(frontendUrl, nextUrl), userInfo, requestContext.getAuthType() == AuthType.MASQUERADE);
         String existingCsrfToken = HttpRequestHelper.getCookieValueFromRequest(req, Const.SecurityConfig.CSRF_COOKIE_NAME);
         if (existingCsrfToken != null && isMatchingCsrfToken(existingCsrfToken, req.getSession().getId())) {
             return new JsonResult(output);

--- a/src/main/java/teammates/ui/webapi/GetCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseAction.java
@@ -20,7 +20,7 @@ public class GetCourseAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -28,12 +28,12 @@ public class GetCourseAction extends Action {
         String entityType = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
 
         if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
             return;
         }
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
-            gateKeeper.verifyStudentInCourse(authContext, courseId);
+            gateKeeper.verifyStudentInCourse(requestContext, courseId);
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseAction.java
@@ -29,12 +29,12 @@ public class GetCourseAction extends Action {
         Course course = logic.getCourse(courseId);
 
         if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
-            gateKeeper.verifyAccessible(getInstructorFromRequest(courseId), course);
+            gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(courseId), course);
             return;
         }
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
-            gateKeeper.verifyAccessible(getStudentFromRequest(courseId), course);
+            gateKeeper.verifyStudentInCourse(getStudentFromRequest(courseId), course);
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseAction.java
@@ -26,15 +26,14 @@ public class GetCourseAction extends Action {
 
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String entityType = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
-        Course course = logic.getCourse(courseId);
 
         if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
-            gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(courseId), course);
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
             return;
         }
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
-            gateKeeper.verifyStudentInCourse(getStudentFromRequest(courseId), course);
+            gateKeeper.verifyStudentInCourse(authContext, courseId);
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetCourseSectionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSectionsAction.java
@@ -27,7 +27,7 @@ public class GetCourseSectionsAction extends Action {
         Course course = logic.getCourse(courseId);
         Instructor instructor = getInstructorFromRequest(courseId);
 
-        gateKeeper.verifyAccessible(instructor, course);
+        gateKeeper.verifyInstructorInCourse(instructor, course);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetCourseSectionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSectionsAction.java
@@ -4,8 +4,6 @@ import java.util.Set;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
-import teammates.storage.entity.Course;
-import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Section;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -24,10 +22,8 @@ public class GetCourseSectionsAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(courseId);
-        Instructor instructor = getInstructorFromRequest(courseId);
 
-        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetCourseSectionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSectionsAction.java
@@ -23,7 +23,7 @@ public class GetCourseSectionsAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
@@ -29,7 +29,7 @@ public class GetCourseSessionResultsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyAccessible(instructor, feedbackSession);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
@@ -28,7 +28,7 @@ public class GetCourseSessionResultsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
@@ -28,8 +28,7 @@ public class GetCourseSessionResultsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetCoursesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCoursesAction.java
@@ -46,7 +46,7 @@ public class GetCoursesAction extends Action {
     }
 
     private JsonResult getStudentCourses() {
-        List<Course> courses = logic.getCoursesForStudentAccount(authContext.account());
+        List<Course> courses = logic.getCoursesForStudentAccount(requestContext.getAccount());
         CoursesData coursesData = new CoursesData(courses);
         List<CourseData> courseDataList = coursesData.getCourses();
 
@@ -58,7 +58,7 @@ public class GetCoursesAction extends Action {
     private JsonResult getInstructorCourses() {
         String courseStatus = getNonNullRequestParamValue(Const.ParamsNames.COURSE_STATUS);
 
-        List<Instructor> instructors = logic.getInstructorsByAccountId(authContext.account().getId());
+        List<Instructor> instructors = logic.getInstructorsByAccountId(requestContext.getAccount().getId());
         List<Course> courses;
 
         switch (courseStatus) {

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -33,7 +33,7 @@ public class GetDeadlineExtensionsAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -32,7 +32,7 @@ public class GetDeadlineExtensionsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -7,7 +7,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.DeadlineExtension;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
@@ -31,9 +30,8 @@ public class GetDeadlineExtensionsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -7,6 +7,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.DeadlineExtension;
 import teammates.storage.entity.FeedbackSession;
+import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
@@ -30,10 +31,9 @@ public class GetDeadlineExtensionsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        gateKeeper.verifyAccessible(
-                getInstructorFromRequest(feedbackSession.getCourseId()),
-                feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -32,7 +32,7 @@ public class GetDeadlineExtensionsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -47,8 +47,7 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyInstructorCanAccessSession(getInstructorFromRequest(courseId),
-                    feedbackSession);
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
             break;
         case INSTRUCTOR_SUBMISSION:
             Instructor instructor = getInstructorOfCourseForSubmission(courseId, true);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -46,8 +46,8 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             checkAccessControlForStudentFeedbackSubmission(student, feedbackSession);
             break;
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyLoggedInUserPrivileges(requestContext);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
             break;
         case INSTRUCTOR_SUBMISSION:
             Instructor instructor = getInstructorOfCourseForSubmission(courseId, true);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -47,7 +47,7 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(getInstructorFromRequest(courseId),
+            gateKeeper.verifyInstructorCanAccessSession(getInstructorFromRequest(courseId),
                     feedbackSession);
             break;
         case INSTRUCTOR_SUBMISSION:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -53,8 +53,9 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
-            gateKeeper.verifyAccessible(getInstructorFromRequest(courseId),
-                    feedbackSession, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            Instructor fullDetailInstructor = getInstructorFromRequest(courseId);
+            gateKeeper.verifyInstructorCanAccessSession(fullDetailInstructor, feedbackSession);
+            gateKeeper.verifyAccessible(fullDetailInstructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -53,9 +53,7 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(requestContext);
-            Instructor fullDetailInstructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-            gateKeeper.verifyInstructorHasPrivilege(fullDetailInstructor,
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
                     Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -55,7 +55,8 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             Instructor fullDetailInstructor = getInstructorFromRequest(courseId);
             gateKeeper.verifyInstructorCanAccessSession(fullDetailInstructor, feedbackSession);
-            gateKeeper.verifyAccessible(fullDetailInstructor, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
+            gateKeeper.verifyInstructorHasPrivilege(fullDetailInstructor,
+                    Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -52,9 +52,9 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
             checkAccessControlForInstructorFeedbackResult(instructor, feedbackSession);
             break;
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            gateKeeper.verifyLoggedInUserPrivileges(requestContext);
             Instructor fullDetailInstructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
             gateKeeper.verifyInstructorHasPrivilege(fullDetailInstructor,
                     Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -54,7 +54,7 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(authContext);
             Instructor fullDetailInstructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorCanAccessSession(fullDetailInstructor, feedbackSession);
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
             gateKeeper.verifyInstructorHasPrivilege(fullDetailInstructor,
                     Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
             break;

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -47,9 +47,9 @@ public class GetFeedbackSessionLogsAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
         gateKeeper.verifyInstructorInCourse(instructor, course);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -46,7 +46,7 @@ public class GetFeedbackSessionLogsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -46,7 +46,7 @@ public class GetFeedbackSessionLogsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -13,7 +13,6 @@ import teammates.common.util.Const;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.FeedbackSessionLog;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -45,11 +44,10 @@ public class GetFeedbackSessionLogsAction extends Action {
             }
         }
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT,
+                Const.InstructorPermissions.CAN_MODIFY_SESSION,
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionLogsAction.java
@@ -46,9 +46,10 @@ public class GetFeedbackSessionLogsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
-        gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_SESSION);
-        gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -29,7 +29,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -6,7 +6,6 @@ import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionSubmittedGiverSet;
@@ -30,9 +29,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -32,7 +32,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
 
-        gateKeeper.verifyAccessible(instructor, feedbackSession);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -29,7 +29,7 @@ public class GetFeedbackSessionsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -43,11 +43,11 @@ public class GetFeedbackSessionsAction extends Action {
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
             if (courseId != null) {
-                gateKeeper.verifyStudentInCourse(authContext, courseId);
+                gateKeeper.verifyStudentInCourse(requestContext, courseId);
             }
         } else {
             if (courseId != null) {
-                gateKeeper.verifyInstructorInCourse(authContext, courseId);
+                gateKeeper.verifyInstructorInCourse(requestContext, courseId);
             }
         }
     }
@@ -63,7 +63,7 @@ public class GetFeedbackSessionsAction extends Action {
 
         if (courseId == null) {
             if (Const.EntityType.STUDENT.equals(entityType)) {
-                List<Student> students = logic.getStudentsByAccountId(authContext.account().getId());
+                List<Student> students = logic.getStudentsByAccountId(requestContext.getAccount().getId());
                 for (Student student : students) {
                     String studentCourseId = student.getCourseId();
                     List<FeedbackSession> sessions = logic.getFeedbackSessionsForCourse(studentCourseId);
@@ -74,7 +74,7 @@ public class GetFeedbackSessionsAction extends Action {
             } else if (Const.EntityType.INSTRUCTOR.equals(entityType)) {
                 boolean isInRecycleBin = getBooleanRequestParamValue(Const.ParamsNames.IS_IN_RECYCLE_BIN);
 
-                instructors = logic.getInstructorsByAccountId(authContext.account().getId());
+                instructors = logic.getInstructorsByAccountId(requestContext.getAccount().getId());
 
                 if (isInRecycleBin) {
                     feedbackSessions = logic.getSoftDeletedFeedbackSessionsForInstructors(instructors);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -45,12 +45,12 @@ public class GetFeedbackSessionsAction extends Action {
         if (Const.EntityType.STUDENT.equals(entityType)) {
             if (courseId != null) {
                 Course course = logic.getCourse(courseId);
-                gateKeeper.verifyAccessible(getStudentFromRequest(courseId), course);
+                gateKeeper.verifyStudentInCourse(getStudentFromRequest(courseId), course);
             }
         } else {
             if (courseId != null) {
                 Course course = logic.getCourse(courseId);
-                gateKeeper.verifyAccessible(getInstructorFromRequest(courseId), course);
+                gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(courseId), course);
             }
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.util.Const;
-import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -44,13 +43,11 @@ public class GetFeedbackSessionsAction extends Action {
 
         if (Const.EntityType.STUDENT.equals(entityType)) {
             if (courseId != null) {
-                Course course = logic.getCourse(courseId);
-                gateKeeper.verifyStudentInCourse(getStudentFromRequest(courseId), course);
+                gateKeeper.verifyStudentInCourse(authContext, courseId);
             }
         } else {
             if (courseId != null) {
-                Course course = logic.getCourse(courseId);
-                gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(courseId), course);
+                gateKeeper.verifyInstructorInCourse(authContext, courseId);
             }
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -43,7 +43,7 @@ public class GetHasResponsesAction extends Action {
 
             String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-            gateKeeper.verifyAccessible(
+            gateKeeper.verifyInstructorInCourse(
                     getInstructorFromRequest(courseId),
                     logic.getCourse(courseId));
 

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -43,7 +43,7 @@ public class GetHasResponsesAction extends Action {
 
             String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
 
             return;
         }
@@ -59,7 +59,7 @@ public class GetHasResponsesAction extends Action {
                 continue;
             }
 
-            gateKeeper.verifyStudentInCourse(authContext, courseId);
+            gateKeeper.verifyStudentInCourse(requestContext, courseId);
         }
     }
 
@@ -123,6 +123,6 @@ public class GetHasResponsesAction extends Action {
         }
 
         String courseId = feedbackQuestion.getCourseId();
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -61,7 +61,7 @@ public class GetHasResponsesAction extends Action {
                 continue;
             }
 
-            gateKeeper.verifyAccessible(
+            gateKeeper.verifyStudentCanAccessSession(
                     getStudentFromRequest(courseId),
                     feedbackSession);
         }
@@ -128,7 +128,7 @@ public class GetHasResponsesAction extends Action {
 
         String courseId = feedbackQuestion.getCourseId();
         FeedbackSession feedbackSession = feedbackQuestion.getFeedbackSession();
-        gateKeeper.verifyAccessible(
+        gateKeeper.verifyInstructorCanAccessSession(
                 getInstructorFromRequest(courseId),
                 feedbackSession);
     }

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -43,9 +43,7 @@ public class GetHasResponsesAction extends Action {
 
             String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-            gateKeeper.verifyInstructorInCourse(
-                    getInstructorFromRequest(courseId),
-                    logic.getCourse(courseId));
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
 
             return;
         }

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -59,9 +59,7 @@ public class GetHasResponsesAction extends Action {
                 continue;
             }
 
-            gateKeeper.verifyStudentCanAccessSession(
-                    getStudentFromRequest(courseId),
-                    feedbackSession);
+            gateKeeper.verifyStudentInCourse(authContext, courseId);
         }
     }
 
@@ -125,9 +123,6 @@ public class GetHasResponsesAction extends Action {
         }
 
         String courseId = feedbackQuestion.getCourseId();
-        FeedbackSession feedbackSession = feedbackQuestion.getFeedbackSession();
-        gateKeeper.verifyInstructorCanAccessSession(
-                getInstructorFromRequest(courseId),
-                feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorAction.java
@@ -39,7 +39,7 @@ public class GetInstructorAction extends BasicFeedbackSubmissionAction {
             }
             break;
         case FULL_DETAIL:
-            gateKeeper.verifyLoggedInUserPrivileges(authContext);
+            gateKeeper.verifyLoggedInUserPrivileges(requestContext);
             break;
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);

--- a/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
@@ -20,7 +20,7 @@ public class GetInstructorPrivilegeAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -43,13 +42,11 @@ public class GetInstructorsAction extends Action {
         if (intentStr == null) {
             // get partial details of instructors with information hiding
             // student should belong to the course
-            Student student = getStudentFromRequest(courseId);
-            gateKeeper.verifyStudentInCourse(student, course);
+            gateKeeper.verifyStudentInCourse(authContext, courseId);
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // this need instructor privileges
-            Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(instructor, course);
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
         } else {
             throw new InvalidHttpParameterException("unknown intent");
         }

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -44,12 +44,12 @@ public class GetInstructorsAction extends Action {
             // get partial details of instructors with information hiding
             // student should belong to the course
             Student student = getStudentFromRequest(courseId);
-            gateKeeper.verifyAccessible(student, course);
+            gateKeeper.verifyStudentInCourse(student, course);
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // this need instructor privileges
             Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyAccessible(instructor, course);
+            gateKeeper.verifyInstructorInCourse(instructor, course);
         } else {
             throw new InvalidHttpParameterException("unknown intent");
         }

--- a/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorsAction.java
@@ -25,7 +25,7 @@ public class GetInstructorsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -42,11 +42,11 @@ public class GetInstructorsAction extends Action {
         if (intentStr == null) {
             // get partial details of instructors with information hiding
             // student should belong to the course
-            gateKeeper.verifyStudentInCourse(authContext, courseId);
+            gateKeeper.verifyStudentInCourse(requestContext, courseId);
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // this need instructor privileges
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         } else {
             throw new InvalidHttpParameterException("unknown intent");
         }
@@ -77,14 +77,14 @@ public class GetInstructorsAction extends Action {
         } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
             // get all instructors of a course without information hiding
             // adds googleId if caller is admin or has the appropriate privilege to modify instructor
-            if (authContext.isAdmin() || getInstructorFromRequest(courseId).getPrivileges()
+            if (requestContext.isAdmin() || getInstructorFromRequest(courseId).getPrivileges()
                     .isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR)) {
                 data = new InstructorsData();
 
                 for (Instructor instructor : instructorsOfCourse) {
                     InstructorData instructorData = new InstructorData(instructor);
                     instructorData.setGoogleId(instructor.getGoogleId());
-                    if (authContext.isAdmin()) {
+                    if (requestContext.isAdmin()) {
                         instructorData.setKey(instructor.getRegKey());
                     }
                     data.getInstructors().add(instructorData);

--- a/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetNotificationsAction.java
@@ -22,7 +22,7 @@ public class GetNotificationsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -34,11 +34,11 @@ public class GetNotificationsAction extends Action {
 
         for (NotificationTargetUser targetUser : targetUsers) {
             if (targetUser == NotificationTargetUser.STUDENT) {
-                gateKeeper.verifyStudentInAnyCourse(authContext);
+                gateKeeper.verifyStudentInAnyCourse(requestContext);
             }
 
             if (targetUser == NotificationTargetUser.INSTRUCTOR) {
-                gateKeeper.verifyInstructorInAnyCourse(authContext);
+                gateKeeper.verifyInstructorInAnyCourse(requestContext);
             }
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionStatsData;
@@ -31,8 +30,7 @@ public class GetSessionResponseStatsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
@@ -20,7 +20,7 @@ public class GetSessionResponseStatsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -30,7 +30,7 @@ public class GetSessionResponseStatsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
@@ -32,7 +32,7 @@ public class GetSessionResponseStatsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyAccessible(instructor, feedbackSession);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -42,7 +42,7 @@ public class GetStudentAction extends Action {
 
             Instructor instructor = getInstructorFromRequest(courseId);
             gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-            gateKeeper.verifyAccessible(instructor,
+            gateKeeper.verifyInstructorHasPrivilege(instructor,
                     student.getTeamName(),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -36,12 +36,12 @@ public class GetStudentAction extends Action {
             }
 
             Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
             gateKeeper.verifyInstructorHasPrivilege(instructor,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
-            gateKeeper.verifyStudentInCourse(authContext, courseId);
+            gateKeeper.verifyStudentInCourse(requestContext, courseId);
         }
     }
 
@@ -64,7 +64,7 @@ public class GetStudentAction extends Action {
         }
 
         StudentData studentData = new StudentData(student);
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             studentData.setKey(student.getRegKey());
             studentData.setGoogleId(
                     Optional.ofNullable(student.getAccount())

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -41,8 +41,8 @@ public class GetStudentAction extends Action {
             }
 
             Instructor instructor = getInstructorFromRequest(courseId);
-
-            gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
+            gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+            gateKeeper.verifyAccessible(instructor,
                     student.getTeamName(),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -47,7 +47,7 @@ public class GetStudentAction extends Action {
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             student = getStudentFromRequest(courseId);
-            gateKeeper.verifyAccessible(student, course);
+            gateKeeper.verifyStudentInCourse(student, course);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.Account;
-import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -35,9 +34,7 @@ public class GetStudentAction extends Action {
                 throw new EntityNotFoundException(STUDENT_NOT_FOUND);
             }
 
-            Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-            gateKeeper.verifyInstructorHasPrivilege(instructor,
+            gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, courseId,
                     student.getSectionName(),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.Account;
-import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
@@ -28,26 +27,21 @@ public class GetStudentAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-
-        Course course = logic.getCourse(courseId);
-
-        Student student;
-
         UUID studentId = getNullableUuidRequestParamValue(Const.ParamsNames.USER_ID);
+
         if (studentId != null) {
-            student = getStudentInCourse(courseId, studentId);
+            Student student = getStudentInCourse(courseId, studentId);
             if (student == null) {
                 throw new EntityNotFoundException(STUDENT_NOT_FOUND);
             }
 
             Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
             gateKeeper.verifyInstructorHasPrivilege(instructor,
-                    student.getTeamName(),
+                    student.getSectionName(),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
-            student = getStudentFromRequest(courseId);
-            gateKeeper.verifyStudentInCourse(student, course);
+            gateKeeper.verifyStudentInCourse(authContext, courseId);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -33,8 +33,8 @@ public class GetStudentsAction extends Action {
         if (teamName == null) {
             // request to get all students of a course by instructor
             Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
-                    Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
+            gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student
             Student student = getStudentFromRequest(courseId);

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -34,7 +34,7 @@ public class GetStudentsAction extends Action {
             // request to get all students of a course by instructor
             Instructor instructor = getInstructorFromRequest(courseId);
             gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
+            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student
             Student student = getStudentFromRequest(courseId);

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -33,7 +33,7 @@ public class GetStudentsAction extends Action {
         if (teamName == null) {
             // request to get all students of a course by instructor
             Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+            gateKeeper.verifyInstructorInCourse(authContext, courseId);
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -23,7 +23,7 @@ public class GetStudentsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (authContext.isAdmin()) {
+        if (requestContext.isAdmin()) {
             return;
         }
 
@@ -33,7 +33,7 @@ public class GetStudentsAction extends Action {
         if (teamName == null) {
             // request to get all students of a course by instructor
             Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(authContext, courseId);
+            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student
@@ -49,7 +49,7 @@ public class GetStudentsAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String teamName = getRequestParamValue(Const.ParamsNames.TEAM_NAME);
 
-        Instructor instructor = authContext.isAdmin()
+        Instructor instructor = requestContext.isAdmin()
                 ? null
                 : getInstructorFromRequest(courseId);
         String privilegeName = Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS;
@@ -58,7 +58,7 @@ public class GetStudentsAction extends Action {
         boolean hasSectionPrivilege = instructor != null
                 && !instructor.getSectionsWithPrivilege(privilegeName).isEmpty();
 
-        if (authContext.isAdmin() || teamName == null && hasCoursePrivilege) {
+        if (requestContext.isAdmin() || teamName == null && hasCoursePrivilege) {
             // request to get all course students by instructor with course privilege
             List<Student> studentsForCourse = logic.getStudentsForCourse(courseId);
 

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -32,9 +32,8 @@ public class GetStudentsAction extends Action {
 
         if (teamName == null) {
             // request to get all students of a course by instructor
-            Instructor instructor = getInstructorFromRequest(courseId);
-            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                    Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             // request to get team member by current student
             Student student = getStudentFromRequest(courseId);

--- a/src/main/java/teammates/ui/webapi/GetTimeZonesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetTimeZonesAction.java
@@ -21,7 +21,7 @@ public class GetTimeZonesAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isMaintainer() && !authContext.isAdmin()) {
+        if (!requestContext.isMaintainer() && !requestContext.isAdmin()) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetUsageStatisticsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetUsageStatisticsAction.java
@@ -24,7 +24,7 @@ public class GetUsageStatisticsAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        if (!authContext.isMaintainer() && !authContext.isAdmin()) {
+        if (!requestContext.isMaintainer() && !requestContext.isAdmin()) {
             throw new UnauthorizedAccessException("Only Maintainers or Admin are allowed to access this resource.");
         }
     }

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -36,7 +36,7 @@ public class JoinCourseAction extends Action {
         User user;
 
         try {
-            user = logic.joinCourse(regKey, authContext.account());
+            user = logic.joinCourse(regKey, requestContext.getAccount());
         } catch (EntityDoesNotExistException ednee) {
             throw new EntityNotFoundException(ednee);
         } catch (EntityAlreadyExistsException eaee) {
@@ -51,7 +51,7 @@ public class JoinCourseAction extends Action {
     private void sendJoinEmail(String courseId, String userName, String userEmail, boolean isInstructor) {
         Course course = logic.getCourse(courseId);
         EmailWrapper email = emailGenerator.generateUserCourseRegisteredEmail(
-                userName, userEmail, authContext.account().getGoogleId(), isInstructor, course);
+                userName, userEmail, requestContext.getAccount().getGoogleId(), isInstructor, course);
         emailSender.sendEmail(email);
     }
 }

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -33,7 +33,7 @@ public class PublishFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -34,7 +34,7 @@ public class PublishFeedbackSessionAction extends Action {
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -33,8 +33,8 @@ public class PublishFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-
-        gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -8,7 +8,6 @@ import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -32,9 +31,8 @@ public class PublishFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -33,7 +33,7 @@ public class PublishFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -37,7 +37,7 @@ public class RemindFeedbackSessionResultAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -36,9 +36,8 @@ public class RemindFeedbackSessionResultAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -37,7 +37,8 @@ public class RemindFeedbackSessionResultAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -37,7 +37,7 @@ public class RemindFeedbackSessionResultAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -38,7 +38,7 @@ public class RemindFeedbackSessionResultAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -37,7 +37,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -36,9 +36,8 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -37,10 +37,8 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyAccessible(
-                instructor,
-                feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -37,7 +37,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -38,7 +38,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -21,8 +21,9 @@ public class RestoreCourseAction extends Action {
         String idOfCourseToRestore = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Course course = logic.getCourse(idOfCourseToRestore);
 
+        gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToRestore), course);
         gateKeeper.verifyAccessible(getInstructorFromRequest(idOfCourseToRestore),
-                course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
+                Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -22,7 +22,7 @@ public class RestoreCourseAction extends Action {
         Course course = logic.getCourse(idOfCourseToRestore);
 
         gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToRestore), course);
-        gateKeeper.verifyAccessible(getInstructorFromRequest(idOfCourseToRestore),
+        gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToRestore),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -2,7 +2,6 @@ package teammates.ui.webapi;
 
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
-import teammates.storage.entity.Course;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -19,9 +18,8 @@ public class RestoreCourseAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToRestore = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(idOfCourseToRestore);
 
-        gateKeeper.verifyInstructorInCourse(getInstructorFromRequest(idOfCourseToRestore), course);
+        gateKeeper.verifyInstructorInCourse(authContext, idOfCourseToRestore);
         gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToRestore),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -19,7 +19,7 @@ public class RestoreCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToRestore = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(authContext, idOfCourseToRestore);
+        gateKeeper.verifyInstructorInCourse(requestContext, idOfCourseToRestore);
         gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToRestore),
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }

--- a/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreCourseAction.java
@@ -19,8 +19,7 @@ public class RestoreCourseAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String idOfCourseToRestore = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        gateKeeper.verifyInstructorInCourse(requestContext, idOfCourseToRestore);
-        gateKeeper.verifyInstructorHasPrivilege(getInstructorFromRequest(idOfCourseToRestore),
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, idOfCourseToRestore,
                 Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -31,7 +31,7 @@ public class RestoreFeedbackSessionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -31,7 +31,7 @@ public class RestoreFeedbackSessionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -30,9 +30,8 @@ public class RestoreFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("The feedback session does not exist.");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -32,7 +32,7 @@ public class RestoreFeedbackSessionAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -30,10 +30,9 @@ public class RestoreFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("The feedback session does not exist.");
         }
 
-        gateKeeper.verifyAccessible(
-                getInstructorFromRequest(feedbackSession.getCourseId()),
-                feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/SearchStudentsAction.java
@@ -27,11 +27,11 @@ public class SearchStudentsAction extends Action {
         String entity = getNonNullRequestParamValue(Const.ParamsNames.ENTITY_TYPE);
 
         if (Const.EntityType.INSTRUCTOR.equals(entity)) {
-            gateKeeper.verifyInstructorInAnyCourse(authContext);
+            gateKeeper.verifyInstructorInAnyCourse(requestContext);
         }
 
         if (Const.EntityType.ADMIN.equals(entity)) {
-            gateKeeper.verifyAdminPrivileges(authContext);
+            gateKeeper.verifyAdminPrivileges(requestContext);
         }
     }
 
@@ -43,7 +43,7 @@ public class SearchStudentsAction extends Action {
         List<Student> students;
 
         if (Const.EntityType.INSTRUCTOR.equals(entity)) {
-            List<Instructor> instructors = logic.getInstructorsByAccountId(authContext.account().getId());
+            List<Instructor> instructors = logic.getInstructorsByAccountId(requestContext.getAccount().getId());
             students = logic.searchStudents(searchKey, instructors);
         } else if (Const.EntityType.ADMIN.equals(entity)) {
             students = logic.searchStudentsInWholeSystem(searchKey);
@@ -55,7 +55,7 @@ public class SearchStudentsAction extends Action {
         for (Student s : students) {
             StudentData studentData = new StudentData(s);
 
-            if (authContext.isAdmin() && Const.EntityType.ADMIN.equals(entity)) {
+            if (requestContext.isAdmin() && Const.EntityType.ADMIN.equals(entity)) {
                 studentData.addAdditionalInformationForAdminSearch(
                         s.getRegKey(),
                         s.getGoogleId(),

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -34,10 +34,10 @@ public class SendJoinReminderEmailAction extends Action {
         Instructor instructor = getInstructorFromRequest(course.getId());
 
         if (user == null || user instanceof Student) {
-            gateKeeper.verifyInstructorInCourse(instructor, course);
+            gateKeeper.verifyInstructorInCourse(authContext, course.getId());
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         } else if (user instanceof Instructor) {
-            gateKeeper.verifyInstructorInCourse(instructor, course);
+            gateKeeper.verifyInstructorInCourse(authContext, course.getId());
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
         }
     }

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -34,10 +34,10 @@ public class SendJoinReminderEmailAction extends Action {
         Instructor instructor = getInstructorFromRequest(course.getId());
 
         if (user == null || user instanceof Student) {
-            gateKeeper.verifyInstructorInCourse(authContext, course.getId());
+            gateKeeper.verifyInstructorInCourse(requestContext, course.getId());
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         } else if (user instanceof Instructor) {
-            gateKeeper.verifyInstructorInCourse(authContext, course.getId());
+            gateKeeper.verifyInstructorInCourse(requestContext, course.getId());
             gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
         }
     }

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -31,14 +31,12 @@ public class SendJoinReminderEmailAction extends Action {
             throw new EntityNotFoundException("Course does not exist!");
         }
 
-        Instructor instructor = getInstructorFromRequest(course.getId());
-
         if (user == null || user instanceof Student) {
-            gateKeeper.verifyInstructorInCourse(requestContext, course.getId());
-            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, course.getId(),
+                    Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         } else if (user instanceof Instructor) {
-            gateKeeper.verifyInstructorInCourse(requestContext, course.getId());
-            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, course.getId(),
+                    Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -34,9 +34,11 @@ public class SendJoinReminderEmailAction extends Action {
         Instructor instructor = getInstructorFromRequest(course.getId());
 
         if (user == null || user instanceof Student) {
-            gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            gateKeeper.verifyInstructorInCourse(instructor, course);
+            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         } else if (user instanceof Instructor) {
-            gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+            gateKeeper.verifyInstructorInCourse(instructor, course);
+            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -35,10 +35,10 @@ public class SendJoinReminderEmailAction extends Action {
 
         if (user == null || user instanceof Student) {
             gateKeeper.verifyInstructorInCourse(instructor, course);
-            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
         } else if (user instanceof Instructor) {
             gateKeeper.verifyInstructorInCourse(instructor, course);
-            gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+            gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
         }
     }
 

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -33,7 +33,7 @@ public class UnpublishFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -33,7 +33,7 @@ public class UnpublishFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -33,8 +33,8 @@ public class UnpublishFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-
-        gateKeeper.verifyAccessible(instructor, feedbackSession, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -8,7 +8,6 @@ import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -32,9 +31,8 @@ public class UnpublishFeedbackSessionAction extends Action {
         if (feedbackSession == null) {
             throw new EntityNotFoundException("Feedback session not found");
         }
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -34,7 +34,7 @@ public class UnpublishFeedbackSessionAction extends Action {
         }
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -27,7 +27,7 @@ public class UpdateCourseAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         Instructor instructor = getInstructorFromRequest(courseId);
 
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -5,7 +5,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.storage.entity.Course;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.CourseData;
@@ -25,10 +24,7 @@ public class UpdateCourseAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Instructor instructor = getInstructorFromRequest(courseId);
-
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_COURSE);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -25,10 +25,9 @@ public class UpdateCourseAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Course course = logic.getCourse(courseId);
         Instructor instructor = getInstructorFromRequest(courseId);
 
-        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -28,7 +28,8 @@ public class UpdateCourseAction extends Action {
         Course course = logic.getCourse(courseId);
         Instructor instructor = getInstructorFromRequest(courseId);
 
-        gateKeeper.verifyAccessible(instructor, course, Const.InstructorPermissions.CAN_MODIFY_COURSE);
+        gateKeeper.verifyInstructorInCourse(instructor, course);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateCourseAction.java
@@ -29,7 +29,7 @@ public class UpdateCourseAction extends Action {
         Instructor instructor = getInstructorFromRequest(courseId);
 
         gateKeeper.verifyInstructorInCourse(instructor, course);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_COURSE);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_COURSE);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -38,7 +38,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -37,7 +37,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -10,6 +10,7 @@ import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
+import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
@@ -35,10 +36,9 @@ public class UpdateDeadlineExtensionsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        gateKeeper.verifyAccessible(
-                getInstructorFromRequest(feedbackSession.getCourseId()),
-                feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -37,7 +37,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -10,7 +10,6 @@ import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
@@ -36,9 +35,8 @@ public class UpdateDeadlineExtensionsAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -37,7 +37,7 @@ public class UpdateFeedbackQuestionAction extends Action {
         FeedbackSession feedbackSession = getNonNullFeedbackSession(
                 feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -6,6 +6,8 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
+import teammates.storage.entity.FeedbackSession;
+import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionData;
@@ -31,9 +33,11 @@ public class UpdateFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        gateKeeper.verifyAccessible(getInstructorFromRequest(feedbackQuestion.getCourseId()),
-                getNonNullFeedbackSession(feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId()),
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackQuestion.getCourseId());
+        FeedbackSession feedbackSession = getNonNullFeedbackSession(
+                feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -7,7 +7,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackQuestionData;
@@ -33,11 +32,10 @@ public class UpdateFeedbackQuestionAction extends Action {
             throw new EntityNotFoundException("Unknown question id");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackQuestion.getCourseId());
         FeedbackSession feedbackSession = getNonNullFeedbackSession(
                 feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -36,7 +36,7 @@ public class UpdateFeedbackQuestionAction extends Action {
         Instructor instructor = getInstructorFromRequest(feedbackQuestion.getCourseId());
         FeedbackSession feedbackSession = getNonNullFeedbackSession(
                 feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -36,7 +36,7 @@ public class UpdateFeedbackQuestionAction extends Action {
         Instructor instructor = getInstructorFromRequest(feedbackQuestion.getCourseId());
         FeedbackSession feedbackSession = getNonNullFeedbackSession(
                 feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -33,7 +33,7 @@ public class UpdateFeedbackSessionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -33,7 +33,7 @@ public class UpdateFeedbackSessionAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -6,6 +6,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
+import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
@@ -31,10 +32,9 @@ public class UpdateFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        gateKeeper.verifyAccessible(
-                getInstructorFromRequest(feedbackSession.getCourseId()),
-                feedbackSession,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -6,7 +6,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
-import teammates.storage.entity.Instructor;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionData;
@@ -32,9 +31,8 @@ public class UpdateFeedbackSessionAction extends Action {
             throw new EntityNotFoundException("Feedback session not found");
         }
 
-        Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -34,7 +34,7 @@ public class UpdateFeedbackSessionAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         gateKeeper.verifyInstructorCanAccessSession(instructor, feedbackSession);
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -28,7 +28,7 @@ public class UpdateInstructorAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -26,9 +26,8 @@ public class UpdateInstructorAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -27,7 +27,7 @@ public class UpdateInstructorAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -27,8 +27,8 @@ public class UpdateInstructorAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorAction.java
@@ -27,7 +27,7 @@ public class UpdateInstructorAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -34,8 +34,8 @@ public class UpdateInstructorPrivilegeAction extends Action {
         String courseId = instructorToUpdate.getCourseId();
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(courseId), Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -33,9 +33,8 @@ public class UpdateInstructorPrivilegeAction extends Action {
 
         String courseId = instructorToUpdate.getCourseId();
 
-        Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -35,7 +35,7 @@ public class UpdateInstructorPrivilegeAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(courseId);
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -34,7 +34,7 @@ public class UpdateInstructorPrivilegeAction extends Action {
         String courseId = instructorToUpdate.getCourseId();
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(courseId));
+        gateKeeper.verifyInstructorInCourse(authContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateInstructorPrivilegeAction.java
@@ -34,7 +34,7 @@ public class UpdateInstructorPrivilegeAction extends Action {
         String courseId = instructorToUpdate.getCourseId();
 
         Instructor instructor = getInstructorFromRequest(courseId);
-        gateKeeper.verifyInstructorInCourse(authContext, courseId);
+        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -47,7 +47,7 @@ public class UpdateResponseInstructorCommentAction extends Action {
         if (comment.getGiver().equals(instructor)) {
             return;
         }
-        gateKeeper.verifyInstructorCanAccessSession(instructor, session);
+        gateKeeper.verifyInstructorInCourse(authContext, session.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, response.getGiver().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         gateKeeper.verifyInstructorHasPrivilege(instructor, response.getRecipient().getSectionName(),

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -48,9 +48,9 @@ public class UpdateResponseInstructorCommentAction extends Action {
             return;
         }
         gateKeeper.verifyInstructorCanAccessSession(instructor, session);
-        gateKeeper.verifyAccessible(instructor, response.getGiver().getSectionName(),
+        gateKeeper.verifyInstructorHasPrivilege(instructor, response.getGiver().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyAccessible(instructor, response.getRecipient().getSectionName(),
+        gateKeeper.verifyInstructorHasPrivilege(instructor, response.getRecipient().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -47,9 +47,10 @@ public class UpdateResponseInstructorCommentAction extends Action {
         if (comment.getGiver().equals(instructor)) {
             return;
         }
-        gateKeeper.verifyAccessible(instructor, session, response.getGiver().getSectionName(),
+        gateKeeper.verifyInstructorCanAccessSession(instructor, session);
+        gateKeeper.verifyAccessible(instructor, response.getGiver().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyAccessible(instructor, session, response.getRecipient().getSectionName(),
+        gateKeeper.verifyAccessible(instructor, response.getRecipient().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -47,7 +47,7 @@ public class UpdateResponseInstructorCommentAction extends Action {
         if (comment.getGiver().equals(instructor)) {
             return;
         }
-        gateKeeper.verifyInstructorInCourse(authContext, session.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, session.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, response.getGiver().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         gateKeeper.verifyInstructorHasPrivilege(instructor, response.getRecipient().getSectionName(),

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -47,10 +47,11 @@ public class UpdateResponseInstructorCommentAction extends Action {
         if (comment.getGiver().equals(instructor)) {
             return;
         }
-        gateKeeper.verifyInstructorInCourse(requestContext, session.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, response.getGiver().getSectionName(),
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(),
+                response.getGiver().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyInstructorHasPrivilege(instructor, response.getRecipient().getSectionName(),
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(),
+                response.getRecipient().getSectionName(),
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -57,8 +57,8 @@ public class UpdateStudentAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(existingStudent.getCourseId());
-        gateKeeper.verifyAccessible(
-                instructor, logic.getCourse(existingStudent.getCourseId()), Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(existingStudent.getCourseId()));
+        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -57,7 +57,7 @@ public class UpdateStudentAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(existingStudent.getCourseId());
-        gateKeeper.verifyInstructorInCourse(authContext, existingStudent.getCourseId());
+        gateKeeper.verifyInstructorInCourse(requestContext, existingStudent.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -57,7 +57,7 @@ public class UpdateStudentAction extends Action {
         }
 
         Instructor instructor = getInstructorFromRequest(existingStudent.getCourseId());
-        gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(existingStudent.getCourseId()));
+        gateKeeper.verifyInstructorInCourse(authContext, existingStudent.getCourseId());
         gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -58,7 +58,7 @@ public class UpdateStudentAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(existingStudent.getCourseId());
         gateKeeper.verifyInstructorInCourse(instructor, logic.getCourse(existingStudent.getCourseId()));
-        gateKeeper.verifyAccessible(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -10,7 +10,6 @@ import teammates.common.util.Const;
 import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
-import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidOperationException;
@@ -56,9 +55,8 @@ public class UpdateStudentAction extends Action {
             throw new EntityNotFoundException(STUDENT_NOT_FOUND_FOR_EDIT);
         }
 
-        Instructor instructor = getInstructorFromRequest(existingStudent.getCourseId());
-        gateKeeper.verifyInstructorInCourse(requestContext, existingStudent.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(instructor, Const.InstructorPermissions.CAN_MODIFY_STUDENT);
+        gateKeeper.verifyInstructorHasPrivilege(requestContext, existingStudent.getCourseId(),
+                Const.InstructorPermissions.CAN_MODIFY_STUDENT);
     }
 
     @Override

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -128,7 +128,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             action.setRecaptchaVerifier(mockRecaptchaVerifier);
             action.setEmailGenerator(mockEmailGenerator);
             action.init(req);
-            stubAuthLogicUsersLogic(action.authContext);
+            stubAuthLogicUsersLogic(action.requestContext.getAuthContext());
             return action;
         } catch (ActionMappingException e) {
             throw new RuntimeException(e);

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -713,6 +713,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
         otherCourseInstructor.setCourse(otherCourse);
         ensureUserHasAccount(otherCourseInstructor);
+        otherCourseInstructor.setGoogleId("other-course-instructor-googleId");
 
         Student sameCourseStudent = getTypicalStudent();
         sameCourseStudent.setCourse(currentCourse);
@@ -858,18 +859,20 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
         logoutUser();
-        loginAsInstructor(sameCourseInstructor.getId().toString());
+        loginAsInstructor(sameCourseInstructor.getGoogleId());
     }
 
     private void loginAsInstructorOfOtherCourse() {
         Instructor otherCourseInstructor = getTypicalInstructor();
         Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
         otherCourseInstructor.setCourse(otherCourse);
+        ensureUserHasAccount(otherCourseInstructor);
+        otherCourseInstructor.setGoogleId("other-course-instructor-googleId");
 
         stubInstructorFromGoogleId(otherCourseInstructor);
 
         logoutUser();
-        loginAsInstructor(otherCourseInstructor.getId().toString());
+        loginAsInstructor(otherCourseInstructor.getGoogleId());
     }
 
     private void verifySameCourseAccessibility(
@@ -887,13 +890,14 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
                 "instructor-googleId", Provider.TEAMMATES_DEV, "validInstructorSubject",
                 "validTenantId", instructor.getName(), instructor.getEmail()));
 
+        instructor.setCourse(thisCourse);
+        instructor.setPrivileges(
+                new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         stubInstructorFromGoogleId(instructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
-        instructor.setCourse(thisCourse);
-
         logoutUser();
-        loginAsInstructor(instructor.getId().toString());
+        loginAsInstructor(instructor.getGoogleId());
         verifyCanAccess(params);
 
         instructor.setPrivileges(instructorPrivileges);
@@ -920,13 +924,14 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         Instructor instructor = getTypicalInstructor();
         ensureUserHasAccount(instructor);
 
+        instructor.setCourse(thisCourse);
+        instructor.setPrivileges(
+                new InstructorPrivileges(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER));
         stubInstructorFromGoogleId(instructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
-        instructor.setCourse(thisCourse);
-
         logoutUser();
-        loginAsInstructor(instructor.getId().toString());
+        loginAsInstructor(instructor.getGoogleId());
         verifyCanAccess(params);
 
         instructor.setPrivileges(instructorPrivileges);
@@ -946,27 +951,29 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         stubStudentFromGoogleId(sameCourseStudent);
 
         logoutUser();
-        loginAsStudent(sameCourseStudent.getId().toString());
+        loginAsStudent(sameCourseStudent.getGoogleId());
     }
 
     private void loginAsStudentOfOtherCourse() {
         Student otherCourseStudent = getTypicalStudent();
         Course otherCourse = new Course("other-course-id", "other-course-name", Const.DEFAULT_TIME_ZONE, "teammates");
         otherCourseStudent.setCourse(otherCourse);
+        ensureUserHasAccount(otherCourseStudent);
+        otherCourseStudent.setGoogleId("other-course-student-googleId");
         stubStudentFromGoogleId(otherCourseStudent);
 
         logoutUser();
-        loginAsStudent(otherCourseStudent.getId().toString());
+        loginAsStudent(otherCourseStudent.getGoogleId());
     }
 
     private void stubInstructorFromGoogleId(Instructor instructor) {
         ensureUserHasAccount(instructor);
-        when(mockLogic.getInstructorByGoogleId(anyString(), anyString())).thenReturn(instructor);
+        when(mockLogic.getInstructorByGoogleId(instructor.getCourseId(), instructor.getGoogleId())).thenReturn(instructor);
     }
 
     private void stubStudentFromGoogleId(Student student) {
         ensureUserHasAccount(student);
-        when(mockLogic.getStudentByGoogleId(anyString(), anyString())).thenReturn(student);
+        when(mockLogic.getStudentByGoogleId(student.getCourseId(), student.getGoogleId())).thenReturn(student);
     }
 
     private void ensureUserHasAccount(User user) {

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +37,8 @@ import teammates.logic.api.MockEmailSender;
 import teammates.logic.api.MockLogsProcessor;
 import teammates.logic.api.MockTaskQueuer;
 import teammates.logic.api.MockUserProvision;
+import teammates.logic.core.AuthLogic;
+import teammates.logic.core.UsersLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
@@ -66,6 +69,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
     static final String DELETE = HttpDelete.METHOD_NAME;
 
     Logic mockLogic = mock(Logic.class);
+    UsersLogic mockUsersLogic = mock(UsersLogic.class);
     MockTaskQueuer mockTaskQueuer = new MockTaskQueuer();
     MockEmailSender mockEmailSender = new MockEmailSender();
     MockLogsProcessor mockLogsProcessor = new MockLogsProcessor();
@@ -124,6 +128,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             action.setRecaptchaVerifier(mockRecaptchaVerifier);
             action.setEmailGenerator(mockEmailGenerator);
             action.init(req);
+            stubAuthLogicUsersLogic(action.authContext);
             return action;
         } catch (ActionMappingException e) {
             throw new RuntimeException(e);
@@ -248,6 +253,40 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             Account account = authContext.account();
             return account == null ? null : mockLogic.getInstructorByGoogleId(courseId, account.getGoogleId());
         }).when(mockLogic).getInstructorFromAuthContext(any(AuthContext.class), anyString());
+    }
+
+    private void stubAuthLogicUsersLogic(AuthContext authContext) {
+        injectUsersLogicIntoAuthLogic(mockUsersLogic);
+
+        doAnswer(invocation -> {
+            UUID accountId = invocation.getArgument(0);
+            String courseId = invocation.getArgument(1);
+            Account account = authContext.account();
+            if (account != null && account.getId().equals(accountId)) {
+                return mockLogic.getStudentByGoogleId(courseId, account.getGoogleId());
+            }
+            return UsersLogic.inst().getStudentByAccountId(accountId, courseId);
+        }).when(mockUsersLogic).getStudentByAccountId(any(UUID.class), anyString());
+
+        doAnswer(invocation -> {
+            UUID accountId = invocation.getArgument(0);
+            String courseId = invocation.getArgument(1);
+            Account account = authContext.account();
+            if (account != null && account.getId().equals(accountId)) {
+                return mockLogic.getInstructorByGoogleId(courseId, account.getGoogleId());
+            }
+            return UsersLogic.inst().getInstructorByAccountId(accountId, courseId);
+        }).when(mockUsersLogic).getInstructorByAccountId(any(UUID.class), anyString());
+    }
+
+    private void injectUsersLogicIntoAuthLogic(UsersLogic usersLogic) {
+        try {
+            Field usersLogicField = AuthLogic.class.getDeclaredField("usersLogic");
+            usersLogicField.setAccessible(true);
+            usersLogicField.set(AuthLogic.inst(), usersLogic);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/test/java/teammates/ui/webapi/GetCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetCourseActionTest.java
@@ -35,6 +35,7 @@ public class GetCourseActionTest extends BaseActionTest<GetCourseAction> {
     void testSpecificAccessControl_courseDoesNotExist_cannotAccess() {
         loginAsInstructor(googleId);
         when(mockLogic.getCourse("course-id")).thenReturn(null);
+        when(mockLogic.getInstructorByGoogleId("course-id", googleId)).thenReturn(null);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "course-id",

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -489,7 +489,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
         GetFeedbackResponsesAction action = getAction(params1);
         UnauthorizedAccessException uae = assertThrows(UnauthorizedAccessException.class, action::checkAccessControl);
-        assertEquals("You don't have submission privilege", uae.getMessage());
+        assertEquals("Instructor does not have privilege [cansubmitsessioninsection]", uae.getMessage());
 
         questionAnswerableToInstructor.setShowGiverNameTo(List.of(ViewerType.INSTRUCTORS));
         questionAnswerableToInstructor.setShowRecipientNameTo(List.of(ViewerType.INSTRUCTORS));

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -504,7 +504,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
         GetFeedbackResponsesAction action2 = getAction(params2);
         UnauthorizedAccessException uae2 = assertThrows(UnauthorizedAccessException.class, action2::checkAccessControl);
-        assertEquals("Instructor [valid1@teammates.tmt] does not have privilege [canmodifysessioncommentinsection]",
+        assertEquals("Instructor does not have privilege [canmodifysessioncommentinsection]",
                 uae2.getMessage());
     }
 
@@ -602,7 +602,8 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
         GetFeedbackResponsesAction action1 = getAction(params1);
         UnauthorizedAccessException uae1 = assertThrows(UnauthorizedAccessException.class, action1::checkAccessControl);
-        assertEquals("Trying to access system using a non-existent instructor entity", uae1.getMessage());
+        assertEquals("Instructor does not have privilege [canmodifysessioncommentinsection] on section [test-section]",
+                uae1.getMessage());
 
         FeedbackQuestion questionThatCannotBeModerated = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -504,8 +504,8 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
         GetFeedbackResponsesAction action2 = getAction(params2);
         UnauthorizedAccessException uae2 = assertThrows(UnauthorizedAccessException.class, action2::checkAccessControl);
-        assertEquals("Feedback session [test-feedbacksession] is not accessible to instructor "
-                + "[valid1@teammates.tmt] for privilege [canmodifysessioncommentinsection]", uae2.getMessage());
+        assertEquals("Instructor [valid1@teammates.tmt] does not have privilege [canmodifysessioncommentinsection]",
+                uae2.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/ui/webapi/GetHasResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetHasResponsesActionTest.java
@@ -235,7 +235,6 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
         };
 
-        when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
 
         ______TS("Non-logged-in users cannot access");
@@ -264,8 +263,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verify(mockLogic, times(2))
                 .getInstructorByGoogleId(typicalCourse.getId(), getTypicalStudent().getGoogleId());
 
-        // check that getCourse and getFeedbackQuestion are run once per test for logged in users
-        verify(mockLogic, times(2)).getCourse(typicalCourse.getId());
+        // check that getFeedbackQuestion is run once per test for logged in users
         verify(mockLogic, times(2)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
 
@@ -281,7 +279,6 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
         };
 
-        when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
 
         Instructor instructorOfOtherCourse = getTypicalInstructor();
@@ -296,7 +293,6 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         verify(mockLogic, times(2))
                 .getInstructorByGoogleId(typicalCourse.getId(), instructorOfOtherCourse.getGoogleId());
-        verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
 
@@ -312,7 +308,6 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
         };
 
-        when(mockLogic.getCourse(typicalCourse.getId())).thenReturn(typicalCourse);
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
         when(mockLogic.getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId()))
                 .thenReturn(typicalInstructor);
@@ -324,7 +319,6 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
 
         verify(mockLogic, times(2))
                 .getInstructorByGoogleId(typicalCourse.getId(), typicalInstructor.getGoogleId());
-        verify(mockLogic, times(1)).getCourse(typicalCourse.getId());
         verify(mockLogic, times(1)).getFeedbackQuestion(typicalFeedbackQuestion.getId());
     }
 

--- a/src/test/java/teammates/ui/webapi/GetHasResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetHasResponsesActionTest.java
@@ -339,7 +339,7 @@ public class GetHasResponsesActionTest extends BaseActionTest<GetHasResponsesAct
         verifyCanAccess(params);
 
         verify(mockLogic, times(1)).getFeedbackSessionsForCourse(typicalCourse.getId());
-        verify(mockLogic, times(3))
+        verify(mockLogic, times(1))
                 .getStudentByGoogleId(typicalStudent.getCourseId(), typicalStudent.getGoogleId());
     }
 

--- a/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
@@ -409,10 +409,6 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     @Test
     void testGetStudents_invalidCourse_cannotAccess() {
         loginAsInstructor(stubInstructorWithAllPrivileges.getGoogleId());
-        when(mockLogic.getInstructorByGoogleId(
-                "invalid-course-id",
-                stubInstructorWithAllPrivileges.getGoogleId()))
-                .thenReturn(stubInstructorWithAllPrivileges);
         when(mockLogic.getCourse("invalid-course-id")).thenReturn(null);
         verifyCannotAccess(
                 Const.ParamsNames.COURSE_ID, "invalid-course-id"


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Introduced RequestContext objects, which currently wraps AuthContext as well as holds a cache for user objects. This can be used to cache other commonly fetched entities in the action layer in the future (course, session, etc.)
2. Refactored gatekeeper to accept AuthContext and `courseId` instead of specific Instructor, Course, FeedbackSession objects.
3. Simplified existing permissions checks. Most checks are now simplified to a single call to gatekeeper.

Note that there are some existing inconsistencies around how privileges are handled, particularly in submission vs non-submission flows. This will be resolved in a future PR.