### PR TITLE
[#14092] Exhaustively handle no-recipient warning messages

### DIFF
--- a/src/web/app/components/question-submission-form/no-recipients-warning.component.html
+++ b/src/web/app/components/question-submission-form/no-recipients-warning.component.html
@@ -1,17 +1,9 @@
 @switch (recipientType) {
-  @case (QuestionRecipientType.OWN_TEAM_MEMBERS) {
+  @case (QuestionRecipientType.STUDENTS) {
     <div class="alert alert-warning" role="alert">
       <span
-        >This question is for team members and you don't have any team members. Therefore, you will not be able to
-        answer this question.</span
-      >
-    </div>
-  }
-  @case (QuestionRecipientType.TEAMS_EXCLUDING_SELF) {
-    <div class="alert alert-warning" role="alert">
-      <span
-        >This question is for other teams in this course and this course doesn't have any other team. Therefore, you
-        will not be able to answer this question.</span
+        >This question is for students in this course and this course doesn't have any student. Therefore, you will not
+        be able to answer this question.</span
       >
     </div>
   }
@@ -23,32 +15,65 @@
       >
     </div>
   }
-  @case (QuestionRecipientType.SELF) {
-    <!-- The giver is always a valid recipient of a self-evaluation question, so no warning is needed. -->
-  }
-  @case (QuestionRecipientType.STUDENTS) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
-  }
   @case (QuestionRecipientType.STUDENTS_IN_SAME_SECTION) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
-  }
-  @case (QuestionRecipientType.INSTRUCTORS) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for other students in your section and your section doesn't have any other student. Therefore,
+        you will not be able to answer this question.</span
+      >
+    </div>
   }
   @case (QuestionRecipientType.TEAMS) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for teams in this course and this course doesn't have any team. Therefore, you will not be
+        able to answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.TEAMS_EXCLUDING_SELF) {
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for other teams in this course and this course doesn't have any other team. Therefore, you
+        will not be able to answer this question.</span
+      >
+    </div>
   }
   @case (QuestionRecipientType.TEAMS_IN_SAME_SECTION) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for other teams in your section and your section doesn't have any other team. Therefore, you
+        will not be able to answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.INSTRUCTORS) {
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for instructors and there are no instructors you can give feedback to. Therefore, you will not
+        be able to answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.OWN_TEAM_MEMBERS) {
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for team members and you don't have any team members. Therefore, you will not be able to
+        answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.SELF) {
+    <!-- The giver is always a valid recipient of a self-evaluation question, so an empty recipient list is impossible. -->
   }
   @case (QuestionRecipientType.OWN_TEAM) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+    <!-- Only a student giver can use this path and a student always has an own team, so an empty recipient list is impossible. -->
   }
   @case (QuestionRecipientType.OWN_TEAM_MEMBERS_INCLUDING_SELF) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+    <!-- The giver is always included as a recipient, so an empty recipient list is impossible. -->
   }
   @case (QuestionRecipientType.NONE) {
-    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+    <!-- This question type has no specific recipient, so a "no valid recipients" warning is not applicable. -->
   }
   @default never;
 }

--- a/src/web/app/components/question-submission-form/no-recipients-warning.component.html
+++ b/src/web/app/components/question-submission-form/no-recipients-warning.component.html
@@ -1,0 +1,54 @@
+@switch (recipientType) {
+  @case (QuestionRecipientType.OWN_TEAM_MEMBERS) {
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for team members and you don't have any team members. Therefore, you will not be able to
+        answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.TEAMS_EXCLUDING_SELF) {
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for other teams in this course and this course doesn't have any other team. Therefore, you
+        will not be able to answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.STUDENTS_EXCLUDING_SELF) {
+    <div class="alert alert-warning" role="alert">
+      <span
+        >This question is for other students in this course and this course doesn't have any other student. Therefore,
+        you will not be able to answer this question.</span
+      >
+    </div>
+  }
+  @case (QuestionRecipientType.SELF) {
+    <!-- The giver is always a valid recipient of a self-evaluation question, so no warning is needed. -->
+  }
+  @case (QuestionRecipientType.STUDENTS) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.STUDENTS_IN_SAME_SECTION) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.INSTRUCTORS) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.TEAMS) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.TEAMS_IN_SAME_SECTION) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.OWN_TEAM) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.OWN_TEAM_MEMBERS_INCLUDING_SELF) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @case (QuestionRecipientType.NONE) {
+    <!-- A "no valid recipients" warning is not applicable for this recipient type. -->
+  }
+  @default never;
+}

--- a/src/web/app/components/question-submission-form/no-recipients-warning.component.spec.ts
+++ b/src/web/app/components/question-submission-form/no-recipients-warning.component.spec.ts
@@ -33,6 +33,26 @@ describe('NoRecipientsWarningComponent', () => {
     );
   });
 
