### PR TITLE
[#14064] Replace index-based loops with for-of loops on frontend

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,7 +64,6 @@ module.exports = defineConfig(
       '@typescript-eslint/no-deprecated': 'warn',
       // The rules below are mostly stylistic rules that are deemed reasonable to be disabled.
       // They can be re-enabled in the future if desired.
-      '@typescript-eslint/prefer-for-of': 'off',
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/consistent-generic-constructors': 'off',

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -403,7 +403,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       (value: string | EnrollStatus) => typeof value === 'string',
     );
 
-    for (let i = 0; i < statuses.length; i += 1) {
+    for (const _status of statuses) {
       studentLists.push([]);
     }
 

--- a/src/web/app/pipes/search-terms-highlighter.pipe.spec.ts
+++ b/src/web/app/pipes/search-terms-highlighter.pipe.spec.ts
@@ -43,10 +43,8 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: '<span class="highlighted-text">Student</span>',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
-      expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch),
-      ).toEqual(consolidatedSamples[i].expected);
+    for (const sample of consolidatedSamples) {
+      expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch)).toEqual(sample.expected);
     }
   });
 
@@ -65,10 +63,8 @@ describe('SearchTermsHighlighterPipe', () => {
         sampleValue: 'Student',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
-      expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch),
-      ).toEqual(consolidatedSamples[i].sampleValue);
+    for (const sample of consolidatedSamples) {
+      expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch)).toEqual(sample.sampleValue);
     }
   });
 
@@ -121,10 +117,8 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: '<span class="highlighted-text">new student</span>' + ' <span class="highlighted-text">team</span> a',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
-      expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch),
-      ).toEqual(consolidatedSamples[i].expected);
+    for (const sample of consolidatedSamples) {
+      expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch)).toEqual(sample.expected);
     }
   });
 
@@ -163,10 +157,8 @@ describe('SearchTermsHighlighterPipe', () => {
           'r</span>s<span class="highlighted-text">e</span>',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
-      expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-      ).toEqual(consolidatedSamples[i].expected);
+    for (const sample of consolidatedSamples) {
+      expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true)).toEqual(sample.expected);
     }
   });
 
@@ -198,10 +190,8 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: '',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
-      expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-      ).toEqual(consolidatedSamples[i].expected);
+    for (const sample of consolidatedSamples) {
+      expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true)).toEqual(sample.expected);
     }
   });
 
@@ -256,10 +246,8 @@ describe('SearchTermsHighlighterPipe', () => {
           expected: 'Test<span class="highlighted-text"> Course</span>',
         },
       ];
-      for (let i = 0; i < consolidatedSamples.length; i += 1) {
-        expect(
-          highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-        ).toEqual(consolidatedSamples[i].expected);
+      for (const sample of consolidatedSamples) {
+        expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true)).toEqual(sample.expected);
       }
     },
   );
@@ -277,10 +265,8 @@ describe('SearchTermsHighlighterPipe', () => {
         expected: 'Test Course',
       },
     ];
-    for (let i = 0; i < consolidatedSamples.length; i += 1) {
-      expect(
-        highlighterPipe.transform(consolidatedSamples[i].sampleValue, consolidatedSamples[i].sampleSearch, true),
-      ).toEqual(consolidatedSamples[i].expected);
+    for (const sample of consolidatedSamples) {
+      expect(highlighterPipe.transform(sample.sampleValue, sample.sampleSearch, true)).toEqual(sample.expected);
     }
   });
 });

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -722,9 +722,9 @@ export function calculateRubricQuestionStatistics(
   stats.isWeightStatsVisible = stats.hasWeights && stats.weights.length > 0 && stats.weights[0].length > 0;
 
   const emptyAnswers: number[][] = [];
-  for (let i = 0; i < question.rubricSubQuestions.length; i += 1) {
+  for (const _subQuestion of question.rubricSubQuestions) {
     const subQuestionAnswers: number[] = [];
-    for (let j = 0; j < question.rubricChoices.length; j += 1) {
+    for (const _choice of question.rubricChoices) {
       subQuestionAnswers.push(0);
     }
     emptyAnswers.push(subQuestionAnswers);
@@ -878,8 +878,8 @@ function sumValidValuesByColumn(matrix: number[][]): number[] {
   const sums: number[] = [];
   for (let c = 0; c < matrix[0].length; c += 1) {
     let sum = 0;
-    for (let r = 0; r < matrix.length; r += 1) {
-      sum += matrix[r][c] === null ? 0 : matrix[r][c];
+    for (const row of matrix) {
+      sum += row[c] === null ? 0 : row[c];
     }
     sums[c] = sum;
   }
@@ -891,8 +891,8 @@ function countValidValuesByColumn(matrix: number[][]): number[] {
   const counts: number[] = [];
   for (let c = 0; c < matrix[0].length; c += 1) {
     let count = 0;
-    for (let r = 0; r < matrix.length; r += 1) {
-      count += matrix[r][c] === null ? 0 : 1;
+    for (const row of matrix) {
+      count += row[c] === null ? 0 : 1;
     }
     counts[c] = count;
   }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes [#14064](https://github.com/TEAMMATES/teammates/issues/14064)

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
- Re-enables the `@typescript-eslint/prefer-for-of` ESLint rule by removing its override in `eslint.config.js`.
- Converts all 12 reported index-based for loops to for...of across `question-statistics.util.ts`, `search-terms-highlighter.pipe.spec.ts`, and `instructor-course-enroll-page.component.ts`.
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->
