### PR TITLE
[#14144] Enable @typescript-eslint/prefer-nullish-coalescing and remove rule override

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,7 +74,7 @@ module.exports = defineConfig(
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/prefer-nullish-coalescing': 'off',
+      '@typescript-eslint/prefer-nullish-coalescing': 'error',
       '@typescript-eslint/no-floating-promises': 'off',
       '@typescript-eslint/unbound-method': 'off',
       '@typescript-eslint/no-misused-promises': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,7 +74,6 @@ module.exports = defineConfig(
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/prefer-nullish-coalescing': 'error',
       '@typescript-eslint/no-floating-promises': 'off',
       '@typescript-eslint/unbound-method': 'off',
       '@typescript-eslint/no-misused-promises': 'off',

--- a/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.ts
+++ b/src/web/app/components/extension-confirm-modal/extension-confirm-modal.component.ts
@@ -316,8 +316,8 @@ export class ExtensionConfirmModalComponent implements OnInit {
           strB = b.email;
           break;
         case SortBy.INSTRUCTOR_PERMISSION_ROLE:
-          strA = a.role || '';
-          strB = b.role || '';
+          strA = a.role ?? '';
+          strB = b.role ?? '';
           break;
         case SortBy.SESSION_END_DATE:
           strA = a.extensionDeadline.toString();

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -335,9 +335,9 @@ export class QuestionSubmissionFormComponent implements DoCheck {
         firstRecipient: FeedbackResponseRecipientSubmissionFormModel,
         secondRecipient: FeedbackResponseRecipientSubmissionFormModel,
       ) => {
-        const firstRecipientIndex: number = indexes.get(firstRecipient.recipientIdentifier) || Number.MAX_SAFE_INTEGER;
+        const firstRecipientIndex: number = indexes.get(firstRecipient.recipientIdentifier) ?? Number.MAX_SAFE_INTEGER;
         const secondRecipientIndex: number =
-          indexes.get(secondRecipient.recipientIdentifier) || Number.MAX_SAFE_INTEGER;
+          indexes.get(secondRecipient.recipientIdentifier) ?? Number.MAX_SAFE_INTEGER;
 
         return firstRecipientIndex - secondRecipientIndex;
       },

--- a/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/constsum-options-question-edit-answer-form.component.ts
@@ -100,7 +100,7 @@ export class ConstsumOptionsQuestionEditAnswerFormComponent extends QuestionEdit
    * Checks if any of the points are below the minPoint.
    */
   get isAnyPointBelowMinimum(): boolean {
-    const comparator: number = this.questionDetails.minPoint ? this.questionDetails.minPoint : 0;
+    const comparator: number = this.questionDetails.minPoint ?? 0;
     return this.responseDetails.answers.reduce(
       (isBelowMinimum: boolean, curr: number) => isBelowMinimum || curr < comparator,
       false,
@@ -111,7 +111,7 @@ export class ConstsumOptionsQuestionEditAnswerFormComponent extends QuestionEdit
    * Checks if any of the points are above the maxPoint.
    */
   get isAnyPointAboveMaximum(): boolean {
-    const comparator: number = this.questionDetails.maxPoint ? this.questionDetails.maxPoint : this.totalRequiredPoints;
+    const comparator: number = this.questionDetails.maxPoint ?? this.totalRequiredPoints;
     return this.responseDetails.answers.reduce(
       (isAboveMaximum: boolean, curr: number) => isAboveMaximum || curr > comparator,
       false,

--- a/src/web/app/components/sortable-table/sortable-table.component.ts
+++ b/src/web/app/components/sortable-table/sortable-table.component.ts
@@ -185,7 +185,7 @@ export class SortableTableComponent implements OnInit, OnChanges {
 
   getAlignment(column: ColumnData): { 'text-align': ColumnData['alignment'] } {
     return {
-      'text-align': `${column?.alignment || 'start'}`,
+      'text-align': `${column?.alignment ?? 'start'}`,
     };
   }
 }

--- a/src/web/app/components/visibility-panel/visibility-panel.component.ts
+++ b/src/web/app/components/visibility-panel/visibility-panel.component.ts
@@ -157,8 +157,8 @@ export class VisibilityPanelComponent {
   }
 
   getCheckboxAriaLabel(visibilityType: FeedbackVisibilityType, visibilityControl: VisibilityControl): string {
-    const group: string = this.visibilityTypeAriaLabels.get(visibilityType) || '';
-    const groupVisibility: string = this.visibilityControlAriaLabels.get(visibilityControl) || '';
+    const group: string = this.visibilityTypeAriaLabels.get(visibilityType) ?? '';
+    const groupVisibility: string = this.visibilityControlAriaLabels.get(visibilityControl) ?? '';
     return `${group} can see ${groupVisibility}`;
   }
 

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -118,7 +118,7 @@ export class PageComponent implements OnInit {
         }
         r.data.subscribe((resp: Data) => {
           this.pageTitle = resp['pageTitle'];
-          this.title.setTitle(resp['htmlTitle'] || DEFAULT_TITLE);
+          this.title.setTitle(resp['htmlTitle'] ?? DEFAULT_TITLE);
         });
       }
     });

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -163,7 +163,7 @@ export class AdminHomePageComponent implements OnInit {
         registeredAtText: request.registeredAt
           ? this.dateFormatService.formatDateDetailed(request.registeredAt, timezone)
           : '',
-        comments: request.comments || '',
+        comments: request.comments ?? '',
         registrationLink: '',
         showLinks: false,
       };

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.ts
@@ -117,7 +117,7 @@ export class InstructorHelpPageComponent implements AfterViewInit {
   }
 
   scrollTo(target: string, timeout?: number): void {
-    setTimeout(() => this.pageScrollService.scrollToAnchor(target), timeout || 500);
+    setTimeout(() => this.pageScrollService.scrollToAnchor(target), timeout ?? 500);
   }
 
   /**

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-section.component.ts
@@ -73,7 +73,7 @@ export abstract class InstructorHelpSectionComponent implements OnInit, OnChange
   private generateTerms(): void {
     this.questionHtml.forEach((question: InstructorHelpPanelComponent) => {
       const id: string = question.id;
-      const text: string = (question.elementRef.nativeElement.textContent || '').toLowerCase();
+      const text: string = (question.elementRef.nativeElement.textContent ?? '').toLowerCase();
 
       // filter small words away
       let keywords: string[] = text.split(' ').filter((word: string) => word.length > 3);
@@ -97,7 +97,7 @@ export abstract class InstructorHelpSectionComponent implements OnInit, OnChange
 
   private filterFaq(searchTerm: string): void {
     this.showQuestion = [];
-    const searchTermSplit: string[] = (searchTerm.match(/[^\s"]+|"([^"]*)"/gi) || [])
+    const searchTermSplit: string[] = (searchTerm.match(/[^\s"]+|"([^"]*)"/gi) ?? [])
       .map((term: string) => term.replace(/"/g, ''))
       .filter((term: string) => term.length > 3);
     for (const questionDetail of this.questionDetails) {

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.ts
@@ -221,12 +221,12 @@ export class CopyInstructorsFromOtherCoursesModalComponent {
           break;
         case SortBy.INSTRUCTOR_DISPLAYED_TEXT:
           strA = a.instructor.isDisplayedToStudents
-        ? a.instructor.displayedToStudentsAs ?? ''
-        : this.notDisplayedToStudentText;
+            ? (a.instructor.displayedToStudentsAs ?? '')
+            : this.notDisplayedToStudentText;
 
-        strB = b.instructor.isDisplayedToStudents
-        ? b.instructor.displayedToStudentsAs ?? ''
-        : this.notDisplayedToStudentText;
+          strB = b.instructor.isDisplayedToStudents
+            ? (b.instructor.displayedToStudentsAs ?? '')
+            : this.notDisplayedToStudentText;
           break;
         case SortBy.INSTRUCTOR_PERMISSION_ROLE:
           strA = a.instructor.role ?? '';

--- a/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/copy-instructors-from-other-courses-modal/copy-instructors-from-other-courses-modal.component.ts
@@ -221,15 +221,16 @@ export class CopyInstructorsFromOtherCoursesModalComponent {
           break;
         case SortBy.INSTRUCTOR_DISPLAYED_TEXT:
           strA = a.instructor.isDisplayedToStudents
-            ? a.instructor.displayedToStudentsAs || ''
-            : this.notDisplayedToStudentText;
-          strB = b.instructor.isDisplayedToStudents
-            ? b.instructor.displayedToStudentsAs || ''
-            : this.notDisplayedToStudentText;
+        ? a.instructor.displayedToStudentsAs ?? ''
+        : this.notDisplayedToStudentText;
+
+        strB = b.instructor.isDisplayedToStudents
+        ? b.instructor.displayedToStudentsAs ?? ''
+        : this.notDisplayedToStudentText;
           break;
         case SortBy.INSTRUCTOR_PERMISSION_ROLE:
-          strA = a.instructor.role || '';
-          strB = b.instructor.role || '';
+          strA = a.instructor.role ?? '';
+          strB = b.instructor.role ?? '';
           break;
         default:
           strA = '';

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -119,7 +119,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       student.teamName,
       student.name,
       student.email,
-      student.comments || '',
+      student.comments ?? '',
     ]);
   }
 

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -140,7 +140,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
   initializeCourseTabModule(courseView: CourseView): void {
     const model: CourseTabModel = {
       course: courseView.course,
-      instructorPrivilege: courseView.instructorPermissions || {
+      instructorPrivilege: courseView.instructorPermissions ?? {
         canModifyCourse: false,
         canModifyStudent: false,
         canModifyInstructor: false,
@@ -352,7 +352,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
               feedbackSession,
               responseRate: '',
               isLoadingResponseRate: false,
-              instructorPrivilege: feedbackSessionView.instructorPermissions || {
+              instructorPrivilege: feedbackSessionView.instructorPermissions ?? {
                 canModifySession: false,
                 canSubmitSessionInSections: false,
                 canViewSessionInSections: false,

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -932,9 +932,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       recipientType: newQuestionModel.recipientType,
 
       numberOfEntitiesToGiveFeedbackToSetting: newQuestionModel.numberOfEntitiesToGiveFeedbackToSetting,
-      customNumberOfEntitiesToGiveFeedbackTo: newQuestionModel.customNumberOfEntitiesToGiveFeedbackTo
-        ? newQuestionModel.customNumberOfEntitiesToGiveFeedbackTo
-        : 1,
+      customNumberOfEntitiesToGiveFeedbackTo: newQuestionModel.customNumberOfEntitiesToGiveFeedbackTo ?? 1,
 
       showResponsesTo: newQuestionModel.showResponsesTo,
       showGiverNameTo: newQuestionModel.showGiverNameTo,

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/instructor-session-individual-extension-page.component.ts
@@ -644,8 +644,8 @@ export class InstructorSessionIndividualExtensionPageComponent implements OnInit
           strB = b.email;
           break;
         case SortBy.INSTRUCTOR_PERMISSION_ROLE:
-          strA = a.role || '';
-          strB = b.role || '';
+          strA = a.role ?? '';
+          strB = b.role ?? '';
           break;
         case SortBy.SESSION_END_DATE:
           strA = a.extensionDeadline.toString();

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -414,7 +414,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
               feedbackSession: session,
               responseRate: '',
               isLoadingResponseRate: false,
-              instructorPrivilege: sessionView.instructorPermissions || {
+              instructorPrivilege: sessionView.instructorPermissions ?? {
                 canModifySession: false,
                 canSubmitSessionInSections: false,
                 canViewSessionInSections: false,
@@ -619,7 +619,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
             const session: FeedbackSession = sessionView.feedbackSession;
             this.recycleBinFeedbackSessionRowModels.push({
               feedbackSession: session,
-              instructorPrivilege: sessionView.instructorPermissions || {
+              instructorPrivilege: sessionView.instructorPermissions ?? {
                 canModifySession: false,
                 canSubmitSessionInSections: false,
                 canViewSessionInSections: false,

--- a/src/web/app/pages-monitoring/usage-stats-page/stats-line-chart/stats-line-chart.component.ts
+++ b/src/web/app/pages-monitoring/usage-stats-page/stats-line-chart/stats-line-chart.component.ts
@@ -64,8 +64,8 @@ export class StatsLineChartComponent implements OnChanges {
     this.yScale = d3
       .scaleLinear()
       .domain([
-        (d3.max(this.data, (d: DataPoint) => d.value) || 0) + 1,
-        (d3.min(this.data, (d: DataPoint) => d.value) || 0) - 1,
+        (d3.max(this.data, (d: DataPoint) => d.value) ?? 0) + 1,
+        (d3.min(this.data, (d: DataPoint) => d.value) ?? 0) - 1,
       ])
       .range([0, this.height - 2 * this.margin]);
 

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -125,8 +125,8 @@ export class SessionResultPageComponent implements OnInit {
       )
       .subscribe((queryParams: Params) => {
         this.feedbackSessionId = queryParams['fsid'];
-        this.regKey = queryParams['key'] || '';
-        this.previewAsPerson = queryParams['previewas'] ? queryParams['previewas'] : '';
+        this.regKey = queryParams['key'] ?? '';
+        this.previewAsPerson = queryParams['previewas'] ?? '';
         if (queryParams['entitytype'] === 'instructor') {
           this.entityType = 'instructor';
           this.intent = Intent.INSTRUCTOR_RESULT;

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -171,14 +171,14 @@ export class SessionSubmissionPageComponent implements OnInit {
       )
       .subscribe((queryParams: Params) => {
         this.feedbackSessionId = queryParams['fsid'];
-        this.regKey = queryParams['key'] ? queryParams['key'] : '';
-        this.moderatedPerson = queryParams['moderatedperson'] ? queryParams['moderatedperson'] : '';
-        this.previewAsPerson = queryParams['previewas'] ? queryParams['previewas'] : '';
+        this.regKey = queryParams['key'] ?? '';
+        this.moderatedPerson = queryParams['moderatedperson'] ?? '';
+        this.previewAsPerson = queryParams['previewas'] ?? '';
         if (queryParams['entitytype'] === 'instructor') {
           this.entityType = 'instructor';
           this.intent = Intent.INSTRUCTOR_SUBMISSION;
         }
-        this.moderatedQuestionId = queryParams['moderatedquestionId'] ? queryParams['moderatedquestionId'] : '';
+        this.moderatedQuestionId = queryParams['moderatedquestionId'] ?? '';
 
         if (this.previewAsPerson) {
           // disable submission in the preview mode

--- a/src/web/app/pages-static/about-page/about-page.component.ts
+++ b/src/web/app/pages-static/about-page/about-page.component.ts
@@ -62,9 +62,7 @@ export class AboutPageComponent implements OnInit {
 
   private setUrl<T extends { username?: string; url?: string; avatarUrl?: string }>(dev: T): T {
     if (dev.username) {
-      if (!dev.url) {
-        dev.url = `https://github.com/${dev.username}`;
-      }
+      dev.url ??= `https://github.com/${dev.username}`;
       dev.avatarUrl = `https://github.com/${dev.username}.png`;
     }
     return dev;
@@ -72,7 +70,7 @@ export class AboutPageComponent implements OnInit {
 
   private setDisplayedName(dev: Contributor): Contributor {
     if (dev.name || dev.username) {
-      dev.displayedName = dev.name || `@${dev.username}`;
+      dev.displayedName = dev.name ?? `@${dev.username}`;
     }
     return dev;
   }

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -90,9 +90,9 @@ export function calculateConstsumRecipientsQuestionStatistics(
     recipientType === QuestionRecipientType.TEAMS || recipientType === QuestionRecipientType.TEAMS_EXCLUDING_SELF;
 
   for (const response of responses) {
-    const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail || response.recipient;
+    const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail ?? response.recipient;
 
-    stats.pointsPerOption[identifier] = stats.pointsPerOption[identifier] || [];
+    stats.pointsPerOption[identifier] = stats.pointsPerOption[identifier] ?? [];
     stats.pointsPerOption[identifier].push(response.responseDetails.answers[0]);
 
     if (response.giver === response.recipient) {
@@ -211,7 +211,7 @@ export function calculateMcqQuestionStatistics(
   for (const response of responses) {
     const isOther: boolean = response.responseDetails.isOther;
     const key: string = isOther ? 'Other' : response.responseDetails.answer;
-    stats.answerFrequency[key] = (stats.answerFrequency[key] || 0) + 1;
+    stats.answerFrequency[key] = (stats.answerFrequency[key] ?? 0) + 1;
   }
 
   if (question.hasAssignedWeights) {
@@ -254,8 +254,8 @@ export function calculateMcqQuestionStatistics(
     const recipientEmails: Record<string, string> = {};
     const recipientToTeam: Record<string, string> = {};
     for (const response of responses) {
-      perRecipientResponse[response.recipient] = perRecipientResponse[response.recipient] || {};
-      recipientEmails[response.recipient] = recipientEmails[response.recipient] || response.recipientEmail || '';
+      perRecipientResponse[response.recipient] = perRecipientResponse[response.recipient] ?? {};
+      recipientEmails[response.recipient] = recipientEmails[response.recipient] ?? response.recipientEmail ?? '';
       for (const choice of question.mcqChoices) {
         perRecipientResponse[response.recipient][choice] = 0;
       }
@@ -372,9 +372,9 @@ export function calculateMsqQuestionStatistics(
     if (!responseEmail) {
       continue;
     }
-    perRecipientResponse[responseEmail] = perRecipientResponse[responseEmail] || {};
-    recipientEmails[responseEmail] = recipientEmails[responseEmail] || responseEmail || '';
-    recipientNames[responseEmail] = recipientNames[responseEmail] || response.recipient || '';
+    perRecipientResponse[responseEmail] = perRecipientResponse[responseEmail] ?? {};
+    recipientEmails[responseEmail] = recipientEmails[responseEmail] ?? responseEmail ?? '';
+    recipientNames[responseEmail] = recipientNames[responseEmail] ?? response.recipient ?? '';
     for (const choice of question.msqChoices) {
       perRecipientResponse[responseEmail][choice] = 0;
     }
@@ -425,7 +425,7 @@ function updateResponseCountPerOptionForMsqResponse(
   responseCountPerOption: Record<string, number>,
 ): void {
   if (responseDetails.isOther) {
-    responseCountPerOption['Other'] = (responseCountPerOption['Other'] || 0) + 1;
+    responseCountPerOption['Other'] = (responseCountPerOption['Other'] ?? 0) + 1;
   }
 
   for (const answer of responseDetails.answers) {
@@ -437,7 +437,7 @@ function updateResponseCountPerOptionForMsqResponse(
       // ignore other answer if any
       continue;
     }
-    responseCountPerOption[answer] = (responseCountPerOption[answer] || 0) + 1;
+    responseCountPerOption[answer] = (responseCountPerOption[answer] ?? 0) + 1;
   }
 }
 
@@ -453,16 +453,16 @@ export function calculateNumScaleQuestionStatistics(
     const { giver }: { giver: string } = response;
     const { recipient }: { recipient: string } = response;
     const { recipientTeam }: { recipientTeam: string } = response;
-    stats.teamToRecipientToScores[recipientTeam] = stats.teamToRecipientToScores[recipientTeam] || {};
+    stats.teamToRecipientToScores[recipientTeam] = stats.teamToRecipientToScores[recipientTeam] ?? {};
     stats.teamToRecipientToScores[recipientTeam][recipient] = stats.teamToRecipientToScores[recipientTeam][
       recipient
-    ] || { responses: [] };
+    ] ?? { responses: [] };
     stats.teamToRecipientToScores[recipientTeam][recipient].responses.push({
       answer: response.responseDetails.answer,
       isSelf: giver === recipient,
     });
 
-    stats.recipientEmails[recipient] = stats.recipientEmails[recipient] || response.recipientEmail || '';
+    stats.recipientEmails[recipient] = stats.recipientEmails[recipient] ?? response.recipientEmail ?? '';
   }
 
   for (const team of Object.keys(stats.teamToRecipientToScores)) {
@@ -597,15 +597,15 @@ export function calculateRankRecipientsQuestionStatistics(
   const teamMembersPerTeam: Record<string, string[]> = {};
 
   for (const response of responses) {
-    const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail || response.recipient;
+    const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail ?? response.recipient;
 
-    stats.ranksReceivedPerOption[identifier] = stats.ranksReceivedPerOption[identifier] || [];
+    stats.ranksReceivedPerOption[identifier] = stats.ranksReceivedPerOption[identifier] ?? [];
     stats.ranksReceivedPerOption[identifier].push(response.responseDetails.answer);
 
     if (response.recipient === response.giver) {
       stats.selfRankPerOption[identifier] = response.responseDetails.answer;
     } else {
-      ranksReceivedPerOptionExcludeSelf[identifier] = ranksReceivedPerOptionExcludeSelf[identifier] || [];
+      ranksReceivedPerOptionExcludeSelf[identifier] = ranksReceivedPerOptionExcludeSelf[identifier] ?? [];
       ranksReceivedPerOptionExcludeSelf[identifier].push(response.responseDetails.answer);
     }
 
@@ -617,7 +617,7 @@ export function calculateRankRecipientsQuestionStatistics(
     }
 
     if (isRecipientOwnTeamMember) {
-      teamMembersPerTeam[response.recipientTeam] = teamMembersPerTeam[response.recipientTeam] || [];
+      teamMembersPerTeam[response.recipientTeam] = teamMembersPerTeam[response.recipientTeam] ?? [];
       if (!teamMembersPerTeam[response.recipientTeam].includes(identifier)) {
         teamMembersPerTeam[response.recipientTeam].push(identifier);
       }
@@ -690,7 +690,7 @@ function calculateRankPerOptionInTeam(
     .map((team: string) => teamMembersPerTeam[team])
     .map((teamMembers: string[]) =>
       teamMembers.reduce((ranksReceivedPerOptionInTeam: Record<string, number[]>, teamMember: string) => {
-        ranksReceivedPerOptionInTeam[teamMember] = ranksReceivedPerOption[teamMember] || [];
+        ranksReceivedPerOptionInTeam[teamMember] = ranksReceivedPerOption[teamMember] ?? [];
         return ranksReceivedPerOptionInTeam;
       }, {}),
     )
@@ -759,9 +759,9 @@ export function calculateRubricQuestionStatistics(
 
   // calculate per recipient stats
   for (const response of responses) {
-    stats.perRecipientStatsMap[response.recipientEmail || response.recipient] = stats.perRecipientStatsMap[
-      response.recipientEmail || response.recipient
-    ] || {
+    stats.perRecipientStatsMap[response.recipientEmail ?? response.recipient] = stats.perRecipientStatsMap[
+      response.recipientEmail ?? response.recipient
+    ] ?? {
       recipientName: response.recipient,
       recipientEmail: response.recipientEmail,
       recipientTeam: response.recipientTeam,
@@ -779,11 +779,11 @@ export function calculateRubricQuestionStatistics(
       if (subAnswer === RUBRIC_ANSWER_NOT_CHOSEN) {
         continue;
       }
-      stats.perRecipientStatsMap[response.recipientEmail || response.recipient].answers[i][subAnswer] += 1;
+      stats.perRecipientStatsMap[response.recipientEmail ?? response.recipient].answers[i][subAnswer] += 1;
       if (stats.weights[i][subAnswer] !== null) {
-        stats.perRecipientStatsMap[response.recipientEmail || response.recipient].subQuestionTotalChosenWeight[i] +=
+        stats.perRecipientStatsMap[response.recipientEmail ?? response.recipient].subQuestionTotalChosenWeight[i] +=
           +stats.weights[i][subAnswer].toFixed(5);
-        stats.perRecipientStatsMap[response.recipientEmail || response.recipient].areSubQuestionChosenWeightsAllNull[
+        stats.perRecipientStatsMap[response.recipientEmail ?? response.recipient].areSubQuestionChosenWeightsAllNull[
           i
         ] = false;
       }
@@ -879,7 +879,7 @@ function sumValidValuesByColumn(matrix: number[][]): number[] {
   for (let c = 0; c < matrix[0].length; c += 1) {
     let sum = 0;
     for (const row of matrix) {
-      sum += row[c] === null ? 0 : row[c];
+      sum += row[c] ?? 0;
     }
     sums[c] = sum;
   }

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -90,7 +90,7 @@ export function calculateConstsumRecipientsQuestionStatistics(
     recipientType === QuestionRecipientType.TEAMS || recipientType === QuestionRecipientType.TEAMS_EXCLUDING_SELF;
 
   for (const response of responses) {
-    const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail ?? response.recipient;
+    const identifier: string = isRecipientTeam ? response.recipient : (response.recipientEmail ?? response.recipient);
 
     stats.pointsPerOption[identifier] = stats.pointsPerOption[identifier] ?? [];
     stats.pointsPerOption[identifier].push(response.responseDetails.answers[0]);
@@ -597,7 +597,7 @@ export function calculateRankRecipientsQuestionStatistics(
   const teamMembersPerTeam: Record<string, string[]> = {};
 
   for (const response of responses) {
-    const identifier: string = isRecipientTeam ? response.recipient : response.recipientEmail ?? response.recipient;
+    const identifier: string = isRecipientTeam ? response.recipient : (response.recipientEmail ?? response.recipient);
 
     stats.ranksReceivedPerOption[identifier] = stats.ranksReceivedPerOption[identifier] ?? [];
     stats.ranksReceivedPerOption[identifier].push(response.responseDetails.answer);

--- a/src/web/services/link.service.ts
+++ b/src/web/services/link.service.ts
@@ -26,7 +26,7 @@ export class LinkService {
    */
   generateCourseJoinLink(entity: Student | Instructor, entityType: string): string {
     const frontendUrl: string = window.location.origin;
-    const key: string = entity.key || '';
+    const key: string = entity.key ?? '';
     const params: {
       [key: string]: string;
     } = {
@@ -106,7 +106,7 @@ export class LinkService {
    */
   generateSubmitUrl(entity: Student | Instructor, isInstructor: boolean, feedbackSessionId: string): string {
     const frontendUrl: string = window.location.origin;
-    const key: string = entity.key || '';
+    const key: string = entity.key ?? '';
     const params: {
       [key: string]: string;
     } = {
@@ -128,7 +128,7 @@ export class LinkService {
    */
   generateResultUrl(entity: Student | Instructor, isInstructor: boolean, feedbackSessionId: string): string {
     const frontendUrl: string = window.location.origin;
-    const key: string = entity.key || '';
+    const key: string = entity.key ?? '';
     const params: {
       [key: string]: string;
     } = {

--- a/src/web/services/masquerade-mode.service.ts
+++ b/src/web/services/masquerade-mode.service.ts
@@ -13,7 +13,7 @@ export class MasqueradeModeService {
   getMasqueradeAccountId(): string {
     const urlParams: URLSearchParams = new URLSearchParams(window.location.search);
     const accountIdParam: string | null = urlParams.get('masqueradeaccountid');
-    return accountIdParam || '';
+    return accountIdParam ?? '';
   }
 
   /**

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -357,7 +357,7 @@ export class SearchService {
     const timezone: string = this.timezoneService.guessTimezone() || 'UTC';
     accountRequestResult.createdAtText = this.formatTimestampAsString(createdAt, timezone);
     accountRequestResult.registeredAtText = registeredAt ? this.formatTimestampAsString(registeredAt, timezone) : null;
-    accountRequestResult.comments = comments || '';
+    accountRequestResult.comments = comments ?? '';
 
     const registrationLink: string = this.linkService.generateAccountRegistrationLink(registrationKey);
     accountRequestResult = {

--- a/src/web/services/timezone.service.ts
+++ b/src/web/services/timezone.service.ts
@@ -100,7 +100,7 @@ export class TimezoneService {
    * Resolves the local date time to a UNIX timestamp.
    */
   resolveLocalDateTime(date: DateFormat, time: TimeFormat, timeZone?: string, resolveMidnightTo0000 = false): number {
-    const inst: moment.Moment = this.getMomentInstance(null, timeZone || this.guessTimezone());
+    const inst: moment.Moment = this.getMomentInstance(null, timeZone ?? this.guessTimezone());
     inst.set('year', date.year);
     inst.set('month', date.month - 1); // moment month is from 0-11
     inst.set('date', date.day);


### PR DESCRIPTION
Fixes #14144

## Outline of Solution

* Enabled `@typescript-eslint/prefer-nullish-coalescing` in the ESLint configuration.
* Fixed all existing violations across the codebase by:

  * Replacing logical OR (`||`) fallback expressions with nullish coalescing (`??`) where appropriate.
  * Replacing null/undefined fallback ternary expressions with `??`.
  * Replacing assignment patterns with `??=` where applicable.
* Removed the rule override and ensured the codebase complies with the rule.

## Testing

* `npm run lint:eslint`
* `./gradlew lint`

Both commands pass successfully.