+  it('should show the students warning for STUDENTS', () => {
+    component.recipientType = QuestionRecipientType.STUDENTS;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for students in this course and this course doesn't have any student. Therefore, you will not " +
+        'be able to answer this question.',
+    );
+  });
+
+  it('should show the teams warning for TEAMS', () => {
+    component.recipientType = QuestionRecipientType.TEAMS;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for teams in this course and this course doesn't have any team. Therefore, you will not be " +
+        'able to answer this question.',
+    );
+  });
+
   it('should show the other teams warning for TEAMS_EXCLUDING_SELF', () => {
     component.recipientType = QuestionRecipientType.TEAMS_EXCLUDING_SELF;
     fixture.detectChanges();
@@ -53,13 +73,38 @@ describe('NoRecipientsWarningComponent', () => {
     );
   });
 
+  it('should show the same section students warning for STUDENTS_IN_SAME_SECTION', () => {
+    component.recipientType = QuestionRecipientType.STUDENTS_IN_SAME_SECTION;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for other students in your section and your section doesn't have any other student. Therefore, " +
+        'you will not be able to answer this question.',
+    );
+  });
+
+  it('should show the same section teams warning for TEAMS_IN_SAME_SECTION', () => {
+    component.recipientType = QuestionRecipientType.TEAMS_IN_SAME_SECTION;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for other teams in your section and your section doesn't have any other team. Therefore, you " +
+        'will not be able to answer this question.',
+    );
+  });
+
+  it('should show the instructors warning for INSTRUCTORS', () => {
+    component.recipientType = QuestionRecipientType.INSTRUCTORS;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      'This question is for instructors and there are no instructors you can give feedback to. Therefore, you will not ' +
+        'be able to answer this question.',
+    );
+  });
+
   const recipientTypesWithoutWarning: QuestionRecipientType[] = [
     QuestionRecipientType.SELF,
-    QuestionRecipientType.STUDENTS,
-    QuestionRecipientType.STUDENTS_IN_SAME_SECTION,
-    QuestionRecipientType.INSTRUCTORS,
-    QuestionRecipientType.TEAMS,
-    QuestionRecipientType.TEAMS_IN_SAME_SECTION,
     QuestionRecipientType.OWN_TEAM,
     QuestionRecipientType.OWN_TEAM_MEMBERS_INCLUDING_SELF,
     QuestionRecipientType.NONE,

--- a/src/web/app/components/question-submission-form/no-recipients-warning.component.spec.ts
+++ b/src/web/app/components/question-submission-form/no-recipients-warning.component.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { NoRecipientsWarningComponent } from './no-recipients-warning.component';
+import { QuestionRecipientType } from '../../../types/api-output';
+
+describe('NoRecipientsWarningComponent', () => {
+  let component: NoRecipientsWarningComponent;
+  let fixture: ComponentFixture<NoRecipientsWarningComponent>;
+
+  const getWarning = (): HTMLElement | null => {
+    const warning = fixture.debugElement.query(By.css('.alert.alert-warning'));
+    return warning ? (warning.nativeElement as HTMLElement) : null;
+  };
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NoRecipientsWarningComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should show the team members warning for OWN_TEAM_MEMBERS', () => {
+    component.recipientType = QuestionRecipientType.OWN_TEAM_MEMBERS;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for team members and you don't have any team members. Therefore, you will not be able to answer " +
+        'this question.',
+    );
+  });
+
+  it('should show the other teams warning for TEAMS_EXCLUDING_SELF', () => {
+    component.recipientType = QuestionRecipientType.TEAMS_EXCLUDING_SELF;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for other teams in this course and this course doesn't have any other team. Therefore, you will " +
+        'not be able to answer this question.',
+    );
+  });
+
+  it('should show the other students warning for STUDENTS_EXCLUDING_SELF', () => {
+    component.recipientType = QuestionRecipientType.STUDENTS_EXCLUDING_SELF;
+    fixture.detectChanges();
+
+    expect(getWarning()?.textContent).toContain(
+      "This question is for other students in this course and this course doesn't have any other student. Therefore, " +
+        'you will not be able to answer this question.',
+    );
+  });
+
+  const recipientTypesWithoutWarning: QuestionRecipientType[] = [
+    QuestionRecipientType.SELF,
+    QuestionRecipientType.STUDENTS,
+    QuestionRecipientType.STUDENTS_IN_SAME_SECTION,
+    QuestionRecipientType.INSTRUCTORS,
+    QuestionRecipientType.TEAMS,
+    QuestionRecipientType.TEAMS_IN_SAME_SECTION,
+    QuestionRecipientType.OWN_TEAM,
+    QuestionRecipientType.OWN_TEAM_MEMBERS_INCLUDING_SELF,
+    QuestionRecipientType.NONE,
+  ];
+
+  recipientTypesWithoutWarning.forEach((recipientType: QuestionRecipientType) => {
+    it(`should not show any warning for ${recipientType}`, () => {
+      component.recipientType = recipientType;
+      fixture.detectChanges();
+
+      expect(getWarning()).toBeNull();
+    });
+  });
+});

