### PR TITLE
[#13721] Migrate Instructor Privileges to be keyed by session and section ID instead of name

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
@@ -2,11 +2,15 @@ package teammates.e2e.cases;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
+import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.e2e.pageobjects.InstructorCourseEditPage;
@@ -113,12 +117,27 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
         ______TS("edit instructor");
         instructors[0].setName("Edited Name");
         instructors[0].setEmail("icedit.edited@gmail.tmt");
-        instructors[0].getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, true);
-        instructors[0].getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
-        instructors[0].getPrivileges().updatePrivilege("Section 2",
-                Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
-        instructors[0].getPrivileges().updatePrivilege("Section 1", "First feedback session",
-                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        // Rebuild privileges: update course level, then add section and session entries
+        InstructorPermissionSet courseLevel = instructors[0].getPrivileges().getCourseLevelPrivileges();
+        courseLevel.setCanModifySession(true);
+        courseLevel.setCanModifyStudent(false);
+
+        Map<String, InstructorPermissionSet> sectionLevel =
+                new LinkedHashMap<>(instructors[0].getPrivileges().getSectionLevelPrivileges());
+        InstructorPermissionSet section2Perms = new InstructorPermissionSet();
+        section2Perms.setCanViewSessionInSections(true);
+        sectionLevel.put("Section 2", section2Perms);
+
+        Map<String, Map<String, InstructorPermissionSet>> sessionLevel =
+                new LinkedHashMap<>(instructors[0].getPrivileges().getSessionLevelPrivileges());
+        Map<String, InstructorPermissionSet> section1Sessions =
+                new LinkedHashMap<>(sessionLevel.getOrDefault("Section 1", new LinkedHashMap<>()));
+        InstructorPermissionSet firstSessionPerms = new InstructorPermissionSet();
+        firstSessionPerms.setCanSubmitSessionInSections(true);
+        section1Sessions.put("First feedback session", firstSessionPerms);
+        sessionLevel.put("Section 1", section1Sessions);
+
+        instructors[0].setPrivileges(new InstructorPrivilegesLegacy(courseLevel, sectionLevel, sessionLevel));
 
         editPage.editInstructor(2, instructors[0]);
         editPage.waitForPageToLoad();

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseEditPage.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.support.ui.Select;
 
 import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
@@ -129,7 +130,7 @@ public class InstructorCourseEditPage extends AppPage {
         }
     }
 
-    public void verifyCustomPrivileges(int instrNum, InstructorPrivileges privileges) {
+    public void verifyCustomPrivileges(int instrNum, InstructorPrivilegesLegacy privileges) {
         clickEditInstructorButton(instrNum);
 
         InstructorPermissionSet courseLevelPrivileges = privileges.getCourseLevelPrivileges();

--- a/src/main/java/teammates/common/datatransfer/DefaultInstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/DefaultInstructorPrivileges.java
@@ -5,11 +5,11 @@ package teammates.common.datatransfer;
  */
 public final class DefaultInstructorPrivileges {
 
-    static final InstructorPermissionSet PRIVILEGES_MANAGER = new InstructorPermissionSet();
-    static final InstructorPermissionSet PRIVILEGES_OBSERVER = new InstructorPermissionSet();
-    static final InstructorPermissionSet PRIVILEGES_TUTOR = new InstructorPermissionSet();
-    static final InstructorPermissionSet PRIVILEGES_ALL = new InstructorPermissionSet();
-    static final InstructorPermissionSet PRIVILEGES_NONE = new InstructorPermissionSet();
+    public static final InstructorPermissionSet PRIVILEGES_MANAGER = new InstructorPermissionSet();
+    public static final InstructorPermissionSet PRIVILEGES_OBSERVER = new InstructorPermissionSet();
+    public static final InstructorPermissionSet PRIVILEGES_TUTOR = new InstructorPermissionSet();
+    public static final InstructorPermissionSet PRIVILEGES_ALL = new InstructorPermissionSet();
+    public static final InstructorPermissionSet PRIVILEGES_NONE = new InstructorPermissionSet();
 
     static {
         PRIVILEGES_MANAGER.setCanModifyCourse(false);

--- a/src/main/java/teammates/common/datatransfer/InstructorPermissionSet.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPermissionSet.java
@@ -95,7 +95,7 @@ public class InstructorPermissionSet {
         return copy;
     }
 
-    boolean get(String privilegeName) {
+    public boolean get(String privilegeName) {
         switch (privilegeName) {
         case Const.InstructorPermissions.CAN_MODIFY_COURSE:
             return canModifyCourse;

--- a/src/main/java/teammates/common/datatransfer/InstructorPermissionSet.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPermissionSet.java
@@ -95,6 +95,9 @@ public class InstructorPermissionSet {
         return copy;
     }
 
+    /**
+     * Returns the value of the specified privilege. Returns false if the privilege name is invalid.
+     */
     public boolean get(String privilegeName) {
         switch (privilegeName) {
         case Const.InstructorPermissions.CAN_MODIFY_COURSE:

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -203,6 +203,9 @@ public final class InstructorPrivileges {
         });
     }
 
+    /**
+     * Adds a section entry with default privileges if it does not exist.
+     */
     public void addSectionWithDefaultPrivileges(UUID sectionId) {
         this.sectionLevel.putIfAbsent(sectionId, getOverallPrivilegesForSections());
     }

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -6,13 +6,15 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import teammates.common.util.Const;
 
 /**
- * Stores the permissions of an instructor.
+ * Stores the permissions of an instructor using UUIDs as keys for section and session level.
+ * This is the runtime format. The storage format is {@link InstructorPrivilegesLegacy}.
  */
 public final class InstructorPrivileges {
 
@@ -41,14 +43,14 @@ public final class InstructorPrivileges {
             new LinkedHashSet<>(Arrays.asList(SESSION_LEVEL_ONLY_LIST));
 
     private final InstructorPermissionSet courseLevel;
-    private final Map<String, InstructorPermissionSet> sectionLevel;
-    private final Map<String, Map<String, InstructorPermissionSet>> sessionLevel;
+    private final Map<UUID, InstructorPermissionSet> sectionLevel;
+    private final Map<UUID, Map<UUID, InstructorPermissionSet>> sessionLevel;
 
     @JsonCreator
     private InstructorPrivileges(
             InstructorPermissionSet courseLevel,
-            Map<String, InstructorPermissionSet> sectionLevel,
-            Map<String, Map<String, InstructorPermissionSet>> sessionLevel) {
+            Map<UUID, InstructorPermissionSet> sectionLevel,
+            Map<UUID, Map<UUID, InstructorPermissionSet>> sessionLevel) {
         this.courseLevel = courseLevel;
         this.sectionLevel = sectionLevel;
         this.sessionLevel = sessionLevel;
@@ -156,17 +158,17 @@ public final class InstructorPrivileges {
     }
 
     /**
-     * Sets privilege for the privilege specified by privilegeName for sectionName.
+     * Sets privilege for the privilege specified by privilegeName for sectionId.
      */
-    public void updatePrivilege(String sectionName, String privilegeName, boolean isAllowed) {
-        updatePrivilegeInSectionLevel(sectionName, privilegeName, isAllowed);
+    public void updatePrivilege(UUID sectionId, String privilegeName, boolean isAllowed) {
+        updatePrivilegeInSectionLevel(sectionId, privilegeName, isAllowed);
     }
 
     /**
-     * Sets privilege for the privilege specified by privilegeName for sessionName in sectionName.
+     * Sets privilege for the privilege specified by privilegeName for sessionId in sectionId.
      */
-    public void updatePrivilege(String sectionName, String sessionName, String privilegeName, boolean isAllowed) {
-        updatePrivilegeInSessionLevel(sectionName, sessionName, privilegeName, isAllowed);
+    public void updatePrivilege(UUID sectionId, UUID sessionId, String privilegeName, boolean isAllowed) {
+        updatePrivilegeInSessionLevel(sectionId, sessionId, privilegeName, isAllowed);
     }
 
     private void updatePrivilegeInCourseLevel(String privilegeName, boolean isAllowed) {
@@ -176,33 +178,33 @@ public final class InstructorPrivileges {
         this.courseLevel.put(privilegeName, isAllowed);
     }
 
-    private void updatePrivilegeInSectionLevel(String sectionName, String privilegeName, boolean isAllowed) {
+    private void updatePrivilegeInSectionLevel(UUID sectionId, String privilegeName, boolean isAllowed) {
         if (!isPrivilegeNameValidForSectionLevel(privilegeName)) {
             return;
         }
-        addSectionWithDefaultPrivileges(sectionName);
-        this.sectionLevel.get(sectionName).put(privilegeName, isAllowed);
+        addSectionWithDefaultPrivileges(sectionId);
+        this.sectionLevel.get(sectionId).put(privilegeName, isAllowed);
     }
 
-    private void updatePrivilegeInSessionLevel(String sectionName, String sessionName,
+    private void updatePrivilegeInSessionLevel(UUID sectionId, UUID sessionId,
                                                String privilegeName, boolean isAllowed) {
         if (!isPrivilegeNameValidForSessionLevel(privilegeName)) {
             return;
         }
-        verifyExistenceOfsectionName(sectionName);
-        this.sessionLevel.get(sectionName).computeIfAbsent(sessionName, key -> new InstructorPermissionSet())
-                                          .put(privilegeName, isAllowed);
+        verifyExistenceOfSectionId(sectionId);
+        this.sessionLevel.get(sectionId).computeIfAbsent(sessionId, key -> new InstructorPermissionSet())
+                                        .put(privilegeName, isAllowed);
     }
 
-    private void verifyExistenceOfsectionName(String sectionName) {
-        this.sessionLevel.computeIfAbsent(sectionName, key -> {
-            addSectionWithDefaultPrivileges(sectionName);
+    private void verifyExistenceOfSectionId(UUID sectionId) {
+        this.sessionLevel.computeIfAbsent(sectionId, key -> {
+            addSectionWithDefaultPrivileges(sectionId);
             return new LinkedHashMap<>();
         });
     }
 
-    void addSectionWithDefaultPrivileges(String sectionName) {
-        this.sectionLevel.putIfAbsent(sectionName, getOverallPrivilegesForSections());
+    public void addSectionWithDefaultPrivileges(UUID sectionId) {
+        this.sectionLevel.putIfAbsent(sectionId, getOverallPrivilegesForSections());
     }
 
     /**
@@ -213,24 +215,24 @@ public final class InstructorPrivileges {
     }
 
     /**
-     * Returns true if it is allowed for the privilege specified by privilegeName in sectionName.
+     * Returns true if it is allowed for the privilege specified by privilegeName in sectionId.
      */
-    public boolean isAllowedForPrivilege(String sectionName, String privilegeName) {
-        return isAllowedInSectionLevel(sectionName, privilegeName);
+    public boolean isAllowedForPrivilege(UUID sectionId, String privilegeName) {
+        return isAllowedInSectionLevel(sectionId, privilegeName);
     }
 
     /**
-     * Returns true if it is allowed for the privilege specified by privilegeName for sessionName in sectionName.
+     * Returns true if it is allowed for the privilege specified by privilegeName for sessionId in sectionId.
      */
-    public boolean isAllowedForPrivilege(String sectionName, String sessionName, String privilegeName) {
-        return isAllowedInSessionLevel(sectionName, sessionName, privilegeName);
+    public boolean isAllowedForPrivilege(UUID sectionId, UUID sessionId, String privilegeName) {
+        return isAllowedInSessionLevel(sectionId, sessionId, privilegeName);
     }
 
     /**
      * Returns true if privilege for session is present for any section.
      */
-    public boolean isAllowedForPrivilegeAnySection(String sessionName, String privilegeName) {
-        return isAllowedInSessionLevelAnySection(sessionName, privilegeName);
+    public boolean isAllowedForPrivilegeAnySection(UUID sessionId, String privilegeName) {
+        return isAllowedInSessionLevelAnySection(sessionId, privilegeName);
     }
 
     /**
@@ -247,37 +249,37 @@ public final class InstructorPrivileges {
         return this.courseLevel.get(privilegeName);
     }
 
-    private boolean isAllowedInSectionLevel(String sectionName, String privilegeName) {
+    private boolean isAllowedInSectionLevel(UUID sectionId, String privilegeName) {
 
         assert isPrivilegeNameValid(privilegeName);
 
-        if (!this.sectionLevel.containsKey(sectionName)) {
+        if (!this.sectionLevel.containsKey(sectionId)) {
             return isAllowedInCourseLevel(privilegeName);
         }
 
-        return this.sectionLevel.get(sectionName).get(privilegeName);
+        return this.sectionLevel.get(sectionId).get(privilegeName);
     }
 
-    private boolean isAllowedInSessionLevel(String sectionName, String sessionName, String privilegeName) {
+    private boolean isAllowedInSessionLevel(UUID sectionId, UUID sessionId, String privilegeName) {
 
         assert isPrivilegeNameValid(privilegeName);
 
-        if (!this.sessionLevel.containsKey(sectionName)
-                || !this.sessionLevel.get(sectionName).containsKey(sessionName)) {
-            return isAllowedInSectionLevel(sectionName, privilegeName);
+        if (!this.sessionLevel.containsKey(sectionId)
+                || !this.sessionLevel.get(sectionId).containsKey(sessionId)) {
+            return isAllowedInSectionLevel(sectionId, privilegeName);
         }
 
-        return this.sessionLevel.get(sectionName).get(sessionName).get(privilegeName);
+        return this.sessionLevel.get(sectionId).get(sessionId).get(privilegeName);
     }
 
-    private boolean isAllowedInSessionLevelAnySection(String sessionName, String privilegeName) {
+    private boolean isAllowedInSessionLevelAnySection(UUID sessionId, String privilegeName) {
 
         assert isPrivilegeNameValid(privilegeName);
 
-        Set<String> sections = new LinkedHashSet<>(this.sessionLevel.keySet());
+        Set<UUID> sections = new LinkedHashSet<>(this.sessionLevel.keySet());
         sections.addAll(this.sectionLevel.keySet());
-        for (String sectionName : sections) {
-            if (isAllowedInSessionLevel(sectionName, sessionName, privilegeName)) {
+        for (UUID sectionId : sections) {
+            if (isAllowedInSessionLevel(sectionId, sessionId, privilegeName)) {
                 return true;
             }
         }
@@ -299,7 +301,7 @@ public final class InstructorPrivileges {
                 sectionMap.setCanViewSessionInSections(true);
             }
         }
-        for (Map<String, InstructorPermissionSet> section : this.sessionLevel.values()) {
+        for (Map<UUID, InstructorPermissionSet> section : this.sessionLevel.values()) {
             for (InstructorPermissionSet sessionMap : section.values()) {
                 if (sessionMap.isCanModifySessionCommentsInSections()) {
                     sessionMap.setCanViewSessionInSections(true);
@@ -313,21 +315,21 @@ public final class InstructorPrivileges {
     }
 
     /**
-     * Returns the section level privileges of the instructor.
+     * Returns the section level privileges of the instructor, keyed by section UUID.
      */
-    public Map<String, InstructorPermissionSet> getSectionLevelPrivileges() {
-        Map<String, InstructorPermissionSet> copy = new LinkedHashMap<>();
+    public Map<UUID, InstructorPermissionSet> getSectionLevelPrivileges() {
+        Map<UUID, InstructorPermissionSet> copy = new LinkedHashMap<>();
         sectionLevel.forEach((key, value) -> copy.put(key, value.getCopy()));
         return copy;
     }
 
     /**
-     * Returns the session level privileges of the instructor.
+     * Returns the session level privileges of the instructor, keyed by section UUID then session UUID.
      */
-    public Map<String, Map<String, InstructorPermissionSet>> getSessionLevelPrivileges() {
-        Map<String, Map<String, InstructorPermissionSet>> copy = new LinkedHashMap<>();
+    public Map<UUID, Map<UUID, InstructorPermissionSet>> getSessionLevelPrivileges() {
+        Map<UUID, Map<UUID, InstructorPermissionSet>> copy = new LinkedHashMap<>();
         sessionLevel.forEach((sessionLevelKey, sessionLevelValue) -> {
-            Map<String, InstructorPermissionSet> sectionCopy = new LinkedHashMap<>();
+            Map<UUID, InstructorPermissionSet> sectionCopy = new LinkedHashMap<>();
             sessionLevelValue.forEach((key, value) -> sectionCopy.put(key, value.getCopy()));
 
             copy.put(sessionLevelKey, sectionCopy);
@@ -336,10 +338,10 @@ public final class InstructorPrivileges {
     }
 
     /**
-     * Returns the list of sections the instructor has the specified privilege name.
+     * Returns the list of sections the instructor has the specified privilege name, keyed by section UUID.
      */
-    public Map<String, InstructorPermissionSet> getSectionsWithPrivilege(String privilegeName) {
-        Map<String, InstructorPermissionSet> copy = new LinkedHashMap<>();
+    public Map<UUID, InstructorPermissionSet> getSectionsWithPrivilege(String privilegeName) {
+        Map<UUID, InstructorPermissionSet> copy = new LinkedHashMap<>();
         sectionLevel.forEach((key, value) -> {
             if (isAllowedInSectionLevel(key, privilegeName)) {
                 copy.put(key, value.getCopy());

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivilegesLegacy.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivilegesLegacy.java
@@ -1,0 +1,93 @@
+package teammates.common.datatransfer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Stores the permissions of an instructor using section and session <em>names</em> as map keys.
+ * This is the legacy format used exclusively for DB serialization.
+ *
+ * <p>This class intentionally contains no logic. All privilege logic must be performed using
+ * {@link InstructorPrivileges} (the runtime UUID-keyed format). Conversion between the two formats
+ * is centralised in {@code InstructorPermissionsLogic}.
+ */
+public final class InstructorPrivilegesLegacy {
+
+    private final InstructorPermissionSet courseLevel;
+    private final Map<String, InstructorPermissionSet> sectionLevel;
+    private final Map<String, Map<String, InstructorPermissionSet>> sessionLevel;
+
+    /**
+     * Creates a legacy privileges object from all three maps. Used by Jackson for deserialization
+     * and by {@code InstructorPermissionsLogic} when converting from the runtime format.
+     */
+    @JsonCreator
+    public InstructorPrivilegesLegacy(
+            InstructorPermissionSet courseLevel,
+            Map<String, InstructorPermissionSet> sectionLevel,
+            Map<String, Map<String, InstructorPermissionSet>> sessionLevel) {
+        this.courseLevel = courseLevel != null ? courseLevel : new InstructorPermissionSet();
+        this.sectionLevel = sectionLevel != null ? sectionLevel : new LinkedHashMap<>();
+        this.sessionLevel = sessionLevel != null ? sessionLevel : new LinkedHashMap<>();
+    }
+
+    /**
+     * Creates a legacy privileges object with no section or session entries and all course-level
+     * privileges set to {@code false}.
+     */
+    public InstructorPrivilegesLegacy() {
+        this(new InstructorPermissionSet(), new LinkedHashMap<>(), new LinkedHashMap<>());
+    }
+
+    public InstructorPermissionSet getCourseLevelPrivileges() {
+        return courseLevel.getCopy();
+    }
+
+    /**
+     * Returns the section-level privileges of the instructor, keyed by section name.
+     */
+    public Map<String, InstructorPermissionSet> getSectionLevelPrivileges() {
+        Map<String, InstructorPermissionSet> copy = new LinkedHashMap<>();
+        sectionLevel.forEach((key, value) -> copy.put(key, value.getCopy()));
+        return copy;
+    }
+
+    /**
+     * Returns the session-level privileges of the instructor, keyed by section name then session name.
+     */
+    public Map<String, Map<String, InstructorPermissionSet>> getSessionLevelPrivileges() {
+        Map<String, Map<String, InstructorPermissionSet>> copy = new LinkedHashMap<>();
+        sessionLevel.forEach((sectionKey, sessionMap) -> {
+            Map<String, InstructorPermissionSet> sessionCopy = new LinkedHashMap<>();
+            sessionMap.forEach((sessionKey, value) -> sessionCopy.put(sessionKey, value.getCopy()));
+            copy.put(sectionKey, sessionCopy);
+        });
+        return copy;
+    }
+
+    @Override
+    public boolean equals(Object another) {
+        if (!(another instanceof InstructorPrivilegesLegacy)) {
+            return false;
+        }
+        if (another == this) {
+            return true;
+        }
+        InstructorPrivilegesLegacy rhs = (InstructorPrivilegesLegacy) another;
+        return this.getCourseLevelPrivileges().equals(rhs.getCourseLevelPrivileges())
+                && this.getSectionLevelPrivileges().equals(rhs.getSectionLevelPrivileges())
+                && this.getSessionLevelPrivileges().equals(rhs.getSessionLevelPrivileges());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            this.getCourseLevelPrivileges(),
+            this.getSectionLevelPrivileges(),
+            this.getSessionLevelPrivileges()
+        );
+    }
+}

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -14,6 +14,8 @@ import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.EnrollResults;
 import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.Provider;
@@ -146,34 +148,61 @@ public class Logic {
     /**
      * Checks if the given instructor has the specified section-level permissions.
      */
-    public boolean hasInstructorPermissionsForSection(Instructor instructor, String sectionName,
+    public boolean hasInstructorPermissionsForSection(Instructor instructor, UUID sectionId,
             String... permissionNames) {
-        return instructorPermissionsLogic.hasPermissionsForSection(instructor, sectionName, permissionNames);
+        return instructorPermissionsLogic.hasPermissionsForSection(instructor, sectionId, permissionNames);
     }
 
     /**
      * Checks if the given instructor has the specified session-in-section-level permissions.
      */
-    public boolean hasInstructorPermissionsForSessionInSection(Instructor instructor, String sectionName,
-            String feedbackSessionName, String... permissionNames) {
+    public boolean hasInstructorPermissionsForSessionInSection(Instructor instructor, UUID sectionId,
+            UUID feedbackSessionId, String... permissionNames) {
         return instructorPermissionsLogic.hasPermissionsForSessionInSection(
-                instructor, sectionName, feedbackSessionName, permissionNames);
+                instructor, sectionId, feedbackSessionId, permissionNames);
     }
 
     /**
      * Checks if the given instructor has the specified session-in-section-level permissions in any section.
      */
     public boolean hasInstructorPermissionsForSectionInAnySection(Instructor instructor,
-            String sessionName, String... permissionNames) {
-        return instructorPermissionsLogic.hasPermissionsForSectionInAnySection(instructor, sessionName, permissionNames);
+            UUID sessionId, String... permissionNames) {
+        return instructorPermissionsLogic.hasPermissionsForSectionInAnySection(instructor, sessionId, permissionNames);
     }
 
     /**
      * Returns a map of sections with the specified permission for the given instructor.
      */
-    public Map<String, InstructorPermissionSet> getSectionsWithInstructorPermission(
+    public Map<UUID, InstructorPermissionSet> getSectionsWithInstructorPermission(
             Instructor instructor, String permissionName) {
         return instructorPermissionsLogic.getSectionsWithPermission(instructor, permissionName);
+    }
+
+    /**
+     * Returns the InstructorPrivileges for the given instructor.
+     *
+     * <p>
+     * For instructors with predefined roles, the privileges are determined by their
+     * role.
+     * For instructors with the custom role, the privileges are determined by their
+     * stored privileges.
+     */
+    public InstructorPrivileges getInstructorPrivileges(Instructor instructor) {
+        return instructorPermissionsLogic.getInstructorPrivileges(instructor);
+    }
+
+    /**
+     * Converts the given runtime {@link InstructorPrivileges} (UUID-keyed) to legacy name-keyed format.
+     */
+    public InstructorPrivilegesLegacy convertToLegacy(InstructorPrivileges newPrivileges) {
+        return instructorPermissionsLogic.convertToLegacy(newPrivileges);
+    }
+
+    /**
+     * Creates a {@link InstructorPrivilegesLegacy} for a predefined instructor role.
+     */
+    public InstructorPrivilegesLegacy legacyPrivilegesForRole(String roleName) {
+        return instructorPermissionsLogic.legacyPrivilegesForRole(roleName);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -48,7 +48,8 @@ public final class CoursesLogic {
         return instance;
     }
 
-    void initLogicDependencies(CoursesDb coursesDb, UsersLogic usersLogic, InstructorPermissionsLogic instructorPermissionsLogic) {
+    void initLogicDependencies(CoursesDb coursesDb, UsersLogic usersLogic,
+            InstructorPermissionsLogic instructorPermissionsLogic) {
         this.coursesDb = coursesDb;
         this.usersLogic = usersLogic;
         this.instructorPermissionsLogic = instructorPermissionsLogic;

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -7,10 +7,11 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -36,8 +37,8 @@ public final class CoursesLogic {
     private static final CoursesLogic instance = new CoursesLogic();
 
     private CoursesDb coursesDb;
-
     private UsersLogic usersLogic;
+    private InstructorPermissionsLogic instructorPermissionsLogic;
 
     private CoursesLogic() {
         // prevent initialization
@@ -47,9 +48,10 @@ public final class CoursesLogic {
         return instance;
     }
 
-    void initLogicDependencies(CoursesDb coursesDb, UsersLogic usersLogic) {
+    void initLogicDependencies(CoursesDb coursesDb, UsersLogic usersLogic, InstructorPermissionsLogic instructorPermissionsLogic) {
         this.coursesDb = coursesDb;
         this.usersLogic = usersLogic;
+        this.instructorPermissionsLogic = instructorPermissionsLogic;
     }
 
     /**
@@ -94,7 +96,7 @@ public final class CoursesLogic {
                 timeZone, courseCreateRequest.getInstitute());
 
         // Create the initial instructor for the course
-        InstructorPrivileges privileges = new InstructorPrivileges(
+        InstructorPrivilegesLegacy privileges = instructorPermissionsLogic.legacyPrivilegesForRole(
                 Const.InstructorPermissionRoleNames.COOWNER);
         Instructor instructor = new Instructor(
                 course,
@@ -228,6 +230,20 @@ public final class CoursesLogic {
         validateCourse(course);
 
         return course;
+    }
+
+    /**
+     * Returns the section with the given name in the given course, or null if not found.
+     */
+    public Section getSectionByName(String courseId, String sectionName) {
+        return coursesDb.getSectionByName(courseId, sectionName);
+    }
+
+    /**
+     * Returns the section with the given UUID, or null if not found.
+     */
+    public Section getSectionById(UUID sectionId) {
+        return coursesDb.getSectionById(sectionId);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -596,7 +596,7 @@ public final class FeedbackQuestionsLogic {
                 boolean shouldExcludeStudentForInstructor = isInstructorGiver
                         && responseGiver.getGiverUser() instanceof Instructor instructor
                         && !instructorPermissionsLogic.hasPermissionsForSessionInSection(
-                                instructor, student.getSectionName(), question.getFeedbackSession().getName(),
+                                instructor, student.getSectionId(), question.getFeedbackSession().getId(),
                                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
                 if (shouldExcludeStudentForInstructor || shouldExcludeStudent) {
                     continue;
@@ -653,7 +653,7 @@ public final class FeedbackQuestionsLogic {
                 boolean shouldExcludeTeamForInstructor = isInstructorGiver
                         && responseGiver.getGiverUser() instanceof Instructor instructor
                         && !instructorPermissionsLogic.hasPermissionsForSessionInSection(
-                                instructor, team.getSection().getName(), question.getFeedbackSession().getName(),
+                                instructor, team.getSection().getId(), question.getFeedbackSession().getId(),
                                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
 
                 if (shouldExcludeTeamForInstructor || shouldExcludeTeam) {

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -1002,19 +1002,21 @@ public final class FeedbackResponsesLogic {
         boolean isRecipientSectionRestrictedForInstructor = false;
         boolean isVisibleToInstructor = false;
         if (user instanceof Instructor instructor) {
-            isGiverSectionRestrictedForInstructor = !instructorPermissionsLogic.hasPermissionsForSessionInSection(
+            UUID giverSectionId = giver.getSectionId();
+            isGiverSectionRestrictedForInstructor = giverSectionId == null
+                    || !instructorPermissionsLogic.hasPermissionsForSessionInSection(
                         instructor,
-                        Const.DEFAULT_SECTION,
-                        relatedQuestion.getFeedbackSessionName(),
+                        giverSectionId,
+                        relatedQuestion.getFeedbackSession().getId(),
                         Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS
-                );
+                    );
 
-            isRecipientSectionRestrictedForInstructor =
-                    relatedQuestion.getRecipientType() != QuestionRecipientType.NONE
-                    && !instructorPermissionsLogic.hasPermissionsForSessionInSection(
+            UUID recipientSectionId = recipient.getSectionId();
+            isRecipientSectionRestrictedForInstructor = recipientSectionId == null
+                    || !instructorPermissionsLogic.hasPermissionsForSessionInSection(
                             instructor,
-                            Const.DEFAULT_SECTION,
-                            relatedQuestion.getFeedbackSessionName(),
+                            recipientSectionId,
+                            relatedQuestion.getFeedbackSession().getId(),
                             Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS
                     );
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -1003,8 +1003,8 @@ public final class FeedbackResponsesLogic {
         boolean isVisibleToInstructor = false;
         if (user instanceof Instructor instructor) {
             UUID giverSectionId = giver.getSectionId();
-            isGiverSectionRestrictedForInstructor = giverSectionId == null
-                    || !instructorPermissionsLogic.hasPermissionsForSessionInSection(
+            isGiverSectionRestrictedForInstructor = giverSectionId != null
+                    && !instructorPermissionsLogic.hasPermissionsForSessionInSection(
                         instructor,
                         giverSectionId,
                         relatedQuestion.getFeedbackSession().getId(),
@@ -1012,8 +1012,8 @@ public final class FeedbackResponsesLogic {
                     );
 
             UUID recipientSectionId = recipient.getSectionId();
-            isRecipientSectionRestrictedForInstructor = recipientSectionId == null
-                    || !instructorPermissionsLogic.hasPermissionsForSessionInSection(
+            isRecipientSectionRestrictedForInstructor = recipientSectionId != null
+                    && !instructorPermissionsLogic.hasPermissionsForSessionInSection(
                             instructor,
                             recipientSectionId,
                             relatedQuestion.getFeedbackSession().getId(),

--- a/src/main/java/teammates/logic/core/InstructorPermissionsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorPermissionsLogic.java
@@ -1,19 +1,28 @@
 package teammates.logic.core;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.UUID;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
+import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
+import teammates.storage.entity.Section;
 
 /**
  * Handles the logic related to instructor permissions.
  */
 public final class InstructorPermissionsLogic {
     private static final InstructorPermissionsLogic instance = new InstructorPermissionsLogic();
+
+    private CoursesLogic coursesLogic;
+    private FeedbackSessionsLogic feedbackSessionsLogic;
 
     private InstructorPermissionsLogic() {
         // prevent instantiation
@@ -24,7 +33,10 @@ public final class InstructorPermissionsLogic {
     }
 
     void initLogicDependencies() {
-        // no dependencies to initialize
+        // Temporary dependency on courses & sessions logic,
+        // will be removed once we have migrated InstructorPrivileges to SQL.
+        coursesLogic = CoursesLogic.inst();
+        feedbackSessionsLogic = FeedbackSessionsLogic.inst();
     }
 
     /**
@@ -46,14 +58,14 @@ public final class InstructorPermissionsLogic {
     /**
      * Checks if the given instructor has the specified section-level permission.
      */
-    public boolean hasPermissionsForSection(Instructor instructor, String sectionName, String... permissionNames) {
+    public boolean hasPermissionsForSection(Instructor instructor, UUID sectionId, String... permissionNames) {
         Objects.requireNonNull(instructor, "Instructor cannot be null");
-        Objects.requireNonNull(sectionName, "Section name cannot be null");
+        Objects.requireNonNull(sectionId, "Section ID cannot be null");
 
         InstructorPrivileges privileges = getInstructorPrivileges(instructor);
 
         for (String permissionName : permissionNames) {
-            if (!privileges.isAllowedForPrivilege(sectionName, permissionName)) {
+            if (!privileges.isAllowedForPrivilege(sectionId, permissionName)) {
                 return false;
             }
         }
@@ -63,16 +75,16 @@ public final class InstructorPermissionsLogic {
     /**
      * Checks if the given instructor has the specified session-in-section-level permission.
      */
-    public boolean hasPermissionsForSessionInSection(Instructor instructor, String sectionName,
-            String feedbackSessionName, String... permissionNames) {
+    public boolean hasPermissionsForSessionInSection(Instructor instructor, UUID sectionId,
+            UUID feedbackSessionId, String... permissionNames) {
         Objects.requireNonNull(instructor, "Instructor cannot be null");
-        Objects.requireNonNull(sectionName, "Section name cannot be null");
-        Objects.requireNonNull(feedbackSessionName, "Feedback session name cannot be null");
+        Objects.requireNonNull(sectionId, "Section ID cannot be null");
+        Objects.requireNonNull(feedbackSessionId, "Feedback session ID cannot be null");
 
         InstructorPrivileges privileges = getInstructorPrivileges(instructor);
 
         for (String permissionName : permissionNames) {
-            if (!privileges.isAllowedForPrivilege(sectionName, feedbackSessionName, permissionName)) {
+            if (!privileges.isAllowedForPrivilege(sectionId, feedbackSessionId, permissionName)) {
                 return false;
             }
         }
@@ -83,13 +95,13 @@ public final class InstructorPermissionsLogic {
      * Checks if the given instructor has the specified session-in-section-level permission in any section.
      */
     public boolean hasPermissionsForSectionInAnySection(Instructor instructor,
-            String sessionName, String... permissionNames) {
+            UUID sessionId, String... permissionNames) {
         Objects.requireNonNull(instructor, "Instructor cannot be null");
 
         InstructorPrivileges privileges = getInstructorPrivileges(instructor);
 
         for (String permissionName : permissionNames) {
-            if (privileges.isAllowedForPrivilegeAnySection(sessionName, permissionName)) {
+            if (privileges.isAllowedForPrivilegeAnySection(sessionId, permissionName)) {
                 return true;
             }
         }
@@ -99,7 +111,7 @@ public final class InstructorPermissionsLogic {
     /**
      * Returns a map of sections with the specified permission for the given instructor.
      */
-    public Map<String, InstructorPermissionSet> getSectionsWithPermission(Instructor instructor, String permissionName) {
+    public Map<UUID, InstructorPermissionSet> getSectionsWithPermission(Instructor instructor, String permissionName) {
         Objects.requireNonNull(instructor, "Instructor cannot be null");
         Objects.requireNonNull(permissionName, "Permission name cannot be null");
 
@@ -130,10 +142,184 @@ public final class InstructorPermissionsLogic {
         case INSTRUCTOR_PERMISSION_ROLE_TUTOR:
             return new InstructorPrivileges(Const.InstructorPermissionRoleNames.TUTOR);
         case INSTRUCTOR_PERMISSION_ROLE_CUSTOM:
-            return instructor.getPrivileges();
+            return convertLegacyToNew(instructor.getPrivileges(), instructor.getCourseId());
         default:
             throw new IllegalStateException("Unexpected instructor role: " + role);
         }
+    }
 
+    /**
+     * Saves instructor privileges for the given instructor.
+     */
+    public void saveInstructorPrivileges(Instructor instructor, InstructorPrivileges newPrivileges) {
+        Objects.requireNonNull(instructor, "Instructor cannot be null");
+        Objects.requireNonNull(newPrivileges, "Privileges cannot be null");
+
+        newPrivileges.validatePrivileges();
+        instructor.setPrivileges(convertNewToLegacy(newPrivileges));
+    }
+
+    /**
+     * Converts the given legacy {@link InstructorPrivilegesLegacy} (name-keyed) to runtime format with UUID keys.
+     */
+    public InstructorPrivileges convertToRuntime(InstructorPrivilegesLegacy legacyPrivileges) {
+        Objects.requireNonNull(legacyPrivileges, "Privileges cannot be null");
+
+        return convertLegacyToNew(legacyPrivileges, /* courseId= */ null);
+    }
+
+    /**
+     * Converts the given runtime {@link InstructorPrivileges} (UUID-keyed) to legacy name-keyed format.
+     */
+    public InstructorPrivilegesLegacy convertToLegacy(InstructorPrivileges newPrivileges) {
+        Objects.requireNonNull(newPrivileges, "Privileges cannot be null");
+
+        return convertNewToLegacy(newPrivileges);
+    }
+
+    /**
+     * Creates a {@link InstructorPrivilegesLegacy} for a predefined instructor role.
+     */
+    public InstructorPrivilegesLegacy legacyPrivilegesForRole(String roleName) {
+        InstructorPrivileges runtime = new InstructorPrivileges(roleName);
+        return new InstructorPrivilegesLegacy(
+                runtime.getCourseLevelPrivileges(),
+                new LinkedHashMap<>(),
+                new LinkedHashMap<>());
+    }
+
+    /**
+     * Converts legacy name-keyed privileges to runtime UUID-keyed privileges.
+     * Entries for sections or sessions that no longer exist are silently dropped.
+     */
+    private InstructorPrivileges convertLegacyToNew(InstructorPrivilegesLegacy legacy, String courseId) {
+        InstructorPrivileges newPrivileges = new InstructorPrivileges();
+
+        // Copy course-level
+        copyCourseLevelPrivileges(legacy.getCourseLevelPrivileges(), newPrivileges);
+
+        // Convert section-level: name → UUID
+        for (Map.Entry<String, InstructorPermissionSet> entry : legacy.getSectionLevelPrivileges().entrySet()) {
+            String sectionName = entry.getKey();
+            Section section = coursesLogic.getSectionByName(courseId, sectionName);
+            if (section == null) {
+                continue;
+            }
+            UUID sectionId = section.getId();
+            newPrivileges.addSectionWithDefaultPrivileges(sectionId);
+            applyPermissionSet(newPrivileges, sectionId, entry.getValue());
+        }
+
+        // Convert session-level: sectionName → sectionUUID, sessionName → sessionUUID
+        for (Map.Entry<String, Map<String, InstructorPermissionSet>> sectionEntry
+                : legacy.getSessionLevelPrivileges().entrySet()) {
+            String sectionName = sectionEntry.getKey();
+            Section section = coursesLogic.getSectionByName(courseId, sectionName);
+            if (section == null) {
+                continue;
+            }
+            UUID sectionId = section.getId();
+
+            for (Entry<String, InstructorPermissionSet> sessionEntry : sectionEntry.getValue().entrySet()) {
+                String sessionName = sessionEntry.getKey();
+                FeedbackSession feedbackSession = feedbackSessionsLogic.getFeedbackSession(sessionName, courseId);
+                if (feedbackSession == null) {
+                    continue;
+                }
+                UUID sessionId = feedbackSession.getId();
+                applySessionPermissionSet(newPrivileges, sectionId, sessionId, sessionEntry.getValue());
+            }
+        }
+
+        return newPrivileges;
+    }
+
+    /**
+     * Converts runtime UUID-keyed privileges to legacy name-keyed privileges.
+     * Entries for sections or sessions that cannot be resolved are silently dropped.
+     */
+    private InstructorPrivilegesLegacy convertNewToLegacy(InstructorPrivileges newPrivileges) {
+        InstructorPermissionSet courseLevel = newPrivileges.getCourseLevelPrivileges();
+        Map<String, InstructorPermissionSet> sectionLevel = new LinkedHashMap<>();
+        Map<String, Map<String, InstructorPermissionSet>> sessionLevel = new LinkedHashMap<>();
+
+        // Convert section-level: UUID → name
+        for (Map.Entry<UUID, InstructorPermissionSet> entry : newPrivileges.getSectionLevelPrivileges().entrySet()) {
+            Section section = coursesLogic.getSectionById(entry.getKey());
+            if (section == null) {
+                continue;
+            }
+            sectionLevel.put(section.getName(), entry.getValue());
+        }
+
+        // Convert session-level: sectionUUID → sectionName, sessionUUID → sessionName
+        for (Map.Entry<UUID, Map<UUID, InstructorPermissionSet>> sectionEntry
+                : newPrivileges.getSessionLevelPrivileges().entrySet()) {
+            Section section = coursesLogic.getSectionById(sectionEntry.getKey());
+            if (section == null) {
+                continue;
+            }
+            String sectionName = section.getName();
+            Map<String, InstructorPermissionSet> sessions = new LinkedHashMap<>();
+            for (Map.Entry<UUID, InstructorPermissionSet> sessionEntry : sectionEntry.getValue().entrySet()) {
+                FeedbackSession feedbackSession = feedbackSessionsLogic.getFeedbackSession(sessionEntry.getKey());
+                if (feedbackSession == null) {
+                    continue;
+                }
+                sessions.put(feedbackSession.getName(), sessionEntry.getValue());
+            }
+            if (!sessions.isEmpty()) {
+                sessionLevel.put(sectionName, sessions);
+            }
+        }
+
+        return new InstructorPrivilegesLegacy(courseLevel, sectionLevel, sessionLevel);
+    }
+
+    private void copyCourseLevelPrivileges(InstructorPermissionSet src, InstructorPrivileges dest) {
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, src.isCanModifyCourse());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, src.isCanModifyInstructor());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION, src.isCanModifySession());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, src.isCanModifyStudent());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS,
+                src.isCanViewStudentInSections());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS,
+                src.isCanViewSessionInSections());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS,
+                src.isCanSubmitSessionInSections());
+        dest.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS,
+                src.isCanModifySessionCommentsInSections());
+    }
+
+    private void applyPermissionSet(InstructorPrivileges dest, UUID sectionId, InstructorPermissionSet src) {
+        if (src.isCanViewStudentInSections()) {
+            dest.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        }
+        if (src.isCanViewSessionInSections()) {
+            dest.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        }
+        if (src.isCanSubmitSessionInSections()) {
+            dest.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        }
+        if (src.isCanModifySessionCommentsInSections()) {
+            dest.updatePrivilege(sectionId,
+                    Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        }
+    }
+
+    private void applySessionPermissionSet(InstructorPrivileges dest, UUID sectionId, UUID sessionId,
+            InstructorPermissionSet src) {
+        if (src.isCanViewSessionInSections()) {
+            dest.updatePrivilege(sectionId, sessionId,
+                    Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, true);
+        }
+        if (src.isCanSubmitSessionInSections()) {
+            dest.updatePrivilege(sectionId, sessionId,
+                    Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, true);
+        }
+        if (src.isCanModifySessionCommentsInSections()) {
+            dest.updatePrivilege(sectionId, sessionId,
+                    Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        }
     }
 }

--- a/src/main/java/teammates/logic/core/LogicStarter.java
+++ b/src/main/java/teammates/logic/core/LogicStarter.java
@@ -47,7 +47,7 @@ public class LogicStarter implements ServletContextListener {
         authLogic.initLogicDependencies(usersLogic);
         accountRequestsLogic.initLogicDependencies(AccountRequestsDb.inst());
         accountsLogic.initLogicDependencies(AccountsDb.inst(), usersLogic);
-        coursesLogic.initLogicDependencies(CoursesDb.inst(), usersLogic);
+        coursesLogic.initLogicDependencies(CoursesDb.inst(), usersLogic, instructorPermissionsLogic);
         dataBundleLogic.initLogicDependencies(accountsLogic, accountRequestsLogic, coursesLogic, notificationsLogic);
         deadlineExtensionsLogic.initLogicDependencies(DeadlineExtensionsDb.inst(), fsLogic, usersLogic);
         fsLogic.initLogicDependencies(FeedbackSessionsDb.inst(), frLogic, fqLogic, usersLogic);

--- a/src/main/java/teammates/logic/core/UsersLogic.java
+++ b/src/main/java/teammates/logic/core/UsersLogic.java
@@ -155,12 +155,13 @@ public final class UsersLogic {
         instructor.setName(SanitizationHelper.sanitizeName(instructorRequest.getName()));
         instructor.setEmail(SanitizationHelper.sanitizeEmail(instructorRequest.getEmail()));
         instructor.setRole(InstructorPermissionRole.getEnum(instructorRequest.getRoleName()));
-        InstructorPrivileges newPrivileges = instructorRequest.getPrivileges() == null
-                || !Const.InstructorPermissionRoleNames.CUSTOM.equals(instructorRequest.getRoleName())
-                        ? new InstructorPrivileges(instructorRequest.getRoleName())
-                        : instructorRequest.getPrivileges();
-        newPrivileges.validatePrivileges();
-        instructor.setPrivileges(newPrivileges);
+        boolean isCustomRole = Const.InstructorPermissionRoleNames.CUSTOM.equals(instructorRequest.getRoleName());
+        if (isCustomRole && instructorRequest.getPrivileges() != null) {
+            instructorPermissionsLogic.saveInstructorPrivileges(instructor, instructorRequest.getPrivileges());
+        } else {
+            instructorPermissionsLogic.saveInstructorPrivileges(instructor,
+                    new InstructorPrivileges(instructorRequest.getRoleName()));
+        }
         instructor.setDisplayName(SanitizationHelper.sanitizeName(newDisplayName));
         instructor.setDisplayedToStudents(instructorRequest.getIsDisplayedToStudent());
 
@@ -680,7 +681,9 @@ public final class UsersLogic {
                 || instrWithModifyInstructorPrivilege.getGoogleId()
                 .equals(instructorToEdit.getGoogleId()));
         if (isLastRegInstructorWithPrivilege) {
-            instructorToEdit.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+            InstructorPrivileges privileges = instructorPermissionsLogic.getInstructorPrivileges(instructorToEdit);
+            privileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
+            instructorPermissionsLogic.saveInstructorPrivileges(instructorToEdit, privileges);
         }
     }
 

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -77,6 +77,14 @@ public final class CoursesDb {
     }
 
     /**
+     * Get section by UUID.
+     */
+    public Section getSectionById(UUID sectionId) {
+        // TODO: add tests for this method
+        return HibernateUtil.get(Section.class, sectionId);
+    }
+
+    /**
      * Persists a team.
      */
     public Team persistTeam(Team team) {

--- a/src/main/java/teammates/storage/entity/BaseEntity.java
+++ b/src/main/java/teammates/storage/entity/BaseEntity.java
@@ -11,7 +11,7 @@ import jakarta.persistence.MappedSuperclass;
 
 import org.hibernate.annotations.CreationTimestamp;
 
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
@@ -162,15 +162,15 @@ public abstract class BaseEntity {
      * Converter for InstructorPrivileges.
      */
     @Converter
-    public static class InstructorPrivilegesConverter implements AttributeConverter<InstructorPrivileges, String> {
+    public static class InstructorPrivilegesConverter implements AttributeConverter<InstructorPrivilegesLegacy, String> {
         @Override
-        public String convertToDatabaseColumn(InstructorPrivileges entity) {
+        public String convertToDatabaseColumn(InstructorPrivilegesLegacy entity) {
             return JsonUtils.toJson(entity);
         }
 
         @Override
-        public InstructorPrivileges convertToEntityAttribute(String dbData) {
-            return JsonUtils.fromJson(dbData, InstructorPrivileges.class);
+        public InstructorPrivilegesLegacy convertToEntityAttribute(String dbData) {
+            return JsonUtils.fromJson(dbData, InstructorPrivilegesLegacy.class);
         }
     }
 }

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -10,8 +10,9 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 
+import teammates.common.datatransfer.DefaultInstructorPrivileges;
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.UserType;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -36,14 +37,14 @@ public class Instructor extends User {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     @Convert(converter = InstructorPrivilegesConverter.class)
-    private InstructorPrivileges privileges;
+    private InstructorPrivilegesLegacy privileges;
 
     protected Instructor() {
         // required by Hibernate
     }
 
     public Instructor(String name, String email, boolean isDisplayedToStudents,
-            String displayName, InstructorPermissionRole role, InstructorPrivileges privileges) {
+            String displayName, InstructorPermissionRole role, InstructorPrivilegesLegacy privileges) {
         super(name, email);
         this.setDisplayedToStudents(isDisplayedToStudents);
         this.setDisplayName(displayName);
@@ -52,7 +53,7 @@ public class Instructor extends User {
     }
 
     public Instructor(Course course, String name, String email, boolean isDisplayedToStudents,
-            String displayName, InstructorPermissionRole role, InstructorPrivileges privileges) {
+            String displayName, InstructorPermissionRole role, InstructorPrivilegesLegacy privileges) {
         super(course, name, email);
         this.setDisplayedToStudents(isDisplayedToStudents);
         this.setDisplayName(displayName);
@@ -89,11 +90,11 @@ public class Instructor extends User {
         this.role = role;
     }
 
-    public InstructorPrivileges getPrivileges() {
+    public InstructorPrivilegesLegacy getPrivileges() {
         return privileges;
     }
 
-    public void setPrivileges(InstructorPrivileges instructorPrivileges) {
+    public void setPrivileges(InstructorPrivilegesLegacy instructorPrivileges) {
         this.privileges = instructorPrivileges;
     }
 
@@ -150,7 +151,7 @@ public class Instructor extends User {
      */
     public boolean hasCoownerPrivileges() {
         return this.role == InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER
-                || this.privileges.hasAllPrivileges();
+                || this.privileges.getCourseLevelPrivileges().equals(DefaultInstructorPrivileges.PRIVILEGES_ALL);
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/BasicFeedbackSubmissionAction.java
@@ -124,7 +124,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
         if (!StringHelper.isEmpty(moderatedPerson)) {
             gateKeeper.verifyLoggedInUserPrivileges(requestContext);
             gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, feedbackSession.getCourseId(),
-                    student.getSectionName(),
+                    student.getSectionId(),
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
         } else if (!StringHelper.isEmpty(previewAsPerson)) {
             checkAccessControlForPreview(feedbackSession);
@@ -184,7 +184,7 @@ abstract class BasicFeedbackSubmissionAction extends Action {
 
     private void verifyInstructorCanSubmitToSession(FeedbackSession feedbackSession, Instructor instructor)
             throws UnauthorizedAccessException {
-        if (logic.hasInstructorPermissionsForSectionInAnySection(instructor, feedbackSession.getName(),
+        if (logic.hasInstructorPermissionsForSectionInAnySection(instructor, feedbackSession.getId(),
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)) {
             return;
         }

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
@@ -102,15 +103,17 @@ public class CreateInstructorAction extends Action {
         }
 
         // Only assign privileges if the role is custom, otherwise assign default privileges for the role
-        InstructorPrivileges privileges = requestPrivileges == null
-                || !Const.InstructorPermissionRoleNames.CUSTOM.equals(instructorRole)
-                        ? new InstructorPrivileges(instrRole)
-                        : requestPrivileges;
-        privileges.validatePrivileges();
         InstructorPermissionRole role = InstructorPermissionRole.getEnum(instrRole);
+        InstructorPrivilegesLegacy legacyPrivileges;
+        if (requestPrivileges != null && Const.InstructorPermissionRoleNames.CUSTOM.equals(instructorRole)) {
+            requestPrivileges.validatePrivileges();
+            legacyPrivileges = logic.convertToLegacy(requestPrivileges);
+        } else {
+            legacyPrivileges = logic.legacyPrivilegesForRole(instrRole);
+        }
 
         return new Instructor(course, instrName, instrEmail, isDisplayedToStudents, instrDisplayedName, role,
-                privileges);
+                legacyPrivileges);
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -49,9 +49,9 @@ public class CreateResponseInstructorCommentAction extends Action {
                     Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         } else {
             gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionId,
-                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
+                    Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         }
-        
+
         if (!feedbackQuestion.getQuestionDetailsCopy().isInstructorCommentsOnResponsesAllowed()) {
             throw new InvalidHttpParameterException("Invalid question type for instructor comment");
         }

--- a/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateResponseInstructorCommentAction.java
@@ -10,7 +10,6 @@ import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.storage.entity.ResponseRecipient;
 import teammates.ui.exception.EntityNotFoundException;
@@ -43,14 +42,16 @@ public class CreateResponseInstructorCommentAction extends Action {
         FeedbackQuestion feedbackQuestion = feedbackResponse.getFeedbackQuestion();
         FeedbackSession session = feedbackQuestion.getFeedbackSession();
 
-        ResponseGiver giver = feedbackResponse.getGiver();
-        String giverSectionName = giver.getSectionName();
         ResponseRecipient recipient = feedbackResponse.getRecipient();
-        String recipientSectionName = recipient.getSectionName();
-        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), giverSectionName,
+        UUID recipientSectionId = recipient.getSectionId();
+        if (recipientSectionId == null) {
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, session.getCourseId(),
+                    Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
+        } else {
+            gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionId,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
-        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionName,
-                Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
+        }
+        
         if (!feedbackQuestion.getQuestionDetailsCopy().isInstructorCommentsOnResponsesAllowed()) {
             throw new InvalidHttpParameterException("Invalid question type for instructor comment");
         }

--- a/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteResponseInstructorCommentAction.java
@@ -7,7 +7,6 @@ import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -43,12 +42,13 @@ public class DeleteResponseInstructorCommentAction extends Action {
         }
 
         FeedbackResponse response = comment.getFeedbackResponse();
-        ResponseGiver giver = response.getGiver();
-        String giverSectionName = giver.getSectionName();
-        String recipientSectionName = response.getRecipient().getSectionName();
-        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), giverSectionName,
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionName,
+        UUID recipientSectionId = response.getRecipient().getSectionId();
+        if (recipientSectionId == null) {
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                    Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
+            return;
+        }
+        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(), recipientSectionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import java.util.UUID;
+
 import teammates.common.datatransfer.RequestContext;
 import teammates.logic.api.Logic;
 import teammates.logic.core.AuthLogic;
@@ -128,26 +130,26 @@ final class GateKeeper {
     }
 
     /**
-     * Verifies the instructor for the specified course has the privileges specified by privilegeNames for sectionName.
+     * Verifies the instructor for the specified course has the privileges specified by privilegeNames for sectionId.
      */
-    void verifyInstructorHasPrivilegeForSection(RequestContext requestContext, String courseId, String sectionName,
+    void verifyInstructorHasPrivilegeForSection(RequestContext requestContext, String courseId, UUID sectionId,
             String... privilegeNames) throws UnauthorizedAccessException {
         Instructor instructor = requestContext.getInstructorForCourse(courseId, authLogic::getInstructorFromAuthContext);
-        verifyInstructorHasPrivilegeForSection(instructor, sectionName, privilegeNames);
+        verifyInstructorHasPrivilegeForSection(instructor, sectionId, privilegeNames);
     }
 
     /**
-     * Verifies the instructor has the privileges specified by privilegeNames for sectionName.
+     * Verifies the instructor has the privileges specified by privilegeNames for sectionId.
      */
-    void verifyInstructorHasPrivilegeForSection(Instructor instructor, String sectionName, String... privilegeNames)
+    void verifyInstructorHasPrivilegeForSection(Instructor instructor, UUID sectionId, String... privilegeNames)
             throws UnauthorizedAccessException {
-        verifyNotNull(sectionName, "section name");
+        verifyNotNull(sectionId, "section ID");
 
         for (String privilegeName : privilegeNames) {
             if (instructor == null
-                    || !logic.hasInstructorPermissionsForSection(instructor, sectionName, privilegeName)) {
+                    || !logic.hasInstructorPermissionsForSection(instructor, sectionId, privilegeName)) {
                 throw new UnauthorizedAccessException("Instructor does not have privilege [" + privilegeName
-                                                      + "] on section [" + sectionName + "]");
+                                                      + "] on section [" + sectionId + "]");
             }
         }
     }

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionAction.java
@@ -121,11 +121,11 @@ public class GetFeedbackSessionAction extends BasicFeedbackSubmissionAction {
                 logic.hasInstructorPermissions(instructorSubmission, Const.InstructorPermissions.CAN_MODIFY_SESSION);
         boolean canSubmitSessionInSections = logic.hasInstructorPermissions(instructorSubmission,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)
-                || logic.hasInstructorPermissionsForSectionInAnySection(instructorSubmission, feedbackSession.getName(),
+                || logic.hasInstructorPermissionsForSectionInAnySection(instructorSubmission, feedbackSession.getId(),
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         boolean canViewSessionInSections = logic.hasInstructorPermissions(instructorSubmission,
                 Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS)
-                || logic.hasInstructorPermissionsForSectionInAnySection(instructorSubmission, feedbackSession.getName(),
+                || logic.hasInstructorPermissionsForSectionInAnySection(instructorSubmission, feedbackSession.getId(),
                 Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         return new InstructorFeedbackSessionPermissionsData(
                 canModifySession,

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionsAction.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackSession;
@@ -128,16 +129,16 @@ public class GetFeedbackSessionsAction extends Action {
         if (instructor == null) {
             return new InstructorFeedbackSessionPermissionsData(false, false, false);
         }
-        String sessionName = session.getFeedbackSession().getFeedbackSessionName();
+        UUID sessionId = session.getFeedbackSession().getFeedbackSessionId();
         boolean canModifySession = logic.hasInstructorPermissions(instructor,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
         boolean canSubmitSessionInSections = logic.hasInstructorPermissions(instructor,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)
-                || logic.hasInstructorPermissionsForSectionInAnySection(instructor, sessionName,
+                || logic.hasInstructorPermissionsForSectionInAnySection(instructor, sessionId,
                 Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS);
         boolean canViewSessionInSections = logic.hasInstructorPermissions(instructor,
                 Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS)
-                || logic.hasInstructorPermissionsForSectionInAnySection(instructor, sessionName,
+                || logic.hasInstructorPermissionsForSectionInAnySection(instructor, sessionId,
                 Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS);
         return new InstructorFeedbackSessionPermissionsData(canModifySession,
                 canSubmitSessionInSections, canViewSessionInSections);

--- a/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/GetInstructorPrivilegeAction.java
@@ -55,7 +55,8 @@ public class GetInstructorPrivilegeAction extends Action {
             instructor = getInstructor(userId);
         }
 
-        InstructorPrivilegeData response = new InstructorPrivilegeData(instructor.getPrivileges());
+        InstructorPrivilegeData response =
+                new InstructorPrivilegeData(logic.getInstructorPrivileges(instructor));
 
         return new JsonResult(response);
     }

--- a/src/main/java/teammates/ui/webapi/GetStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentAction.java
@@ -35,7 +35,7 @@ public class GetStudentAction extends Action {
             }
 
             gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, courseId,
-                    student.getSectionName(),
+                    student.getSectionId(),
                     Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS);
         } else {
             gateKeeper.verifyStudentInCourse(requestContext, courseId);

--- a/src/main/java/teammates/ui/webapi/GetStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetStudentsAction.java
@@ -3,6 +3,7 @@ package teammates.ui.webapi;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.Instructor;
@@ -66,11 +67,11 @@ public class GetStudentsAction extends Action {
             // request to get students by instructor with section privilege
             List<Student> studentsForCourse = logic.getStudentsForCourse(courseId);
             List<Student> studentsToReturn = new LinkedList<>();
-            Set<String> sectionsWithViewPrivileges =
+            Set<UUID> sectionsWithViewPrivileges =
                     logic.getSectionsWithInstructorPermission(instructor, privilegeName).keySet();
 
             studentsForCourse.forEach(student -> {
-                if (sectionsWithViewPrivileges.contains(student.getSectionName())) {
+                if (sectionsWithViewPrivileges.contains(student.getSectionId())) {
                     studentsToReturn.add(student);
                 }
             });

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -54,7 +54,7 @@ public class UpdateResponseInstructorCommentAction extends Action {
                     Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
             return;
         }
-        
+
         gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(),
                 recipientSectionId, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }

--- a/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateResponseInstructorCommentAction.java
@@ -47,12 +47,16 @@ public class UpdateResponseInstructorCommentAction extends Action {
         if (comment.getGiver().equals(instructor)) {
             return;
         }
+
+        UUID recipientSectionId = response.getRecipient().getSectionId();
+        if (recipientSectionId == null) {
+            gateKeeper.verifyInstructorHasPrivilege(requestContext, courseId,
+                    Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
+            return;
+        }
+        
         gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(),
-                response.getGiver().getSectionName(),
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-        gateKeeper.verifyInstructorHasPrivilegeForSection(requestContext, session.getCourseId(),
-                response.getRecipient().getSectionName(),
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
+                recipientSectionId, Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS);
     }
 
     @Override

--- a/src/test/java/teammates/common/datatransfer/InstructorPrivilegesTest.java
+++ b/src/test/java/teammates/common/datatransfer/InstructorPrivilegesTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.UUID;
+
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
@@ -200,7 +202,7 @@ public class InstructorPrivilegesTest extends BaseTestCase {
     public void testUpdatePrivilegeInSectionLevel() {
         InstructorPrivileges privileges =
                 new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER);
-        String sectionId = "sectionId";
+        UUID sectionId = UUID.randomUUID();
 
         privileges.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
         assertEquals(1, privileges.getSectionLevelPrivileges().size());
@@ -227,8 +229,8 @@ public class InstructorPrivilegesTest extends BaseTestCase {
     public void testUpdatePrivilegeInSessionLevel() {
         InstructorPrivileges privileges =
                 new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER);
-        String sectionId = "sectionId";
-        String sessionId = "sessionId";
+        UUID sectionId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
 
         privileges.updatePrivilege(sectionId, sessionId,
                                    Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, false);
@@ -253,8 +255,8 @@ public class InstructorPrivilegesTest extends BaseTestCase {
     public void testAddSectionWithDefaultPrivilegesToSectionLevel() {
         InstructorPrivileges privileges =
                 new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER);
-        String sectionId = "sectionId";
-        String sectionId2 = "sectionId2";
+        UUID sectionId = UUID.randomUUID();
+        UUID sectionId2 = UUID.randomUUID();
 
         privileges.addSectionWithDefaultPrivileges(sectionId);
         assertEquals(1, privileges.getSectionLevelPrivileges().size());
@@ -277,7 +279,7 @@ public class InstructorPrivilegesTest extends BaseTestCase {
 
         assertTrue(privileges.isAllowedForPrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE));
 
-        String sectionId = "sectionId";
+        UUID sectionId = UUID.randomUUID();
         assertTrue(privileges.isAllowedForPrivilege(
                 sectionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
         privileges.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, false);
@@ -286,7 +288,7 @@ public class InstructorPrivilegesTest extends BaseTestCase {
         assertTrue(privileges.isAllowedForPrivilege(
                 sectionId, Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS));
 
-        String sessionId = "sessionId";
+        UUID sessionId = UUID.randomUUID();
         assertFalse(privileges.isAllowedForPrivilege(
                 sectionId, sessionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
     }
@@ -304,21 +306,21 @@ public class InstructorPrivilegesTest extends BaseTestCase {
         // restore courseLevel to pre-validate
         privileges.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, false);
         privileges.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
-        String sectionName = "section";
-        privileges.addSectionWithDefaultPrivileges(sectionName);
+        UUID sectionId = UUID.randomUUID();
+        privileges.addSectionWithDefaultPrivileges(sectionId);
         privileges.validatePrivileges();
         assertTrue(privileges.isAllowedForPrivilege(Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
         assertTrue(privileges.isAllowedForPrivilege(
-                sectionName, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+                sectionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
 
         privileges.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, false);
         privileges.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
-        privileges.updatePrivilege(sectionName, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, false);
-        privileges.updatePrivilege(sectionName, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
+        privileges.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS, false);
+        privileges.updatePrivilege(sectionId, Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
         privileges.validatePrivileges();
         assertTrue(privileges.isAllowedForPrivilege(Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
         assertTrue(privileges.isAllowedForPrivilege(
-                sectionName, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
+                sectionId, Const.InstructorPermissions.CAN_VIEW_SESSION_IN_SECTIONS));
     }
 
 }

--- a/src/test/java/teammates/logic/core/CoursesLogicTest.java
+++ b/src/test/java/teammates/logic/core/CoursesLogicTest.java
@@ -51,7 +51,7 @@ public class CoursesLogicTest extends BaseTestCase {
     public void setUp() {
         coursesDb = mock(CoursesDb.class);
         usersLogic = mock(UsersLogic.class);
-        coursesLogic.initLogicDependencies(coursesDb, usersLogic);
+        coursesLogic.initLogicDependencies(coursesDb, usersLogic, InstructorPermissionsLogic.inst());
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/DataBundleLogicIT.java
+++ b/src/test/java/teammates/logic/core/DataBundleLogicIT.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.Provider;
@@ -136,7 +136,8 @@ public class DataBundleLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         Instructor actualInstructor1 = dataBundle.instructors.get("instructor1OfTypicalCourse");
         InstructorPermissionRole coOwner = InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER;
-        InstructorPrivileges coOwnerPrivileges = new InstructorPrivileges(coOwner.getRoleName());
+        InstructorPrivilegesLegacy coOwnerPrivileges = InstructorPermissionsLogic.inst()
+                .legacyPrivilegesForRole(coOwner.getRoleName());
         Instructor expectedInstructor1 = new Instructor(actualTypicalCourse, "Instructor 1", "instr1@teammates.tmt",
                 true, "Instructor", coOwner, coOwnerPrivileges);
         expectedInstructor1.setId(actualInstructor1.getId());
@@ -146,7 +147,8 @@ public class DataBundleLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         Instructor actualInstructor2 = dataBundle.instructors.get("instructor2OfTypicalCourse");
         InstructorPermissionRole tutor = InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_TUTOR;
-        InstructorPrivileges tutorPrivileges = new InstructorPrivileges(tutor.getRoleName());
+        InstructorPrivilegesLegacy tutorPrivileges = InstructorPermissionsLogic.inst()
+                .legacyPrivilegesForRole(tutor.getRoleName());
         Instructor expectedInstructor2 = new Instructor(actualTypicalCourse, "Instructor 2", "instr2@teammates.tmt",
                 true, "Instructor", tutor, tutorPrivileges);
         expectedInstructor2.setId(actualInstructor2.getId());

--- a/src/test/java/teammates/logic/core/UsersLogicIT.java
+++ b/src/test/java/teammates/logic/core/UsersLogicIT.java
@@ -9,10 +9,10 @@ import java.util.UUID;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
-import teammates.common.util.Const.InstructorPermissions;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
@@ -112,12 +112,14 @@ public class UsersLogicIT extends BaseTestCaseWithDatabaseAccess {
         instructor.setAccount(account);
 
         ______TS("success: preserves modify instructor privilege if last instructor in course with privilege");
-        InstructorPrivileges privileges = instructor.getPrivileges();
-        privileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
-        instructor.setPrivileges(privileges);
+        InstructorPermissionSet courseLevelPerms = instructor.getPrivileges().getCourseLevelPrivileges();
+        courseLevelPerms.setCanModifyInstructor(false);
+        instructor.setPrivileges(new InstructorPrivilegesLegacy(courseLevelPerms,
+                instructor.getPrivileges().getSectionLevelPrivileges(),
+                instructor.getPrivileges().getSessionLevelPrivileges()));
         inTransaction(() -> usersLogic.updateToEnsureValidityOfInstructorsForTheCourse(instructor));
 
-        assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
+        assertFalse(instructor.getPrivileges().getCourseLevelPrivileges().get(
                 Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
     }
 }

--- a/src/test/java/teammates/logic/core/UsersLogicTest.java
+++ b/src/test/java/teammates/logic/core/UsersLogicTest.java
@@ -21,11 +21,11 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPermissionSet;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.Provider;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
-import teammates.common.util.Const.InstructorPermissions;
 import teammates.storage.api.UsersDb;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
@@ -59,11 +59,11 @@ public class UsersLogicTest extends BaseTestCase {
         doAnswer(invocation -> {
             Instructor instructor = invocation.getArgument(0);
             String permissionName = invocation.getArgument(1);
-            InstructorPrivileges effectivePrivileges = instructor.getRole()
+            InstructorPrivilegesLegacy effectiveLegacy = instructor.getRole()
                     == InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM
                             ? instructor.getPrivileges()
-                            : new InstructorPrivileges(instructor.getRole().getRoleName());
-            return effectivePrivileges.isAllowedForPrivilege(permissionName);
+                            : InstructorPermissionsLogic.inst().legacyPrivilegesForRole(instructor.getRole().getRoleName());
+            return effectiveLegacy.getCourseLevelPrivileges().get(permissionName);
         }).when(instructorPermissionsLogic).hasPermissions(any(Instructor.class), any(String.class));
         usersLogic.initLogicDependencies(usersDb, coursesLogic, feedbackResponsesLogic, instructorPermissionsLogic);
 
@@ -200,12 +200,14 @@ public class UsersLogicTest extends BaseTestCase {
 
     @Test
     public void testUpdateToEnsureValidityOfInstructorsForTheCourse_lastModifyInstructorPrivilege_shouldPreserve() {
-        InstructorPrivileges privileges = instructor.getPrivileges();
-        privileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
-        instructor.setPrivileges(privileges);
+        InstructorPermissionSet courseLevelPerms = instructor.getPrivileges().getCourseLevelPrivileges();
+        courseLevelPerms.setCanModifyInstructor(false);
+        instructor.setPrivileges(new InstructorPrivilegesLegacy(courseLevelPerms,
+                instructor.getPrivileges().getSectionLevelPrivileges(),
+                instructor.getPrivileges().getSessionLevelPrivileges()));
         usersLogic.updateToEnsureValidityOfInstructorsForTheCourse(instructor);
 
-        assertFalse(instructor.getPrivileges().isAllowedForPrivilege(
+        assertFalse(instructor.getPrivileges().getCourseLevelPrivileges().get(
                 Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR));
     }
 

--- a/src/test/java/teammates/storage/api/UsersDbTest.java
+++ b/src/test/java/teammates/storage/api/UsersDbTest.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -236,7 +236,7 @@ public class UsersDbTest extends BaseDbTestcase {
                 true,
                 "Instructor Display Name",
                 role,
-                new InstructorPrivileges(role.getRoleName()));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(role.getRoleName()));
         instructor.setId(instructorId);
         instructor.setCourse(course);
         return instructor;

--- a/src/test/java/teammates/test/BaseTestCase.java
+++ b/src/test/java/teammates/test/BaseTestCase.java
@@ -14,7 +14,7 @@ import org.testng.annotations.BeforeClass;
 import teammates.common.datatransfer.AccountRequestStatus;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.NotificationStyle;
 import teammates.common.datatransfer.NotificationTargetUser;
 import teammates.common.datatransfer.Provider;
@@ -28,6 +28,7 @@ import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.TimeHelperExtension;
 import teammates.logic.core.DataBundleLogic;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.Course;
@@ -121,8 +122,8 @@ public class BaseTestCase {
 
     protected Instructor getTypicalInstructor() {
         Course course = getTypicalCourse();
-        InstructorPrivileges instructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER);
+        InstructorPrivilegesLegacy instructorPrivileges =
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.COOWNER);
         InstructorPermissionRole role = InstructorPermissionRole
                 .getEnum(Const.InstructorPermissionRoleNames.COOWNER);
 

--- a/src/test/java/teammates/test/scenariobuilder/GivenInstructor.java
+++ b/src/test/java/teammates/test/scenariobuilder/GivenInstructor.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
@@ -57,7 +59,8 @@ public class GivenInstructor extends GivenBase<Instructor> {
     public GivenInstructor coOwner() {
         entity.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
         entity.setPrivileges(
-                new InstructorPrivileges(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER.getRoleName()));
+                InstructorPermissionsLogic.inst()
+                        .legacyPrivilegesForRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER.getRoleName()));
         return this;
     }
 
@@ -67,7 +70,8 @@ public class GivenInstructor extends GivenBase<Instructor> {
     public GivenInstructor manager() {
         entity.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_MANAGER);
         entity.setPrivileges(
-                new InstructorPrivileges(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_MANAGER.getRoleName()));
+                InstructorPermissionsLogic.inst()
+                        .legacyPrivilegesForRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_MANAGER.getRoleName()));
         return this;
     }
 
@@ -77,7 +81,9 @@ public class GivenInstructor extends GivenBase<Instructor> {
     public GivenInstructor observer() {
         entity.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_OBSERVER);
         entity.setPrivileges(
-                new InstructorPrivileges(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_OBSERVER.getRoleName()));
+                InstructorPermissionsLogic.inst()
+                        .legacyPrivilegesForRole(InstructorPermissionRole
+                                .INSTRUCTOR_PERMISSION_ROLE_OBSERVER.getRoleName()));
         return this;
     }
 
@@ -87,7 +93,8 @@ public class GivenInstructor extends GivenBase<Instructor> {
     public GivenInstructor tutor() {
         entity.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_TUTOR);
         entity.setPrivileges(
-                new InstructorPrivileges(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_TUTOR.getRoleName()));
+                InstructorPermissionsLogic.inst()
+                        .legacyPrivilegesForRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_TUTOR.getRoleName()));
         return this;
     }
 
@@ -96,7 +103,9 @@ public class GivenInstructor extends GivenBase<Instructor> {
      */
     public GivenInstructor custom(InstructorPrivileges privileges) {
         entity.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        entity.setPrivileges(privileges);
+        entity.setPrivileges(
+                InstructorPermissionsLogic.inst().convertToLegacy(privileges)
+        );
         return this;
     }
 
@@ -132,7 +141,8 @@ public class GivenInstructor extends GivenBase<Instructor> {
         boolean isDisplayedToStudents = true;
         String displayName = name;
         InstructorPermissionRole role = InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER;
-        InstructorPrivileges privileges = new InstructorPrivileges(role.getRoleName());
+        InstructorPrivilegesLegacy privileges = InstructorPermissionsLogic.inst()
+                .legacyPrivilegesForRole(role.getRoleName());
         Instructor i = new Instructor(name, email, isDisplayedToStudents, displayName, role, privileges);
         i.setId(instructorId);
         return i;

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -19,6 +19,7 @@ import org.apache.http.client.methods.HttpPut;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.Provider;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
@@ -257,13 +258,16 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
 
     void grantInstructorWithSectionPrivilege(
             Instructor instructor, String privilege, String[] sections) {
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-
-        for (String section : sections) {
-            instructorPrivileges.updatePrivilege(section, privilege, true);
+        InstructorPrivileges runtimePrivileges = new InstructorPrivileges();
+        for (String sectionName : sections) {
+            Section section =
+                    CoursesLogic.inst().getSectionByName(instructor.getCourseId(), sectionName);
+            if (section != null) {
+                runtimePrivileges.updatePrivilege(section.getId(), privilege, true);
+            }
         }
-
-        instructor.setPrivileges(instructorPrivileges);
+        teammates.logic.core.InstructorPermissionsLogic.inst()
+                .saveInstructorPrivileges(instructor, runtimePrivileges);
         assert instructor.isValid();
     }
 
@@ -433,12 +437,17 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         verifyCannotAccess(submissionParams);
 
         ______TS("only instructor with correct course privilege should pass");
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-
-        instructorPrivileges.updatePrivilege(privilege, true);
-        instructor.setPrivileges(instructorPrivileges);
+        InstructorPrivileges runtimePrivileges = new InstructorPrivileges();
+        runtimePrivileges.updatePrivilege(privilege, true);
+        teammates.logic.core.InstructorPermissionsLogic.inst()
+                .saveInstructorPrivileges(instructor, runtimePrivileges);
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        inTransaction(() -> logic.getInstructor(instructor.getId()).setPrivileges(instructorPrivileges));
+        inTransaction(() -> {
+            Instructor dbInstructor = logic.getInstructor(instructor.getId());
+            teammates.logic.core.InstructorPermissionsLogic.inst()
+                    .saveInstructorPrivileges(dbInstructor, runtimePrivileges);
+            dbInstructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+        });
 
         verifyCanAccess(submissionParams);
         verifyAccessibleForAdminToMasqueradeAsInstructor(instructor, submissionParams);
@@ -727,7 +736,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         if (instructor == null) {
             instructor = inTransaction(() -> {
                 Instructor toCreate = new Instructor(course, "instructor-name", email, true, "display-name",
-                        InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                        InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
                 Instructor createdInstructor = logic.createInstructor(toCreate);
 
                 String googleId = email;

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -12,8 +12,11 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import jakarta.servlet.http.Cookie;
@@ -28,6 +31,7 @@ import org.mockito.invocation.InvocationOnMock;
 import teammates.common.datatransfer.AuthContext;
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.Provider;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -40,6 +44,7 @@ import teammates.logic.api.MockLogsProcessor;
 import teammates.logic.api.MockTaskQueuer;
 import teammates.logic.api.MockUserProvision;
 import teammates.logic.core.AuthLogic;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.logic.core.UsersLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
@@ -145,9 +150,9 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         doAnswer(invocation -> {
             Instructor instructor = invocation.getArgument(0);
             List<String> permissionNames = getStringArguments(invocation, 1);
-            InstructorPrivileges privileges = getEffectivePrivileges(instructor);
+            InstructorPrivilegesLegacy privileges = getEffectiveLegacyPrivileges(instructor);
             for (String permissionName : permissionNames) {
-                if (!privileges.isAllowedForPrivilege(permissionName)) {
+                if (!legacyIsAllowedForPrivilege(privileges, permissionName)) {
                     return false;
                 }
             }
@@ -156,62 +161,140 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
 
         doAnswer(invocation -> {
             Instructor instructor = invocation.getArgument(0);
-            String sectionName = invocation.getArgument(1);
+            UUID sectionId = invocation.getArgument(1);
             List<String> permissionNames = getStringArguments(invocation, 2);
-            InstructorPrivileges privileges = getEffectivePrivileges(instructor);
+            InstructorPrivilegesLegacy privileges = getEffectiveLegacyPrivileges(instructor);
             for (String permissionName : permissionNames) {
-                if (!privileges.isAllowedForPrivilege(sectionName, permissionName)) {
+                if (!legacyIsAllowedForPrivilege(privileges, sectionId.toString(), permissionName)) {
                     return false;
                 }
             }
             return true;
-        }).when(mockLogic).hasInstructorPermissionsForSection(any(Instructor.class), anyString(), any());
+        }).when(mockLogic).hasInstructorPermissionsForSection(any(Instructor.class), any(UUID.class), any());
 
         doAnswer(invocation -> {
             Instructor instructor = invocation.getArgument(0);
-            String sectionName = invocation.getArgument(1);
-            String feedbackSessionName = invocation.getArgument(2);
+            UUID sectionId = invocation.getArgument(1);
+            UUID sessionId = invocation.getArgument(2);
             List<String> permissionNames = getStringArguments(invocation, 3);
-            InstructorPrivileges privileges = getEffectivePrivileges(instructor);
+            InstructorPrivilegesLegacy privileges = getEffectiveLegacyPrivileges(instructor);
             for (String permissionName : permissionNames) {
-                if (!privileges.isAllowedForPrivilege(sectionName, feedbackSessionName, permissionName)) {
+                if (!legacyIsAllowedForPrivilege(
+                        privileges, sectionId.toString(), sessionId.toString(), permissionName)) {
                     return false;
                 }
             }
             return true;
         }).when(mockLogic).hasInstructorPermissionsForSessionInSection(
-                any(Instructor.class), anyString(), anyString(), any());
+                any(Instructor.class), any(UUID.class), any(UUID.class), any());
 
         doAnswer(invocation -> {
             Instructor instructor = invocation.getArgument(0);
-            String sessionName = invocation.getArgument(1);
+            UUID sessionId = invocation.getArgument(1);
             List<String> permissionNames = getStringArguments(invocation, 2);
-            InstructorPrivileges privileges = getEffectivePrivileges(instructor);
+            InstructorPrivilegesLegacy privileges = getEffectiveLegacyPrivileges(instructor);
             for (String permissionName : permissionNames) {
-                if (privileges.isAllowedForPrivilegeAnySection(sessionName, permissionName)) {
+                if (legacyIsAllowedForPrivilegeAnySection(privileges, sessionId.toString(), permissionName)) {
                     return true;
                 }
             }
             return false;
         }).when(mockLogic).hasInstructorPermissionsForSectionInAnySection(
-                any(Instructor.class), anyString(), any());
+                any(Instructor.class), any(UUID.class), any());
 
         doAnswer(invocation -> {
             Instructor instructor = invocation.getArgument(0);
             String permissionName = invocation.getArgument(1);
-            return getEffectivePrivileges(instructor).getSectionsWithPrivilege(permissionName);
+            Map<UUID, teammates.common.datatransfer.InstructorPermissionSet> result = new LinkedHashMap<>();
+            getEffectiveLegacyPrivileges(instructor).getSectionLevelPrivileges().forEach((key, value) -> {
+                if (legacyIsAllowedForPrivilege(getEffectiveLegacyPrivileges(instructor), key, permissionName)) {
+                    try {
+                        result.put(UUID.fromString(key), value);
+                    } catch (IllegalArgumentException e) {
+                        // key is not a UUID string - skip it
+                    }
+                }
+            });
+            return result;
         }).when(mockLogic).getSectionsWithInstructorPermission(any(Instructor.class), anyString());
     }
 
-    private InstructorPrivileges getEffectivePrivileges(Instructor instructor) {
+    /**
+     * Returns the stored {@link InstructorPrivilegesLegacy} for custom-role instructors,
+     * or a role-preset legacy object for predefined roles.
+     */
+    private InstructorPrivilegesLegacy getEffectiveLegacyPrivileges(Instructor instructor) {
         InstructorPermissionRole role = instructor.getRole();
-        if (role == InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM) {
+        if (role == InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM || role == null) {
             return instructor.getPrivileges();
         }
-        if (role == null) {
-            return instructor.getPrivileges();
+        return InstructorPermissionsLogic.inst().legacyPrivilegesForRole(role.getRoleName());
+    }
+
+    // ---------------------------------------------------------------------------
+    // Legacy privilege lookup helpers (inlined from the former InstructorPrivilegesLegacy methods)
+    // ---------------------------------------------------------------------------
+
+    private boolean legacyIsAllowedForPrivilege(InstructorPrivilegesLegacy privileges, String privilegeName) {
+        return privileges.getCourseLevelPrivileges().get(privilegeName);
+    }
+
+    private boolean legacyIsAllowedForPrivilege(
+            InstructorPrivilegesLegacy privileges, String sectionKey, String privilegeName) {
+        Map<String, teammates.common.datatransfer.InstructorPermissionSet> sectionLevel =
+                privileges.getSectionLevelPrivileges();
+        if (!sectionLevel.containsKey(sectionKey)) {
+            return legacyIsAllowedForPrivilege(privileges, privilegeName);
         }
-        return new InstructorPrivileges(role.getRoleName());
+        return sectionLevel.get(sectionKey).get(privilegeName);
+    }
+
+    private boolean legacyIsAllowedForPrivilege(
+            InstructorPrivilegesLegacy privileges, String sectionKey, String sessionKey, String privilegeName) {
+        Map<String, Map<String, teammates.common.datatransfer.InstructorPermissionSet>> sessionLevel =
+                privileges.getSessionLevelPrivileges();
+        if (!sessionLevel.containsKey(sectionKey) || !sessionLevel.get(sectionKey).containsKey(sessionKey)) {
+            return legacyIsAllowedForPrivilege(privileges, sectionKey, privilegeName);
+        }
+        return sessionLevel.get(sectionKey).get(sessionKey).get(privilegeName);
+    }
+
+    private boolean legacyIsAllowedForPrivilegeAnySection(
+            InstructorPrivilegesLegacy privileges, String sessionKey, String privilegeName) {
+        Map<String, teammates.common.datatransfer.InstructorPermissionSet> sectionLevel =
+                privileges.getSectionLevelPrivileges();
+        Map<String, Map<String, teammates.common.datatransfer.InstructorPermissionSet>> sessionLevel =
+                privileges.getSessionLevelPrivileges();
+        Set<String> sections = new LinkedHashSet<>(sessionLevel.keySet());
+        sections.addAll(sectionLevel.keySet());
+        for (String sectionKey : sections) {
+            if (legacyIsAllowedForPrivilege(privileges, sectionKey, sessionKey, privilegeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Converts an {@link InstructorPrivileges} (UUID-keyed) to a {@link InstructorPrivilegesLegacy}
+     * for use in tests, treating each UUID key directly as its string representation.
+     * No DB lookups are performed — this is for unit test setup only.
+     */
+    protected static InstructorPrivilegesLegacy toLegacyForTest(InstructorPrivileges privileges) {
+        teammates.common.datatransfer.InstructorPermissionSet courseLevel =
+                privileges.getCourseLevelPrivileges();
+        Map<String, teammates.common.datatransfer.InstructorPermissionSet> sectionLevel =
+                new LinkedHashMap<>();
+        privileges.getSectionLevelPrivileges().forEach(
+                (uuid, perms) -> sectionLevel.put(uuid.toString(), perms));
+        Map<String, Map<String, teammates.common.datatransfer.InstructorPermissionSet>> sessionLevel =
+                new LinkedHashMap<>();
+        privileges.getSessionLevelPrivileges().forEach((sectionUuid, sessionMap) -> {
+            Map<String, teammates.common.datatransfer.InstructorPermissionSet> sessions = new LinkedHashMap<>();
+            sessionMap.forEach((sessionUuid, perms) -> sessions.put(sessionUuid.toString(), perms));
+            sessionLevel.put(sectionUuid.toString(), sessions);
+        });
+        return new InstructorPrivilegesLegacy(courseLevel, sectionLevel, sessionLevel);
     }
 
     private List<String> getStringArguments(InvocationOnMock invocation, int startIndex) {
@@ -968,7 +1051,6 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             Course thisCourse, String privilege, boolean canAccess, String... params) {
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(privilege, canAccess);
-
         verifySameCourseAccessibility(thisCourse, instructorPrivileges, canAccess, params);
     }
 
@@ -981,7 +1063,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
 
         instructor.setCourse(thisCourse);
         instructor.setPrivileges(
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.COOWNER));
         stubInstructorFromGoogleId(instructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
@@ -990,7 +1072,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         verifyCanAccess(params);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(instructorPrivileges);
+        instructor.setPrivileges(toLegacyForTest(instructorPrivileges));
 
         if (canAccess) {
             verifyCanAccess(params);
@@ -1005,7 +1087,6 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
             Course thisCourse, String privilege, boolean canAccess, String... params) {
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(privilege, canAccess);
-
         verifyDifferentCourseAccessibility(thisCourse, instructorPrivileges, canAccess, params);
     }
 
@@ -1016,7 +1097,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
 
         instructor.setCourse(thisCourse);
         instructor.setPrivileges(
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.COOWNER));
         stubInstructorFromGoogleId(instructor);
         when(mockLogic.getCourse(thisCourse.getId())).thenReturn(thisCourse);
 
@@ -1025,7 +1106,7 @@ public abstract class BaseActionTest<T extends Action> extends BaseTestCase {
         verifyCanAccess(params);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(instructorPrivileges);
+        instructor.setPrivileges(toLegacyForTest(instructorPrivileges));
 
         if (canAccess) {
             verifyCanAccess(params);

--- a/src/test/java/teammates/ui/webapi/BinCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BinCourseActionTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
@@ -72,7 +73,7 @@ public class BinCourseActionTest extends BaseActionTest<BinCourseAction> {
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
 
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -92,7 +93,8 @@ public class BinCourseActionTest extends BaseActionTest<BinCourseAction> {
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, instructorPrivileges);
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM,
+                toLegacyForTest(instructorPrivileges));
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackSessionActionTest.java
@@ -16,11 +16,11 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
@@ -173,7 +173,7 @@ public class CreateFeedbackSessionActionTest extends BaseActionTest<CreateFeedba
         return new Instructor(courseInstructorIsIn, "instructor-1",
                 "instructor-1@tm.tmt", false,
                 "", null,
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.MANAGER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.MANAGER));
     }
 
     private FeedbackSession generateSession1InCourse(Course course, Instructor instructor) {

--- a/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateInstructorActionTest.java
@@ -12,11 +12,11 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.ui.exception.InvalidOperationException;
@@ -60,7 +60,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         String newInstructorRole = Const.InstructorPermissionRoleNames.COOWNER;
         Instructor newInstructor = new Instructor(typicalCourse, newInstructorName, newInstructorEmail,
                 false, null, getEnum(newInstructorRole),
-                new InstructorPrivileges(newInstructorRole));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(newInstructorRole));
 
         InstructorCreateRequest requestBody = new InstructorCreateRequest(newInstructorName, newInstructorEmail,
                 newInstructorRole, null, false, null);
@@ -155,7 +155,7 @@ public class CreateInstructorActionTest extends BaseActionTest<CreateInstructorA
         String newInstructorRole = Const.InstructorPermissionRoleNames.COOWNER;
         Instructor newInstructor = new Instructor(typicalCourse, newInstructorName, newInstructorEmail,
                 false, null, getEnum(newInstructorRole),
-                new InstructorPrivileges(newInstructorRole));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(newInstructorRole));
 
         InstructorCreateRequest requestBody = new InstructorCreateRequest(newInstructorName, newInstructorEmail,
                 newInstructorRole, null, false, null);

--- a/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionTest.java
@@ -20,13 +20,14 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
 import teammates.common.datatransfer.questions.FeedbackContributionQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackContributionResponseDetails;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
@@ -418,7 +419,7 @@ public class CreateResponseInstructorCommentActionTest extends BaseActionTest<Cr
     void testAccessControl_instructorWithoutSubmitSessionInSectionsPrivilege_cannotAccess() {
         Instructor instructorWithoutAccess = getTypicalInstructor();
         instructorWithoutAccess.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutAccess.setPrivileges(new InstructorPrivileges(OBSERVER));
+        instructorWithoutAccess.setPrivileges(InstructorPermissionsLogic.inst().legacyPrivilegesForRole(OBSERVER));
 
         String[] params = new String[] { Const.ParamsNames.FEEDBACK_RESPONSE_ID,
                 typicalFeedbackResponse.getId().toString(),
@@ -438,11 +439,9 @@ public class CreateResponseInstructorCommentActionTest extends BaseActionTest<Cr
     void testAccessControl_instructorWithOnlyEitherPrivilege_cannotAccessCrossSectionComment() {
         Instructor instructorWithoutPrivilege = getTypicalInstructor();
         instructorWithoutPrivilege.setEmail("instructorWithPrivilege@teammates.tmt");
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("Section B",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        // Custom instructor with no privileges — real GateKeeper path falls back to course-level (false)
         instructorWithoutPrivilege.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutPrivilege.setPrivileges(privileges);
+        instructorWithoutPrivilege.setPrivileges(new InstructorPrivilegesLegacy());
 
         String[] params = new String[] { Const.ParamsNames.FEEDBACK_RESPONSE_ID,
                 typicalFeedbackResponse.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/DeleteAccountActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteAccountActionTest.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.Provider;
 import teammates.common.util.Const;
 import teammates.storage.entity.Account;
@@ -53,7 +53,7 @@ public class DeleteAccountActionTest extends BaseActionTest<DeleteAccountAction>
         Account stubAccount = new Account(googleId, Provider.TEAMMATES_DEV, "validInstructorSubject",
                 "validTenantId", "name", "instructoremail@tm.tmt");
         Instructor instructor = new Instructor(stubCourse, "name", "instructoremail@tm.tmt",
-                false, "", null, new InstructorPrivileges());
+                false, "", null, new InstructorPrivilegesLegacy());
         instructor.setAccount(stubAccount);
         when(mockLogic.getAccount(accountId)).thenReturn(stubAccount);
         String[] params = {

--- a/src/test/java/teammates/ui/webapi/DeleteCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteCourseActionTest.java
@@ -7,6 +7,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
 import teammates.common.util.Const.InstructorPermissions;
 import teammates.storage.entity.Course;
@@ -89,7 +90,7 @@ public class DeleteCourseActionTest extends BaseActionTest<DeleteCourseAction> {
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
 
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -109,7 +110,8 @@ public class DeleteCourseActionTest extends BaseActionTest<DeleteCourseAction> {
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_COURSE, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, instructorPrivileges);
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM,
+                toLegacyForTest(instructorPrivileges));
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);

--- a/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionTest.java
@@ -14,9 +14,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
@@ -104,7 +105,7 @@ public class DeleteResponseInstructorCommentActionTest extends BaseActionTest<De
         Instructor instructorWithoutAccess = getTypicalInstructor();
         instructorWithoutAccess.setEmail("helper@teammates.tmt");
         instructorWithoutAccess.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutAccess.setPrivileges(new InstructorPrivileges(CUSTOM));
+        instructorWithoutAccess.setPrivileges(InstructorPermissionsLogic.inst().legacyPrivilegesForRole(CUSTOM));
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalResponseInstructorComment.getId().toString(),
@@ -233,11 +234,9 @@ public class DeleteResponseInstructorCommentActionTest extends BaseActionTest<De
         Instructor instructorWithoutPrivilege = getTypicalInstructor();
         instructorWithoutPrivilege.setEmail("instructorWithoutPrivilege@teammates.tmt");
 
-        InstructorPrivileges privileges = new InstructorPrivileges();
-        privileges.updatePrivilege("test-section1",
-                Const.InstructorPermissions.CAN_MODIFY_SESSION_COMMENT_IN_SECTIONS, true);
+        // Custom instructor with no privileges — real GateKeeper path falls back to course-level (false)
         instructorWithoutPrivilege.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutPrivilege.setPrivileges(privileges);
+        instructorWithoutPrivilege.setPrivileges(new InstructorPrivilegesLegacy());
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalResponseInstructorComment.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/DeleteStudentsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/DeleteStudentsActionTest.java
@@ -103,7 +103,7 @@ public class DeleteStudentsActionTest extends BaseActionTest<DeleteStudentsActio
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(instructorPrivileges);
+        instructor.setPrivileges(toLegacyForTest(instructorPrivileges));
 
         loginAsInstructor(instructorId);
 

--- a/src/test/java/teammates/ui/webapi/EnrollStudentsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/EnrollStudentsActionTest.java
@@ -12,7 +12,9 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.EnrollResults;
 import teammates.common.datatransfer.InstructorPermissionRole;
+import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
@@ -54,7 +56,12 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
     public void testExecute_withNewStudent_shouldBeAdded() throws Exception {
         Instructor instructor = getTypicalInstructor();
         // Ensure instructor has the required permissions
-        instructor.getPrivileges().updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
+        // Update the CAN_MODIFY_STUDENT flag while preserving other privileges
+        InstructorPermissionSet courseLevelPerms = instructor.getPrivileges().getCourseLevelPrivileges();
+        courseLevelPerms.setCanModifyStudent(true);
+        instructor.setPrivileges(new InstructorPrivilegesLegacy(courseLevelPerms,
+                instructor.getPrivileges().getSectionLevelPrivileges(),
+                instructor.getPrivileges().getSessionLevelPrivileges()));
         loginAsInstructor(instructor.getGoogleId());
 
         StudentEnrollRequest studentToEnroll = new StudentEnrollRequest("name", "email.com", "team", "section", "");
@@ -103,7 +110,7 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
     @Test
     public void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         loginAsInstructor(instructor.getGoogleId());
@@ -119,7 +126,8 @@ public class EnrollStudentsActionTest extends BaseActionTest<EnrollStudentsActio
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, instructorPrivileges);
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM,
+                toLegacyForTest(instructorPrivileges));
         loginAsInstructor(instructor.getGoogleId());
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructor.getGoogleId())).thenReturn(instructor);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);

--- a/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackResponsesActionTest.java
@@ -2,6 +2,7 @@ package teammates.ui.webapi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -12,16 +13,17 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
@@ -467,8 +469,8 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
 
     @Test
     void testSpecificAccessControl_instructorWithNoPrivileges_cannotAccess() {
-        InstructorPrivileges customInstructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
+        InstructorPrivilegesLegacy customInstructorPrivileges =
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.CUSTOM);
         InstructorPermissionRole customRole = InstructorPermissionRole
                 .getEnum(Const.InstructorPermissionRoleNames.CUSTOM);
         Instructor stubInstructorWithoutPrivileges = new Instructor(stubCourse, "instructor-1-name", "valid1@teammates.tmt",
@@ -602,8 +604,8 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         };
         GetFeedbackResponsesAction action1 = getAction(params1);
         UnauthorizedAccessException uae1 = assertThrows(UnauthorizedAccessException.class, action1::checkAccessControl);
-        assertEquals("Instructor does not have privilege [canmodifysessioncommentinsection] on section [test-section]",
-                uae1.getMessage());
+        // Section is now identified by UUID; only check the privilege name in the message
+        assertTrue(uae1.getMessage().contains("canmodifysessioncommentinsection"));
 
         FeedbackQuestion questionThatCannotBeModerated = getTypicalFeedbackQuestionForSession(stubFeedbackSession);
         stubFeedbackSession.setSessionVisibleFromTime(Instant.now());
@@ -821,13 +823,15 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
         verifyCanAccess(params);
     }
 
-    private @NotNull Instructor getInstructorWithLimitedPrivileges(String privilege) {
+    private Instructor getInstructorWithLimitedPrivileges(String privilege) {
         InstructorPermissionRole customRole = InstructorPermissionRole
                 .getEnum(Const.InstructorPermissionRoleNames.CUSTOM);
-        InstructorPrivileges submitSessionPrivilegesOnly =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
-        submitSessionPrivilegesOnly.updatePrivilege(stubFeedbackSession.getName(), privilege, true);
+        // Use course-level privilege so the real InstructorPermissionsLogic.convertLegacyToNew
+        // has no section entries to look up in the DB, while the mock stubs still work via courseLevel.
+        InstructorPrivileges runtimePrivileges = new InstructorPrivileges();
+        runtimePrivileges.updatePrivilege(privilege, true);
         return new Instructor(stubCourse, "instructor-2-name", "valid2@teammates.tmt",
-                false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, customRole, submitSessionPrivilegesOnly);
+                false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, customRole,
+                toLegacyForTest(runtimePrivileges));
     }
 }

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionTest.java
@@ -13,6 +13,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.datatransfer.logs.FeedbackSessionLogType;
 import teammates.common.util.Const;
 import teammates.storage.entity.Course;
@@ -301,7 +302,7 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
     void testSpecificAccessControl_instructorWithInvalidPermission_cannotAccess() {
 
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -321,7 +322,8 @@ public class GetFeedbackSessionLogsActionTest extends BaseActionTest<GetFeedback
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, instructorPrivileges);
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM,
+                toLegacyForTest(instructorPrivileges));
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionsActionTest.java
@@ -14,9 +14,9 @@ import java.util.stream.Collectors;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.Provider;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
@@ -303,7 +303,7 @@ public class GetFeedbackSessionsActionTest extends BaseActionTest<GetFeedbackSes
 
     private Instructor generateInstructor1InCourse(Course course) {
         Instructor instructor = new Instructor(course, "name", "email@tm.tmt", false, "", null,
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.COOWNER));
         String subject = "validInstructorSubject";
         String tenantId = "validTenantId";
         instructor.setAccount(new Account(

--- a/src/test/java/teammates/ui/webapi/GetInstructorsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetInstructorsActionTest.java
@@ -17,7 +17,9 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
@@ -58,16 +60,15 @@ public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsActio
 
         InstructorPermissionRole customRole = InstructorPermissionRole
                 .getEnum(Const.InstructorPermissionRoleNames.CUSTOM);
-        InstructorPrivileges customInstructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
+        InstructorPrivilegesLegacy customInstructorPrivileges =
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.CUSTOM);
         stubInstructorWithoutPermission = new Instructor(stubCourse, "instructor-1-name", "valid1@teammates.tmt",
                 false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR, customRole, customInstructorPrivileges);
-        InstructorPrivileges modifyInstructorPrivilegeOnly =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
+        InstructorPrivileges modifyInstructorPrivilegeOnly = new InstructorPrivileges();
         modifyInstructorPrivilegeOnly.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
         stubInstructorWithOnlyModifyInstructorPrivilege = new Instructor(stubCourse, "instructor-2-name",
                 "valid2@teammates.tmt", false, Const.DEFAULT_DISPLAY_NAME_FOR_INSTRUCTOR,
-                customRole, modifyInstructorPrivilegeOnly);
+                customRole, toLegacyForTest(modifyInstructorPrivilegeOnly));
 
         stubInstructorWithPermission.setAccount(stubAccount1);
         stubInstructorWithoutPermission.setAccount(stubAccount2);

--- a/src/test/java/teammates/ui/webapi/GetOngoingSessionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetOngoingSessionsActionTest.java
@@ -15,10 +15,10 @@ import java.util.Map;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.Provider;
 import teammates.common.util.Const;
 import teammates.common.util.Const.InstructorPermissionRoleNames;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
@@ -163,7 +163,7 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                         "instructor2", "test2@test.com");
         Instructor instructor2 = new Instructor(course1, "instructor2", "test2@test.com", false, "instructor2",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(InstructorPermissionRoleNames.COOWNER));
         instructor2.setAccount(instructor2Account);
         when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
         Account instructor3Account = new Account(
@@ -171,7 +171,7 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                         "instructor3", "test3@test.com");
         Instructor instructor3 = new Instructor(course2, "instructor3", "test3@test.com", false, "instructor3",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(InstructorPermissionRoleNames.COOWNER));
         instructor3.setAccount(instructor3Account);
         when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
         Account instructor4Account = new Account(
@@ -179,7 +179,7 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                         "instructor4", "test4@test.com");
         Instructor instructor4 = new Instructor(course3, "instructor4", "test4@test.com", false, "instructor4",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(InstructorPermissionRoleNames.COOWNER));
         instructor4.setAccount(instructor4Account);
         when(mockLogic.getInstructorsByCourse(course3.getId())).thenReturn(Collections.singletonList(instructor4));
         FeedbackSession c1Fs2 = new FeedbackSession("name1-2", null, "test-instruction",
@@ -251,7 +251,7 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                         "instructor2", "test2@test.com");
         Instructor instructor2 = new Instructor(course1, "instructor2", "test2@test.com", false, "instructor2",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(InstructorPermissionRoleNames.COOWNER));
         instructor2.setAccount(instructor2Account);
         when(mockLogic.getInstructorsByCourse(course1.getId())).thenReturn(Collections.singletonList(instructor2));
         Account instructor3Account = new Account(
@@ -259,7 +259,7 @@ public class GetOngoingSessionsActionTest extends BaseActionTest<GetOngoingSessi
                         "instructor3", "test3@test.com");
         Instructor instructor3 = new Instructor(course2, "instructor3", "test3@test.com", false, "instructor3",
                 InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
-                new InstructorPrivileges(InstructorPermissionRoleNames.COOWNER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(InstructorPermissionRoleNames.COOWNER));
         instructor3.setAccount(instructor3Account);
         when(mockLogic.getInstructorsByCourse(course2.getId())).thenReturn(Collections.singletonList(instructor3));
         FeedbackSession c1Fs2 = new FeedbackSession("name1-2", null, "test-instruction",

--- a/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentsActionTest.java
@@ -10,13 +10,16 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Section;
@@ -41,6 +44,8 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
     private List<Student> stubStudentListAll;
     private List<Student> stubStudentListSectionTwo;
     private InstructorPrivileges sectionPrivilegesOnly;
+    private String stubSectionOneId;
+    private String stubSectionTwoId;
 
     @Override
     protected String getActionUri() {
@@ -61,46 +66,10 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
         // Instructor with co-owner privileges (course and section privileges)
         stubInstructorWithAllPrivileges = getTypicalInstructor();
 
-        // Instructor without any privileges
-        InstructorPrivileges customInstructorPrivileges1 =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
-        stubInstructorWithoutPrivileges = getTypicalInstructor();
-        stubInstructorWithoutPrivileges.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        stubInstructorWithoutPrivileges.setPrivileges(customInstructorPrivileges1);
-
-        // Instructor with only privilege to view students in sections they are in
-        sectionPrivilegesOnly =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
-        sectionPrivilegesOnly.updatePrivilege("section-1", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
-        stubInstructorWithOnlyViewSectionPrivileges = getTypicalInstructor();
-        stubInstructorWithOnlyViewSectionPrivileges.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        stubInstructorWithOnlyViewSectionPrivileges.setPrivileges(sectionPrivilegesOnly);
-
-        // Instructor with privilege to view students in sections other than the one the student is in
-        InstructorPrivileges customInstructorPrivileges2 =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
-        customInstructorPrivileges2.updatePrivilege("random-1",
-                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
-        stubInstructorWithOnlyViewPrivilegesForDifferentSection = getTypicalInstructor();
-        stubInstructorWithOnlyViewPrivilegesForDifferentSection.setRole(
-                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        stubInstructorWithOnlyViewPrivilegesForDifferentSection.setPrivileges(customInstructorPrivileges2);
-
-        stubInstructorWithOnlyViewSectionPrivileges.setAccount(getTypicalAccount());
-        stubInstructorWithoutPrivileges.setAccount(getTypicalAccount());
-        stubInstructorWithAllPrivileges.setAccount(getTypicalAccount());
-
-        // Instructor with privilege to view students in sections at course level
-        InstructorPrivileges customInstructorPrivileges3 =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.CUSTOM);
-        customInstructorPrivileges3.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
-        stubInstructorWithCourseLevelPrivilege = getTypicalInstructor();
-        stubInstructorWithCourseLevelPrivilege.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        stubInstructorWithCourseLevelPrivilege.setPrivileges(customInstructorPrivileges3);
-
-        // Section one
+        // Create sections first so we can use their UUIDs as privilege keys
         Section stubSection = new Section("section-1");
         stubCourse.addSection(stubSection);
+        stubSectionOneId = stubSection.getId().toString();
         stubTeamOne = new Team("team-1");
         stubSection.addTeam(stubTeamOne);
         Team stubTeamTwo = new Team("team-2");
@@ -111,9 +80,46 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
         //Section two
         Section stubSectionTwo = new Section("section-2");
         stubCourse.addSection(stubSectionTwo);
+        stubSectionTwoId = stubSectionTwo.getId().toString();
         Team stubTeamThree = new Team("team-3");
         stubSectionTwo.addTeam(stubTeamThree);
         stubStudentListSectionTwo = new ArrayList<>();
+
+        // Instructor without any privileges
+        InstructorPrivilegesLegacy customInstructorPrivileges1 =
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.CUSTOM);
+        stubInstructorWithoutPrivileges = getTypicalInstructor();
+        stubInstructorWithoutPrivileges.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+        stubInstructorWithoutPrivileges.setPrivileges(customInstructorPrivileges1);
+
+        // Instructor with only privilege to view students in section one (UUID key)
+        sectionPrivilegesOnly = new InstructorPrivileges();
+        sectionPrivilegesOnly.updatePrivilege(UUID.fromString(stubSectionOneId),
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        stubInstructorWithOnlyViewSectionPrivileges = getTypicalInstructor();
+        stubInstructorWithOnlyViewSectionPrivileges.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+        stubInstructorWithOnlyViewSectionPrivileges.setPrivileges(toLegacyForTest(sectionPrivilegesOnly));
+
+        // Instructor with privilege in a non-existent section (UUID that no student belongs to)
+        InstructorPrivileges customInstructorPrivileges2 = new InstructorPrivileges();
+        customInstructorPrivileges2.updatePrivilege(UUID.randomUUID(),
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        stubInstructorWithOnlyViewPrivilegesForDifferentSection = getTypicalInstructor();
+        stubInstructorWithOnlyViewPrivilegesForDifferentSection.setRole(
+                InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+        stubInstructorWithOnlyViewPrivilegesForDifferentSection.setPrivileges(
+                toLegacyForTest(customInstructorPrivileges2));
+
+        stubInstructorWithOnlyViewSectionPrivileges.setAccount(getTypicalAccount());
+        stubInstructorWithoutPrivileges.setAccount(getTypicalAccount());
+        stubInstructorWithAllPrivileges.setAccount(getTypicalAccount());
+
+        // Instructor with privilege to view students in sections at course level
+        InstructorPrivileges customInstructorPrivileges3 = new InstructorPrivileges();
+        customInstructorPrivileges3.updatePrivilege(Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        stubInstructorWithCourseLevelPrivilege = getTypicalInstructor();
+        stubInstructorWithCourseLevelPrivilege.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+        stubInstructorWithCourseLevelPrivilege.setPrivileges(toLegacyForTest(customInstructorPrivileges3));
 
         stubStudentListAll = new ArrayList<>();
 
@@ -195,8 +201,11 @@ public class GetStudentsActionTest extends BaseActionTest<GetStudentsAction> {
         // Section two students are not in the StudentsData
         verifyStudentsData(stubStudentListSectionOne, actualStudentsData1, Type.INSTRUCTOR);
 
-        sectionPrivilegesOnly.updatePrivilege("section-1", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
-        sectionPrivilegesOnly.updatePrivilege("section-2", Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        sectionPrivilegesOnly.updatePrivilege(UUID.fromString(stubSectionOneId),
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, false);
+        sectionPrivilegesOnly.updatePrivilege(UUID.fromString(stubSectionTwoId),
+                Const.InstructorPermissions.CAN_VIEW_STUDENT_IN_SECTIONS, true);
+        stubInstructorWithOnlyViewSectionPrivileges.setPrivileges(toLegacyForTest(sectionPrivilegesOnly));
         GetStudentsAction action2 = getAction(params);
         JsonResult jsonResult2 = getJsonResult(action2);
         StudentsData actualStudentsData2 = (StudentsData) jsonResult2.getOutput();

--- a/src/test/java/teammates/ui/webapi/PublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/PublishFeedbackSessionActionTest.java
@@ -14,12 +14,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.EmailWrapper;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
@@ -181,7 +182,7 @@ public class PublishFeedbackSessionActionTest extends BaseActionTest<PublishFeed
 
     @Test
     void testCheckSpecificAccessControl_instructorOfSameCourseWithoutPermission_throwsUnauthorizedAccessException() {
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges(
+        InstructorPrivilegesLegacy instructorPrivileges = InstructorPermissionsLogic.inst().legacyPrivilegesForRole(
                 Const.InstructorPermissionRoleNames.OBSERVER);
         typicalInstructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
         typicalInstructor.setPrivileges(instructorPrivileges);

--- a/src/test/java/teammates/ui/webapi/RemindFeedbackSessionResultActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RemindFeedbackSessionResultActionTest.java
@@ -15,10 +15,10 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.Provider;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
@@ -127,7 +127,7 @@ public class RemindFeedbackSessionResultActionTest extends BaseActionTest<Remind
         return new Instructor(courseInstructorIsIn, "instructor-1",
                 "instructor-1@tm.tmt", false,
                 "", null,
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.MANAGER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.MANAGER));
     }
 
     private Student generateStudent1InCourse(Course courseStudentIsIn) {

--- a/src/test/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionActionTest.java
@@ -16,10 +16,10 @@ import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.Provider;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
@@ -126,7 +126,7 @@ public class RemindFeedbackSessionSubmissionActionTest
         return new Instructor(courseInstructorIsIn, "instructor-1",
                 "instructor-1@tm.tmt", false,
                 "", null,
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.MANAGER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.MANAGER));
     }
 
     private Student generateStudent1InCourse(Course courseStudentIsIn) {

--- a/src/test/java/teammates/ui/webapi/RestoreCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/RestoreCourseActionTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.InstructorPermissions;
@@ -67,7 +68,7 @@ public class RestoreCourseActionTest extends BaseActionTest<RestoreCourseAction>
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
 
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -87,7 +88,8 @@ public class RestoreCourseActionTest extends BaseActionTest<RestoreCourseAction>
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(InstructorPermissions.CAN_MODIFY_COURSE, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, instructorPrivileges);
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM,
+                toLegacyForTest(instructorPrivileges));
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);

--- a/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SendJoinReminderEmailActionTest.java
@@ -126,7 +126,7 @@ public class SendJoinReminderEmailActionTest
         canModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(canModifyStudentPrivileges);
+        instructor.setPrivileges(toLegacyForTest(canModifyStudentPrivileges));
 
         when(mockLogic.getUser(student.getId())).thenReturn(student);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
@@ -144,7 +144,7 @@ public class SendJoinReminderEmailActionTest
         cannotModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(cannotModifyStudentPrivileges);
+        instructor.setPrivileges(toLegacyForTest(cannotModifyStudentPrivileges));
 
         when(mockLogic.getUser(student.getId())).thenReturn(student);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
@@ -162,7 +162,7 @@ public class SendJoinReminderEmailActionTest
         canModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, true);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(canModifyStudentPrivileges);
+        instructor.setPrivileges(toLegacyForTest(canModifyStudentPrivileges));
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
@@ -180,7 +180,7 @@ public class SendJoinReminderEmailActionTest
         cannotModifyStudentPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_STUDENT, false);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(cannotModifyStudentPrivileges);
+        instructor.setPrivileges(toLegacyForTest(cannotModifyStudentPrivileges));
 
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
@@ -198,7 +198,7 @@ public class SendJoinReminderEmailActionTest
         canModifyInstructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, true);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(canModifyInstructorPrivileges);
+        instructor.setPrivileges(toLegacyForTest(canModifyInstructorPrivileges));
 
         when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);
@@ -216,7 +216,7 @@ public class SendJoinReminderEmailActionTest
         cannotModifyInstructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_INSTRUCTOR, false);
 
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructor.setPrivileges(cannotModifyInstructorPrivileges);
+        instructor.setPrivileges(toLegacyForTest(cannotModifyInstructorPrivileges));
 
         when(mockLogic.getUser(instructor.getId())).thenReturn(instructor);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorGoogleId)).thenReturn(instructor);

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -164,13 +164,14 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
                                                         Instructor instructor, boolean value) {
         String courseId = session.getCourseId();
 
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
-        instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, value);
+        InstructorPrivileges runtimePrivileges = new InstructorPrivileges();
+        runtimePrivileges.updatePrivilege(Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, value);
 
         inTransaction(() -> {
             Instructor updatedInstructor = logic.getInstructor(instructor.getId());
             updatedInstructor.getCourse().setId(courseId);
-            updatedInstructor.setPrivileges(instructorPrivileges);
+            teammates.logic.core.InstructorPermissionsLogic.inst()
+                    .saveInstructorPrivileges(updatedInstructor, runtimePrivileges);
             updatedInstructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
 
             logic.updateToEnsureValidityOfInstructorsForTheCourse(updatedInstructor);

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -695,11 +695,10 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
         stubFeedbackSession.setStartTime(Instant.now().minus(Duration.ofDays(1)));
         stubFeedbackSession.setEndTime(Instant.now().plus(Duration.ofDays(1)));
 
-        InstructorPrivileges privileges = new InstructorPrivileges(
-                Const.InstructorPermissionRoleNames.CUSTOM);
+        InstructorPrivileges privileges = new InstructorPrivileges();
         privileges.updatePrivilege(Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS, false);
         stubInstructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        stubInstructor.setPrivileges(privileges);
+        stubInstructor.setPrivileges(toLegacyForTest(privileges));
 
         spyFeedbackQuestion.setGiverType(QuestionGiverType.INSTRUCTORS);
 

--- a/src/test/java/teammates/ui/webapi/UnpublishFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UnpublishFeedbackSessionActionTest.java
@@ -15,12 +15,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidFeedbackSessionStateException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.TaskQueue;
 import teammates.common.util.EmailWrapper;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
@@ -203,7 +204,7 @@ public class UnpublishFeedbackSessionActionTest extends BaseActionTest<Unpublish
 
     @Test
     void testCheckSpecificAccessControl_instructorOfSameCourseWithoutPermission_throwsUnauthorizedAccessException() {
-        InstructorPrivileges instructorPrivileges = new InstructorPrivileges(
+        InstructorPrivilegesLegacy instructorPrivileges = InstructorPermissionsLogic.inst().legacyPrivilegesForRole(
                 Const.InstructorPermissionRoleNames.OBSERVER);
         typicalInstructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
         typicalInstructor.setPrivileges(instructorPrivileges);

--- a/src/test/java/teammates/ui/webapi/UpdateCourseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateCourseActionTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
@@ -112,7 +113,7 @@ public class UpdateCourseActionTest extends BaseActionTest<UpdateCourseAction> {
         Course course = new Course("course-id", "name", Const.DEFAULT_TIME_ZONE, "institute");
 
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivileges());
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, new InstructorPrivilegesLegacy());
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);
@@ -132,7 +133,8 @@ public class UpdateCourseActionTest extends BaseActionTest<UpdateCourseAction> {
         InstructorPrivileges instructorPrivileges = new InstructorPrivileges();
         instructorPrivileges.updatePrivilege(Const.InstructorPermissions.CAN_MODIFY_COURSE, true);
         Instructor instructor = new Instructor(course, "name", "instructoremail@tm.tmt",
-                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM, instructorPrivileges);
+                false, "", InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM,
+                toLegacyForTest(instructorPrivileges));
 
         loginAsInstructor(googleId);
         when(mockLogic.getCourse(course.getId())).thenReturn(course);

--- a/src/test/java/teammates/ui/webapi/UpdateDeadlineExtensionsActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateDeadlineExtensionsActionTest.java
@@ -18,9 +18,9 @@ import java.util.UUID;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.DeadlineExtension;
 import teammates.storage.entity.FeedbackSession;
@@ -122,7 +122,7 @@ public class UpdateDeadlineExtensionsActionTest
         return new Instructor(courseInstructorIsIn, "instructor-1",
                 "instructor-1@tm.tmt", false,
                 "", null,
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.MANAGER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.MANAGER));
     }
 
     private FeedbackSession generateSession1InCourse(Course course, Instructor instructor) {

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackQuestionActionTest.java
@@ -14,7 +14,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
 import teammates.common.datatransfer.participanttypes.ViewerType;
@@ -24,6 +23,7 @@ import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
@@ -233,7 +233,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         // create instructor without modify session privilege
         Instructor instructorWithoutAccess = getTypicalInstructor();
         instructorWithoutAccess.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutAccess.setPrivileges(new InstructorPrivileges(OBSERVER));
+        instructorWithoutAccess.setPrivileges(InstructorPermissionsLogic.inst().legacyPrivilegesForRole(OBSERVER));
 
         when(mockLogic.getFeedbackQuestion(typicalFeedbackQuestion.getId())).thenReturn(typicalFeedbackQuestion);
         when(mockLogic.getFeedbackSession(typicalFeedbackQuestion.getFeedbackSession().getName(),

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackSessionActionTest.java
@@ -19,6 +19,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelperExtension;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
@@ -200,7 +201,7 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
         return new Instructor(courseInstructorIsIn, "instructor-1",
                 "instructor-1@tm.tmt", false,
                 "", null,
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.MANAGER));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.MANAGER));
     }
 
     private FeedbackSession generateSession1InCourse(Course course, Instructor inst) {

--- a/src/test/java/teammates/ui/webapi/UpdateInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateInstructorActionTest.java
@@ -13,10 +13,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.exception.InstructorUpdateException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -59,7 +59,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         String updatedInstructorRole = Const.InstructorPermissionRoleNames.COOWNER;
         Instructor updatedInstructor = new Instructor(typicalCourse, updatedInstructorName, updatedInstructorEmail,
                 false, null, getEnum(updatedInstructorRole),
-                new InstructorPrivileges(updatedInstructorRole));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(updatedInstructorRole));
 
         InstructorUpdateRequest requestBody = new InstructorUpdateRequest(typicalInstructorToUpdate.getId(),
                 updatedInstructorName,
@@ -134,7 +134,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         String updatedInstructorRole = Const.InstructorPermissionRoleNames.COOWNER;
         Instructor updatedInstructor = new Instructor(typicalCourse, updatedInstructorName, updatedInstructorEmail,
                 false, null, getEnum(updatedInstructorRole),
-                new InstructorPrivileges(updatedInstructorRole));
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(updatedInstructorRole));
 
         InstructorUpdateRequest requestBody = new InstructorUpdateRequest(typicalInstructorToUpdate.getId(),
                 updatedInstructorName,
@@ -250,7 +250,7 @@ public class UpdateInstructorActionTest extends BaseActionTest<UpdateInstructorA
         instructorWithoutCorrectPrivilege.setGoogleId("no privilege");
         instructorWithoutCorrectPrivilege.setEmail("helper@teammates.tmt");
         instructorWithoutCorrectPrivilege.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutCorrectPrivilege.setPrivileges(new InstructorPrivileges(CUSTOM));
+        instructorWithoutCorrectPrivilege.setPrivileges(InstructorPermissionsLogic.inst().legacyPrivilegesForRole(CUSTOM));
 
         InstructorUpdateRequest requestBody = new InstructorUpdateRequest(typicalInstructorToUpdate.getId(),
                 typicalInstructorToUpdate.getName(), typicalInstructorToUpdate.getEmail(),

--- a/src/test/java/teammates/ui/webapi/UpdateResponseInstructorCommentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateResponseInstructorCommentActionTest.java
@@ -16,9 +16,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.participanttypes.ViewerType;
 import teammates.common.util.Const;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
@@ -248,7 +248,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         Instructor instructorWithPrivileges = getTypicalInstructor();
         instructorWithPrivileges.setEmail("helper@teammates.tmt");
         instructorWithPrivileges.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithPrivileges.setPrivileges(new InstructorPrivileges(COOWNER));
+        instructorWithPrivileges.setPrivileges(InstructorPermissionsLogic.inst().legacyPrivilegesForRole(COOWNER));
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalComment.getId().toString(),
@@ -269,7 +269,7 @@ public class UpdateResponseInstructorCommentActionTest extends BaseActionTest<Up
         Instructor instructorWithoutPrivileges = getTypicalInstructor();
         instructorWithoutPrivileges.setEmail("helper@teammates.tmt");
         instructorWithoutPrivileges.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
-        instructorWithoutPrivileges.setPrivileges(new InstructorPrivileges(CUSTOM));
+        instructorWithoutPrivileges.setPrivileges(InstructorPermissionsLogic.inst().legacyPrivilegesForRole(CUSTOM));
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, typicalComment.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionTest.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.InstructorPermissionRole;
-import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesLegacy;
 import teammates.common.exception.EnrollException;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -26,6 +26,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
+import teammates.logic.core.InstructorPermissionsLogic;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Section;
@@ -232,8 +233,8 @@ public class UpdateStudentActionTest extends BaseActionTest<UpdateStudentAction>
         String instructorId = "instructor-googleId";
         // Instructor with observer role cannot modify student
         Instructor instructor = getTypicalInstructor();
-        InstructorPrivileges instructorPrivileges =
-                new InstructorPrivileges(Const.InstructorPermissionRoleNames.OBSERVER);
+        InstructorPrivilegesLegacy instructorPrivileges =
+                InstructorPermissionsLogic.inst().legacyPrivilegesForRole(Const.InstructorPermissionRoleNames.OBSERVER);
         instructor.setRole(InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
         instructor.setPrivileges(instructorPrivileges);
         when(mockLogic.getInstructorByGoogleId(course.getId(), instructorId)).thenReturn(instructor);

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
@@ -112,9 +112,12 @@
                   <label>
                     <input
                       type="checkbox"
-                      [ngModel]="sectionLevel.sections.map(s => s.id).includes(section.id)"
+                      [ngModel]="sectionLevel.sections.map((s) => s.id).includes(section.id)"
                       (ngModelChange)="editSectionToSectionLevelPermission(i, section.id, $event)"
-                      [disabled]="!sectionLevel.sections.map(s => s.id).includes(section.id) && hasSectionLevelPermission(section.id)"
+                      [disabled]="
+                        !sectionLevel.sections.map((s) => s.id).includes(section.id) &&
+                        hasSectionLevelPermission(section.id)
+                      "
                     />
                     {{ section.name === 'None' ? 'Students not in a section' : section.name }}
                   </label>

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.html
@@ -107,16 +107,16 @@
           </div>
           <div class="col-6 col-sm-9">
             <div id="custom-sections" class="row">
-              @for (section of this.allSections; track section) {
+              @for (section of this.allSections; track section.id) {
                 <div class="col">
                   <label>
                     <input
                       type="checkbox"
-                      [ngModel]="sectionLevel.sectionNames.includes(section)"
-                      (ngModelChange)="editSectionToSectionLevelPermission(i, section, $event)"
-                      [disabled]="!sectionLevel.sectionNames.includes(section) && hasSectionLevelPermission(section)"
+                      [ngModel]="sectionLevel.sections.map(s => s.id).includes(section.id)"
+                      (ngModelChange)="editSectionToSectionLevelPermission(i, section.id, $event)"
+                      [disabled]="!sectionLevel.sections.map(s => s.id).includes(section.id) && hasSectionLevelPermission(section.id)"
                     />
-                    {{ section === 'None' ? 'Students not in a section' : section }}
+                    {{ section.name === 'None' ? 'Students not in a section' : section.name }}
                   </label>
                 </div>
               }

--- a/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/custom-privilege-setting-panel/custom-privilege-setting-panel.component.ts
@@ -14,7 +14,7 @@ export interface InstructorOverallPermission {
  * Instructor section-specific permission of a course.
  */
 export interface InstructorSectionLevelPermission {
-  sectionNames: string[];
+  sections: { id: string; name: string }[];
   privilege: InstructorPermissionSet;
 
   sessionLevel: InstructorSessionLevelPermission[];
@@ -24,6 +24,7 @@ export interface InstructorSectionLevelPermission {
  * Instructor session-specific permission of a course.
  */
 export interface InstructorSessionLevelPermission {
+  sessionId: string;
   sessionName: string;
   privilege: InstructorPermissionSet;
 }
@@ -57,17 +58,17 @@ export class CustomPrivilegeSettingPanelComponent {
   permissionChange: EventEmitter<InstructorOverallPermission> = new EventEmitter();
 
   @Input()
-  allSections: string[] = [];
+  allSections: { id: string; name: string }[] = [];
 
   @Input()
-  allSessions: string[] = [];
+  allSessions: { id: string; name: string }[] = [];
 
   /**
-   * Checks whether there is a section level permission for a give section.
+   * Checks whether there is a section level permission for a given section.
    */
-  hasSectionLevelPermission(sectionName: string): boolean {
+  hasSectionLevelPermission(sectionId: string): boolean {
     return this.permission.sectionLevel.some((sectionLevel: InstructorSectionLevelPermission) =>
-      sectionLevel.sectionNames.includes(sectionName),
+      sectionLevel.sections.some((s) => s.id === sectionId),
     );
   }
 
@@ -78,7 +79,7 @@ export class CustomPrivilegeSettingPanelComponent {
     return (
       this.permission.sectionLevel.length >= this.allSections.length ||
       this.permission.sectionLevel
-        .map((section: InstructorSectionLevelPermission) => section.sectionNames.length)
+        .map((section: InstructorSectionLevelPermission) => section.sections.length)
         .reduce((prev: number, curr: number) => prev + curr, 0) >= this.allSections.length
     );
   }
@@ -126,7 +127,7 @@ export class CustomPrivilegeSettingPanelComponent {
   addSectionLevelPermission(): void {
     const permission: InstructorOverallPermission = this.deepCopy(this.permission);
     permission.sectionLevel.push({
-      sectionNames: [],
+      sections: [],
       privilege: {
         canModifyCourse: false,
         canModifySession: false,
@@ -149,8 +150,9 @@ export class CustomPrivilegeSettingPanelComponent {
    */
   addSessionLevelPermission(index: number): void {
     const permission: InstructorOverallPermission = this.deepCopy(this.permission);
-    permission.sectionLevel[index].sessionLevel = this.allSessions.map((name: string) => ({
-      sessionName: name,
+    permission.sectionLevel[index].sessionLevel = this.allSessions.map((session: { id: string; name: string }) => ({
+      sessionId: session.id,
+      sessionName: session.name,
       privilege: {
         canModifyCourse: false,
         canModifySession: false,
@@ -169,15 +171,20 @@ export class CustomPrivilegeSettingPanelComponent {
   /**
    * Edits section to section level permission at index.
    */
-  editSectionToSectionLevelPermission(index: number, sectionName: string, isAdding: boolean): void {
+  editSectionToSectionLevelPermission(index: number, sectionId: string, isAdding: boolean): void {
     const permission: InstructorOverallPermission = this.deepCopy(this.permission);
-    const sectionNames: Set<string> = new Set(permission.sectionLevel[index].sectionNames);
-    if (isAdding) {
-      sectionNames.add(sectionName);
-    } else {
-      sectionNames.delete(sectionName);
+    const section = this.allSections.find((s) => s.id === sectionId);
+    if (!section) {
+      return;
     }
-    permission.sectionLevel[index].sectionNames = Array.from(sectionNames);
+    const sections = permission.sectionLevel[index].sections;
+    if (isAdding) {
+      if (!sections.some((s) => s.id === sectionId)) {
+        sections.push(section);
+      }
+    } else {
+      permission.sectionLevel[index].sections = sections.filter((s) => s.id !== sectionId);
+    }
 
     this.permissionChange.emit(permission);
   }

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.ts
@@ -123,8 +123,8 @@ export class InstructorCourseEditPageComponent implements OnInit {
   resetCourseFormEvent: EventEmitter<void> = new EventEmitter();
 
   // for fine-grain permission setting
-  allSections: string[] = [];
-  allSessions: string[] = [];
+  allSections: { id: string; name: string }[] = [];
+  allSessions: { id: string; name: string }[] = [];
 
   isCourseLoading = false;
   hasCourseLoadingFailed = false;
@@ -154,10 +154,13 @@ export class InstructorCourseEditPageComponent implements OnInit {
         const students: Students = vals[0];
         const sessions: FeedbackSessions = vals[1];
 
-        this.allSections = Array.from(new Set(students.students.map((value: Student) => value.sectionName)));
-        this.allSessions = sessions.feedbackSessions.map(
-          (sessionView: FeedbackSessionView) => sessionView.feedbackSession.feedbackSessionName,
-        );
+        this.allSections = Array.from(
+          new Map(students.students.map((s: Student) => [s.sectionId, s.sectionName])).entries(),
+        ).map(([id, name]) => ({ id, name }));
+        this.allSessions = sessions.feedbackSessions.map((sv: FeedbackSessionView) => ({
+          id: sv.feedbackSession.feedbackSessionId,
+          name: sv.feedbackSession.feedbackSessionName,
+        }));
 
         this.loadCourseInstructors();
       });
@@ -608,17 +611,18 @@ export class InstructorCourseEditPageComponent implements OnInit {
       .subscribe((resp: InstructorPrivilege) => {
         permission.privilege = resp.privileges.courseLevel;
 
-        this.allSections.forEach((sectionName: string) => {
+        this.allSections.forEach((section: { id: string; name: string }) => {
           const sectionLevelPermission: InstructorSectionLevelPermission = {
-            sectionNames: [sectionName],
-            privilege: resp.privileges.sectionLevel[sectionName] || permission.privilege,
+            sections: [section],
+            privilege: resp.privileges.sectionLevel[section.id] || permission.privilege,
             sessionLevel: [],
           };
 
-          this.allSessions.forEach((sessionName: string) => {
+          this.allSessions.forEach((session: { id: string; name: string }) => {
             const sessionLevelPermission: InstructorSessionLevelPermission = {
-              sessionName,
-              privilege: resp.privileges.sessionLevel[sectionName]?.[sessionName] || sectionLevelPermission.privilege,
+              sessionId: session.id,
+              sessionName: session.name,
+              privilege: resp.privileges.sessionLevel[section.id]?.[session.id] || sectionLevelPermission.privilege,
             };
             sectionLevelPermission.sessionLevel.push(sessionLevelPermission);
           });
@@ -697,12 +701,12 @@ export class InstructorCourseEditPageComponent implements OnInit {
       sessionLevel: {},
     };
     permission.sectionLevel.forEach((sectionLevel: InstructorSectionLevelPermission) => {
-      sectionLevel.sectionNames.forEach((sectionName: string) => {
-        privileges.sectionLevel[sectionName] = sectionLevel.privilege;
-        privileges.sessionLevel[sectionName] = {};
+      sectionLevel.sections.forEach((section: { id: string; name: string }) => {
+        privileges.sectionLevel[section.id] = sectionLevel.privilege;
+        privileges.sessionLevel[section.id] = {};
 
         sectionLevel.sessionLevel.forEach((sessionLevel: InstructorSessionLevelPermission) => {
-          privileges.sessionLevel[sectionName][sessionLevel.sessionName] = sessionLevel.privilege;
+          privileges.sessionLevel[section.id][sessionLevel.sessionId] = sessionLevel.privilege;
         });
       });
     });

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-edit-panel/instructor-edit-panel.component.ts
@@ -115,10 +115,10 @@ export class InstructorEditPanelComponent {
   currInstructorCoursePrivilege?: InstructorCoursePermissions;
 
   @Input()
-  allSections: string[] = [];
+  allSections: { id: string; name: string }[] = [];
 
   @Input()
-  allSessions: string[] = [];
+  allSessions: { id: string; name: string }[] = [];
 
   @Input()
   isSavingNewInstructor = false;

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -133,9 +133,9 @@ export class InstructorSearchPageComponent {
         if (!privilege) {
           continue;
         }
-        const sectionName: string = studentModel.student.sectionName;
+        const sectionId: string = studentModel.student.sectionId;
         const courseLevel: InstructorPermissionSet = privilege.privileges.courseLevel;
-        const sectionLevel: InstructorPermissionSet = privilege.privileges.sectionLevel[sectionName] || courseLevel;
+        const sectionLevel: InstructorPermissionSet = privilege.privileges.sectionLevel[sectionId] || courseLevel;
 
         studentModel.isAllowedToViewStudentInSection = sectionLevel.canViewStudentInSections;
         studentModel.isAllowedToModifyStudent = sectionLevel.canModifyStudent;

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.ts
@@ -146,7 +146,7 @@ export class InstructorStudentListPageComponent implements OnInit {
       next: (students: Students) => {
         courseTab.studentList = []; // Reset the list of students for the course
         const sections: StudentIndexedData = students.students.reduce((acc: StudentIndexedData, x: Student) => {
-          const term: string = x.sectionName;
+          const term: string = x.sectionId;
           (acc[term] = acc[term] || []).push(x);
           return acc;
         }, {});
@@ -164,11 +164,11 @@ export class InstructorStudentListPageComponent implements OnInit {
             next: (instructorPrivilege: InstructorPrivilege) => {
               const courseLevelPrivilege: InstructorPermissionSet = instructorPrivilege.privileges.courseLevel;
 
-              Object.keys(sections).forEach((sectionName: string) => {
+              Object.keys(sections).forEach((sectionId: string) => {
                 const sectionLevelPrivilege: InstructorPermissionSet =
-                  instructorPrivilege.privileges.sectionLevel[sectionName] || courseLevelPrivilege;
+                  instructorPrivilege.privileges.sectionLevel[sectionId] || courseLevelPrivilege;
 
-                const studentsInSection: Student[] = sections[sectionName];
+                const studentsInSection: Student[] = sections[sectionId];
                 const studentModels: StudentListRowModel[] = studentsInSection.map((stuInSection: Student) => {
                   return {
                     student: stuInSection,


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Migrate instructor privileges to be keyed by section and session ID instead of name. A compatibility layer (InstructorPrivilegesLegacy) is introduced to support the existing data format. This is a temporary addition that will be removed once we migrate privileges to be SQL entities.