### PR TITLE
[#14095] Classify nobody-specific questions as Ungrouped Questions

### DIFF
--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -864,6 +864,68 @@ describe('SessionSubmissionPageComponent', () => {
     expect(component.questionsNeedingSubmission.length).toEqual(0);
   });
 
+  it('should classify a question for nobody specific as ungrouped instead of grouping it by recipient', () => {
+    const testSessionSubmissionData: SessionSubmission = {
+      questions: [
+        {
+          question: {
+            feedbackQuestionId: testTextQuestionSubmissionForm.feedbackQuestionId,
+            questionNumber: testTextQuestionSubmissionForm.questionNumber,
+            questionBrief: testTextQuestionSubmissionForm.questionBrief,
+            questionDescription: testTextQuestionSubmissionForm.questionDescription,
+            questionDetails: testTextQuestionSubmissionForm.questionDetails,
+            questionType: testTextQuestionSubmissionForm.questionType,
+            giverType: testTextQuestionSubmissionForm.giverType,
+            recipientType: QuestionRecipientType.STUDENTS,
+            numberOfEntitiesToGiveFeedbackToSetting:
+              testTextQuestionSubmissionForm.numberOfEntitiesToGiveFeedbackToSetting,
+            customNumberOfEntitiesToGiveFeedbackTo:
+              testTextQuestionSubmissionForm.customNumberOfEntitiesToGiveFeedbackTo,
+            showResponsesTo: testTextQuestionSubmissionForm.showResponsesTo,
+            showGiverNameTo: testTextQuestionSubmissionForm.showGiverNameTo,
+            showRecipientNameTo: testTextQuestionSubmissionForm.showRecipientNameTo,
+          },
+          recipients: [{ identifier: 'barry-harris-id', name: 'Barry Harris', section: 'Section A', team: 'Team 1' }],
+          responses: [],
+        },
+        {
+          question: {
+            feedbackQuestionId: 'feedback-question-id-general',
+            questionNumber: 11,
+            questionBrief: testTextQuestionSubmissionForm.questionBrief,
+            questionDescription: testTextQuestionSubmissionForm.questionDescription,
+            questionDetails: testTextQuestionSubmissionForm.questionDetails,
+            questionType: testTextQuestionSubmissionForm.questionType,
+            giverType: testTextQuestionSubmissionForm.giverType,
+            recipientType: QuestionRecipientType.NONE,
+            numberOfEntitiesToGiveFeedbackToSetting:
+              testTextQuestionSubmissionForm.numberOfEntitiesToGiveFeedbackToSetting,
+            customNumberOfEntitiesToGiveFeedbackTo:
+              testTextQuestionSubmissionForm.customNumberOfEntitiesToGiveFeedbackTo,
+            showResponsesTo: testTextQuestionSubmissionForm.showResponsesTo,
+            showGiverNameTo: testTextQuestionSubmissionForm.showGiverNameTo,
+            showRecipientNameTo: testTextQuestionSubmissionForm.showRecipientNameTo,
+          },
+          recipients: [{ identifier: '%GENERAL%', name: '-', section: '', team: '' }],
+          responses: [],
+        },
+      ],
+    };
+
+    vi.spyOn(feedbackSessionsService, 'getSessionSubmissionData').mockReturnValue(of(testSessionSubmissionData));
+
+    component.loadFeedbackQuestions();
+
+    // The question for nobody specific is treated as ungroupable
+    expect(component.ungroupableQuestionsSorted).toContain(11);
+    expect(component.recipientQuestionMap.has('%GENERAL%')).toBe(false);
+    // The question with a specific recipient is still grouped by that recipient
+    expect(component.ungroupableQuestionsSorted).not.toContain(testTextQuestionSubmissionForm.questionNumber);
+    expect(
+      component.recipientQuestionMap.get('barry-harris-id')?.has(testTextQuestionSubmissionForm.questionNumber),
+    ).toBe(true);
+  });
+
   it('should check that there are no responses to submit', () => {
     const testSubmissionForm: QuestionSubmissionFormModel = deepCopy(testTextQuestionSubmissionForm);
     testSubmissionForm.recipientSubmissionForms = [];

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -537,6 +537,7 @@ export class SessionSubmissionPageComponent implements OnInit {
   private addQuestionGrouping(model: QuestionSubmissionFormModel): void {
     const isGroupableQuestion =
       this.getQuestionSubmissionFormModeInDefaultView(model) === QuestionSubmissionFormMode.FIXED_RECIPIENT &&
+      model.recipientType !== QuestionRecipientType.NONE &&
       model.questionType !== FeedbackQuestionType.RANK_RECIPIENTS &&
       model.questionType !== FeedbackQuestionType.CONSTSUM_RECIPIENTS &&
       model.questionType !== FeedbackQuestionType.CONTRIB;


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes [#14095](https://github.com/TEAMMATES/teammates/issues/14095)

**Outline of Solution**

- Added a `recipientType !== NONE` check in `addQuestionGrouping` so `Nobody specific (general feedback)` questions are classified as `ungroupable` instead of being grouped under a blank - recipient in the "Group by recipient" view.
- Added a unit test verifying a `NONE-recipient question` lands in `ungroupableQuestionsSorted` (not recipientQuestionMap), while a specific-recipient question stays grouped.
- All tests passed. 

**Screenshots**
<img width="1254" height="635" alt="Screenshot 2026-06-06 at 01 20 56" src="https://github.com/user-attachments/assets/a0162bee-b909-4755-946b-6df8ef734da3" />

<img width="559" height="130" alt="image" src="https://github.com/user-attachments/assets/11490fbf-ffc6-4329-aff7-b3d579296479" />

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->