--- a/src/web/app/components/question-submission-form/no-recipients-warning.component.ts
+++ b/src/web/app/components/question-submission-form/no-recipients-warning.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input } from '@angular/core';
+import { QuestionRecipientType } from '../../../types/api-output';
+
+/**
+ * Warning shown when there are no valid recipients for a question.
+ */
+@Component({
+  selector: 'tm-no-recipients-warning',
+  templateUrl: './no-recipients-warning.component.html',
+})
+export class NoRecipientsWarningComponent {
+  // enum
+  QuestionRecipientType!: typeof QuestionRecipientType;
+
+  @Input()
+  recipientType: QuestionRecipientType = QuestionRecipientType.NONE;
+
+  constructor() {
+    this.QuestionRecipientType = QuestionRecipientType;
+  }
+}

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -450,26 +450,7 @@
       }
     </div>
     @if (!model.recipientList.length) {
-      <div class="alert alert-warning" role="alert">
-        @if (model.recipientType === QuestionRecipientType.OWN_TEAM_MEMBERS) {
-          <span
-            >This question is for team members and you don't have any team members. Therefore, you will not be able to
-            answer this question.</span
-          >
-        }
-        @if (model.recipientType === QuestionRecipientType.TEAMS_EXCLUDING_SELF) {
-          <span
-            >This question is for other teams in this course and this course doesn't have any other team. Therefore, you
-            will not be able to answer this question.</span
-          >
-        }
-        @if (model.recipientType === QuestionRecipientType.STUDENTS_EXCLUDING_SELF) {
-          <span
-            >This question is for other students in this course and this course doesn't have any other student.
-            Therefore, you will not be able to answer this question.</span
-          >
-        }
-      </div>
+      <tm-no-recipients-warning [recipientType]="model.recipientType"></tm-no-recipients-warning>
     }
     @if (model.recipientList.length > 0 && currentSelectedSessionView === allSessionViews.DEFAULT) {
       <div class="row">

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -10,6 +10,7 @@ import {
   QuestionSubmissionFormModel,
   ResponseSubmissionStatus,
 } from './question-submission-form-model';
+import { NoRecipientsWarningComponent } from './no-recipients-warning.component';
 import { RecipientTypeNamePipe } from './recipient-type-name.pipe';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
 import { FeedbackResponsesService } from '../../../services/feedback-responses.service';
@@ -104,6 +105,7 @@ import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
     VisibilityEntityNamePipe,
     VisibilityCapabilityPipe,
     RecipientTypeNamePipe,
+    NoRecipientsWarningComponent,
   ],
 })
 export class QuestionSubmissionFormComponent implements DoCheck {

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1623,11 +1623,8 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
               class="col-12 constraint-margins"
             >
             </div>
-            <div
-              class="alert alert-warning"
-              role="alert"
-            >
-            </div>
+            <tm-no-recipients-warning>
+            </tm-no-recipients-warning>
           </div>
         </div>
       </tm-question-submission-form>
@@ -4609,11 +4606,8 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
               class="col-12 constraint-margins"
             >
             </div>
-            <div
-              class="alert alert-warning"
-              role="alert"
-            >
-            </div>
+            <tm-no-recipients-warning>
+            </tm-no-recipients-warning>
           </div>
         </div>
       </tm-question-submission-form>

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1624,6 +1624,14 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
             >
             </div>
             <tm-no-recipients-warning>
+              <div
+                class="alert alert-warning"
+                role="alert"
+              >
+                <span>
+                  This question is for teams in this course and this course doesn't have any team. Therefore, you will not be able to answer this question.
+                </span>
+              </div>
             </tm-no-recipients-warning>
           </div>
         </div>
@@ -4607,6 +4615,14 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
             >
             </div>
             <tm-no-recipients-warning>
+              <div
+                class="alert alert-warning"
+                role="alert"
+              >
+                <span>
+                  This question is for teams in this course and this course doesn't have any team. Therefore, you will not be able to answer this question.
+                </span>
+              </div>
             </tm-no-recipients-warning>
           </div>
         </div>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes [#14092](https://github.com/TEAMMATES/teammates/issues/14092)

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
### Problem
- The "no valid recipients" warning only covered 3 of 12 `QuestionRecipientType`
values. Other types silently rendered an empty `alert alert-warning` box.

### Solution
- Extracted the warning into a dedicated `tm-no-recipients-warning` component.
- Used `@switch` with `@default never;` so all recipient types are handled
  exhaustively — a missing case now fails at **compile time**.
- Non-applicable types have explicit, documented `@case`s that render nothing
  (fixes the empty alert box).

### Notes
- Original 3 messages preserved verbatim.
- Added unit tests for the new component; updated affected page snapshot.
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->
