### PR TITLE
[#13721] Use stable ID as response recipient identifier on the frontend

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -255,9 +255,9 @@ public abstract class BaseE2ETestCase extends BaseTestCase {
             FeedbackResponseDetails expectedResponseDetails = expectedFeedbackResponse.getFeedbackResponseDetailsCopy();
             FeedbackResponseData actualResponse = (FeedbackResponseData) actual;
             FeedbackResponseDetails actualResponseDetails = actualResponse.getResponseDetails();
-            assertEquals(expectedFeedbackResponse.getGiver().getIdentifier(),
+            assertEquals(expectedFeedbackResponse.getGiver().getKey(),
                     actualResponse.getGiverIdentifier());
-            assertEquals(expectedFeedbackResponse.getRecipient().getIdentifier(),
+            assertEquals(expectedFeedbackResponse.getRecipient().getKey(),
                     actualResponse.getRecipientIdentifier());
             assertEquals(expectedResponseDetails.getAnswerString(),
                     actualResponse.getResponseDetails().getAnswerString());

--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -23,6 +23,7 @@ import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.storage.entity.ResponseRecipient;
 import teammates.storage.entity.Student;
+import teammates.test.ResponseEntityHelper;
 
 /**
  * SUT: {@link Const.WebPageURIs#SESSION_RESULTS_PAGE}.
@@ -270,20 +271,20 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
                 .toList();
 
         List<FeedbackResponse> selfEvaluationResponses = questionResponses.stream()
-                .filter(fr -> currentStudent.getEmail().equals(fr.getGiver().getIdentifier())
-                        && currentStudent.getEmail().equals(fr.getRecipient().getIdentifier()))
+                .filter(fr -> currentStudent.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getGiver()))
+                        && currentStudent.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getRecipient())))
                 .toList();
 
         List<FeedbackResponse> responsesByOthers = questionResponses.stream()
-                .filter(fr -> !currentStudent.getEmail().equals(fr.getGiver().getIdentifier())
-                        && visibleResponseGivers.contains(fr.getGiver().getIdentifier()))
+                .filter(fr -> !currentStudent.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getGiver()))
+                        && visibleResponseGivers.contains(ResponseEntityHelper.getIdentifier(fr.getGiver())))
                 .toList();
 
         List<FeedbackResponse> responsesToSelf = new ArrayList<>();
         if (visibleResponseGivers.contains("RECEIVER")) {
             responsesToSelf = questionResponses.stream()
-                    .filter(fr -> !currentStudent.getEmail().equals(fr.getGiver().getIdentifier())
-                            && currentStudent.getEmail().equals(fr.getRecipient().getIdentifier()))
+                    .filter(fr -> !currentStudent.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getGiver()))
+                            && currentStudent.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getRecipient())))
                     .toList();
         }
 
@@ -305,20 +306,20 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
                 .toList();
 
         List<FeedbackResponse> selfEvaluationResponses = questionResponses.stream()
-                .filter(fr -> currentInstructor.getEmail().equals(fr.getGiver().getIdentifier())
-                        && currentInstructor.getEmail().equals(fr.getRecipient().getIdentifier()))
+                .filter(fr -> currentInstructor.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getGiver()))
+                        && currentInstructor.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getRecipient())))
                 .toList();
 
         List<FeedbackResponse> responsesByOthers = questionResponses.stream()
-                .filter(fr -> !currentInstructor.getEmail().equals(fr.getGiver().getIdentifier())
-                        && visibleResponseGivers.contains(fr.getGiver().getIdentifier()))
+                .filter(fr -> !currentInstructor.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getGiver()))
+                        && visibleResponseGivers.contains(ResponseEntityHelper.getIdentifier(fr.getGiver())))
                 .toList();
 
         List<FeedbackResponse> responsesToSelf = new ArrayList<>();
         if (visibleResponseGivers.contains("RECEIVER") || visibleResponseGivers.contains("INSTRUCTORS")) {
             responsesToSelf = questionResponses.stream()
-                    .filter(fr -> !currentInstructor.getEmail().equals(fr.getGiver().getIdentifier())
-                            && currentInstructor.getEmail().equals(fr.getRecipient().getIdentifier()))
+                    .filter(fr -> !currentInstructor.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getGiver()))
+                            && currentInstructor.getEmail().equals(ResponseEntityHelper.getIdentifier(fr.getRecipient())))
                     .toList();
         }
 
@@ -421,7 +422,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
             return "";
         }
 
-        return getIdentifier(currentStudent, giver.getIdentifier());
+        return getIdentifier(currentStudent, ResponseEntityHelper.getIdentifier(giver));
     }
 
     private String getIdentifier(Student currentStudent, ResponseRecipient recipient) {
@@ -429,7 +430,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
             return "";
         }
 
-        return getIdentifier(currentStudent, recipient.getIdentifier());
+        return getIdentifier(currentStudent, ResponseEntityHelper.getIdentifier(recipient));
     }
 
     private String getIdentifier(Student currentStudent, String user) {
@@ -474,7 +475,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
             return "";
         }
 
-        return getIdentifier(currentInstructor, giver.getIdentifier());
+        return getIdentifier(currentInstructor, ResponseEntityHelper.getIdentifier(giver));
     }
 
     private String getIdentifier(Instructor currentInstructor, ResponseRecipient recipient) {
@@ -482,7 +483,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
             return "";
         }
 
-        return getIdentifier(currentInstructor, recipient.getIdentifier());
+        return getIdentifier(currentInstructor, ResponseEntityHelper.getIdentifier(recipient));
     }
 
     private String getStudentName(String studentEmail) {

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
@@ -28,6 +28,7 @@ import teammates.storage.entity.ResponseGiver;
 import teammates.storage.entity.ResponseInstructorComment;
 import teammates.storage.entity.ResponseRecipient;
 import teammates.storage.entity.Student;
+import teammates.test.ResponseEntityHelper;
 import teammates.test.ThreadHelper;
 import teammates.ui.output.FeedbackSessionData;
 
@@ -407,7 +408,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
         Set<String> responders = testData.feedbackResponses.values().stream()
                 .filter(r -> r.getFeedbackQuestion().getFeedbackSession().getCourseId().equals(courseId))
                 .map(FeedbackResponse::getGiver)
-                .map(ResponseGiver::getIdentifier)
+                .map(ResponseEntityHelper::getIdentifier)
                 .collect(Collectors.toSet());
 
         return testData.students.values().stream()
@@ -427,9 +428,11 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
     private void sortResponses(List<FeedbackResponse> responses) {
         responses.sort((r1, r2) -> {
             if (r1.getGiver().equals(r2.getGiver())) {
-                return r1.getRecipient().getIdentifier().compareTo(r2.getRecipient().getIdentifier());
+                return ResponseEntityHelper.getIdentifier(r1.getRecipient())
+                        .compareTo(ResponseEntityHelper.getIdentifier(r2.getRecipient()));
             }
-            return r1.getGiver().getIdentifier().compareTo(r2.getGiver().getIdentifier());
+            return ResponseEntityHelper.getIdentifier(r1.getGiver())
+                    .compareTo(ResponseEntityHelper.getIdentifier(r2.getGiver()));
         });
     }
 
@@ -585,8 +588,8 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
             Map<String, List<FeedbackResponse>> recipientToResponse = new HashMap<>();
             Map<String, List<FeedbackResponse>> giverToResponse = new HashMap<>();
             for (FeedbackResponse response : responses) {
-                String recipient = response.getRecipient().getIdentifier();
-                String giver = response.getGiver().getIdentifier();
+                String recipient = ResponseEntityHelper.getIdentifier(response.getRecipient());
+                String giver = ResponseEntityHelper.getIdentifier(response.getGiver());
                 recipientToResponse.computeIfAbsent(recipient, k -> new ArrayList<>()).add(response);
                 giverToResponse.computeIfAbsent(giver, k -> new ArrayList<>()).add(response);
             }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -3,6 +3,7 @@ package teammates.e2e.pageobjects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static teammates.test.ResponseEntityHelper.getIdentifier;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -189,7 +190,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(GRQ_VIEW);
 
         // all responses should be from the same giver
-        String giver = responses.get(0).getGiver().getIdentifier();
+        String giver = getIdentifier(responses.get(0).getGiver());
         QuestionGiverType giverType = question.getGiverType();
         WebElement giverPanel = getUserPanel(giverType, giver, instructors, students, isGroupedByTeam, true);
 
@@ -210,7 +211,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(RGQ_VIEW);
 
         // all responses should have the same recipient
-        String recipient = responses.get(0).getRecipient().getIdentifier();
+        String recipient = getIdentifier(responses.get(0).getRecipient());
         QuestionRecipientType recipientType = question.getRecipientType();
         WebElement recipientPanel = getUserPanel(recipientType, recipient, instructors, students, isGroupedByTeam, false);
 
@@ -231,7 +232,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(GQR_VIEW);
 
         // all responses should be from the same giver
-        String giver = responses.get(0).getGiver().getIdentifier();
+        String giver = getIdentifier(responses.get(0).getGiver());
         QuestionGiverType giverType = question.getGiverType();
         WebElement giverPanel = getUserPanel(giverType, giver, instructors, students, isGroupedByTeam, true);
 
@@ -246,9 +247,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
             for (FeedbackResponse response : responses) {
                 String[] expectedResponses = getExpectedGqrDetails(question, response, instructors, students);
                 String recipientTeam =
-                        getTeam(question.getRecipientType(), response.getRecipient().getIdentifier(), students);
+                        getTeam(question.getRecipientType(), getIdentifier(response.getRecipient()), students);
                 String recipientNameAndEmail = getNameAndEmail(question.getRecipientType(),
-                        response.getRecipient().getIdentifier(), instructors, students);
+                        getIdentifier(response.getRecipient()), instructors, students);
                 verifyTableRowValues(getResponseRow(questionPanel, recipientTeam, recipientNameAndEmail),
                         expectedResponses);
             }
@@ -261,7 +262,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(RQG_VIEW);
 
         // all responses should be from the same recipient
-        String recipient = responses.get(0).getRecipient().getIdentifier();
+        String recipient = getIdentifier(responses.get(0).getRecipient());
         QuestionRecipientType recipientType = question.getRecipientType();
         WebElement recipientPanel = getUserPanel(recipientType, recipient, instructors, students, isGroupedByTeam, false);
 
@@ -275,9 +276,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
         } else {
             for (FeedbackResponse response : responses) {
                 String[] expectedResponses = getExpectedRqgDetails(question, response, instructors, students);
-                String giverTeam = getTeam(question.getGiverType(), response.getGiver().getIdentifier(), students);
+                String giverTeam = getTeam(question.getGiverType(), getIdentifier(response.getGiver()), students);
                 String giverNameAndEmail = getNameAndEmail(question.getGiverType(),
-                        response.getGiver().getIdentifier(), instructors, students);
+                        getIdentifier(response.getGiver()), instructors, students);
                 verifyTableRowValues(getResponseRow(questionPanel, giverTeam, giverNameAndEmail), expectedResponses);
             }
         }
@@ -333,7 +334,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
                                    Collection<Student> students) {
         selectViewType(GQR_VIEW);
 
-        String giver = responses.get(0).getGiver().getIdentifier();
+        String giver = getIdentifier(responses.get(0).getGiver());
         QuestionGiverType giverType = question.getGiverType();
         verifyUserViewStats(giverType, giver, question, responses, instructors, students, isGroupedByTeam, true);
     }
@@ -345,7 +346,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
                                    Collection<Student> students) {
         selectViewType(RQG_VIEW);
 
-        String recipient = responses.get(0).getRecipient().getIdentifier();
+        String recipient = getIdentifier(responses.get(0).getRecipient());
         QuestionRecipientType recipientType = question.getRecipientType();
         verifyUserViewStats(recipientType, recipient, question, responses, instructors, students, isGroupedByTeam, false);
     }
@@ -543,11 +544,11 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(QUESTION_VIEW);
         WebElement questionPanel = getQuestionPanel(question.getQuestionNumber());
 
-        String giverTeam = getTeam(question.getGiverType(), response.getGiver().getIdentifier(), students);
-        String giverName = getNameAndEmail(question.getGiverType(), response.getGiver().getIdentifier(),
+        String giverTeam = getTeam(question.getGiverType(), getIdentifier(response.getGiver()), students);
+        String giverName = getNameAndEmail(question.getGiverType(), getIdentifier(response.getGiver()),
                 instructors, students);
-        String recipientTeam = getTeam(question.getRecipientType(), response.getRecipient().getIdentifier(), students);
-        String recipientName = getNameAndEmail(question.getRecipientType(), response.getRecipient().getIdentifier(),
+        String recipientTeam = getTeam(question.getRecipientType(), getIdentifier(response.getRecipient()), students);
+        String recipientName = getNameAndEmail(question.getRecipientType(), getIdentifier(response.getRecipient()),
                 instructors,
                 students);
         WebElement responseRow = getResponseRow(questionPanel, giverTeam, giverName, recipientTeam, recipientName);
@@ -562,13 +563,13 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(GQR_VIEW);
 
         QuestionGiverType giverType = question.getGiverType();
-        WebElement giverPanel = getUserPanel(giverType, response.getGiver().getIdentifier(), instructors, students,
+        WebElement giverPanel = getUserPanel(giverType, getIdentifier(response.getGiver()), instructors, students,
                 isGroupedByTeam, true);
 
         WebElement questionPanel = getQuestionPanel(giverPanel, question.getQuestionNumber());
-        String recipientTeam = getTeam(question.getRecipientType(), response.getRecipient().getIdentifier(), students);
+        String recipientTeam = getTeam(question.getRecipientType(), getIdentifier(response.getRecipient()), students);
         String recipientName = getNameAndEmail(question.getRecipientType(),
-                response.getRecipient().getIdentifier(), instructors,
+                getIdentifier(response.getRecipient()), instructors,
                 students);
         WebElement responseRow = getResponseRow(questionPanel, recipientTeam, recipientName);
 
@@ -582,13 +583,13 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(RQG_VIEW);
 
         QuestionRecipientType recipientType = question.getRecipientType();
-        WebElement recipientPanel = getUserPanel(recipientType, response.getRecipient().getIdentifier(), instructors,
+        WebElement recipientPanel = getUserPanel(recipientType, getIdentifier(response.getRecipient()), instructors,
                 students,
                 isGroupedByTeam, false);
 
         WebElement questionPanel = getQuestionPanel(recipientPanel, question.getQuestionNumber());
-        String giverTeam = getTeam(question.getGiverType(), response.getGiver().getIdentifier(), students);
-        String giverNameAndEmail = getNameAndEmail(question.getGiverType(), response.getGiver().getIdentifier(),
+        String giverTeam = getTeam(question.getGiverType(), getIdentifier(response.getGiver()), students);
+        String giverNameAndEmail = getNameAndEmail(question.getGiverType(), getIdentifier(response.getGiver()),
                 instructors, students);
         WebElement responseRow = getResponseRow(questionPanel, giverTeam, giverNameAndEmail);
 
@@ -603,12 +604,12 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(GRQ_VIEW);
 
         QuestionGiverType giverType = question.getGiverType();
-        WebElement userPanel = getUserPanel(giverType, response.getGiver().getIdentifier(), instructors, students,
+        WebElement userPanel = getUserPanel(giverType, getIdentifier(response.getGiver()), instructors, students,
                 isGroupedByTeam, true);
 
         QuestionRecipientType recipientType = question.getRecipientType();
-        String recipientTeam = getTeam(recipientType, response.getRecipient().getIdentifier(), students);
-        String recipientName = getName(recipientType, response.getRecipient().getIdentifier(), instructors, students);
+        String recipientTeam = getTeam(recipientType, getIdentifier(response.getRecipient()), students);
+        String recipientName = getName(recipientType, getIdentifier(response.getRecipient()), instructors, students);
 
         WebElement groupedResponses = getGroupedResponses(userPanel, recipientName, recipientTeam, true);
         verifyGroupedResponseComment(groupedResponses, question.getQuestionNumber(), comment);
@@ -621,12 +622,12 @@ public class InstructorFeedbackResultsPage extends AppPage {
         selectViewType(RGQ_VIEW);
 
         QuestionRecipientType recipientType = question.getRecipientType();
-        WebElement userPanel = getUserPanel(recipientType, response.getRecipient().getIdentifier(), instructors, students,
+        WebElement userPanel = getUserPanel(recipientType, getIdentifier(response.getRecipient()), instructors, students,
                 isGroupedByTeam, false);
 
         QuestionGiverType giverType = question.getGiverType();
-        String giverTeam = getTeam(giverType, response.getGiver().getIdentifier(), students);
-        String giverName = getName(giverType, response.getGiver().getIdentifier(), instructors, students);
+        String giverTeam = getTeam(giverType, getIdentifier(response.getGiver()), students);
+        String giverName = getName(giverType, getIdentifier(response.getGiver()), instructors, students);
 
         WebElement groupedResponses = getGroupedResponses(userPanel, giverName, giverTeam, false);
         verifyGroupedResponseComment(groupedResponses, question.getQuestionNumber(), comment);
@@ -698,14 +699,14 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
         for (int i = 0; i < responses.size(); i++) {
             FeedbackResponse response = responses.get(i);
-            expected[i][0] = getTeam(giverType, response.getGiver().getIdentifier(), students);
-            expected[i][1] = getNameAndEmail(giverType, response.getGiver().getIdentifier(), instructors, students);
+            expected[i][0] = getTeam(giverType, getIdentifier(response.getGiver()), students);
+            expected[i][1] = getNameAndEmail(giverType, getIdentifier(response.getGiver()), instructors, students);
             if (recipientType == QuestionRecipientType.NONE) {
                 expected[i][2] = NO_TEAM_LABEL;
                 expected[i][3] = NO_USER_LABEL;
             } else {
-                expected[i][2] = getTeam(recipientType, response.getRecipient().getIdentifier(), students);
-                expected[i][3] = getNameAndEmail(recipientType, response.getRecipient().getIdentifier(),
+                expected[i][2] = getTeam(recipientType, getIdentifier(response.getRecipient()), students);
+                expected[i][3] = getNameAndEmail(recipientType, getIdentifier(response.getRecipient()),
                     instructors, students);
             }
             if (isMissingResponse(response)) {
@@ -727,8 +728,8 @@ public class InstructorFeedbackResultsPage extends AppPage {
             expected[0] = NO_TEAM_LABEL;
             expected[1] = NO_USER_LABEL;
         } else {
-            expected[0] = getTeam(recipientType, response.getRecipient().getIdentifier(), students);
-            expected[1] = getNameAndEmail(recipientType, response.getRecipient().getIdentifier(), instructors,
+            expected[0] = getTeam(recipientType, getIdentifier(response.getRecipient()), students);
+            expected[1] = getNameAndEmail(recipientType, getIdentifier(response.getRecipient()), instructors,
                     students);
         }
         if (isMissingResponse(response)) {
@@ -746,8 +747,8 @@ public class InstructorFeedbackResultsPage extends AppPage {
         String[] expected = new String[3];
         QuestionGiverType giverType = question.getGiverType();
 
-        expected[0] = getTeam(giverType, response.getGiver().getIdentifier(), students);
-        expected[1] = getNameAndEmail(giverType, response.getGiver().getIdentifier(), instructors, students);
+        expected[0] = getTeam(giverType, getIdentifier(response.getGiver()), students);
+        expected[1] = getNameAndEmail(giverType, getIdentifier(response.getGiver()), instructors, students);
 
         if (isMissingResponse(response)) {
             expected[2] = NO_RESPONSE_LABEL;
@@ -1143,16 +1144,16 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     private List<String> getGivers(List<FeedbackResponse> responses) {
-        return responses.stream().map(response -> response.getGiver().getIdentifier()).toList();
+        return responses.stream().map(response -> getIdentifier(response.getGiver())).toList();
     }
 
     private List<String> getRecipients(List<FeedbackResponse> responses) {
-        return responses.stream().map(response -> response.getRecipient().getIdentifier()).sorted().toList();
+        return responses.stream().map(response -> getIdentifier(response.getRecipient())).sorted().toList();
     }
 
     private FeedbackResponse getResponseFromGiver(List<FeedbackResponse> responses, String giver) {
         return responses.stream()
-                .filter(response -> response.getGiver().getIdentifier().equals(giver))
+                .filter(response -> getIdentifier(response.getGiver()).equals(giver))
                 .findFirst()
                 .orElse(null);
     }
@@ -1160,7 +1161,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     private FeedbackResponse getResponseForRecipient(List<FeedbackResponse> responses,
                                                                String recipient) {
         return responses.stream()
-            .filter(response -> response.getRecipient().getIdentifier().equals(recipient))
+            .filter(response -> getIdentifier(response.getRecipient()).equals(recipient))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
@@ -21,6 +21,7 @@ import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.test.BaseTestCase;
 import teammates.test.FileHelper;
+import teammates.test.ResponseEntityHelper;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -124,13 +125,13 @@ public class TestDataValidityTest extends BaseTestCase {
                 });
 
                 dataBundle.feedbackResponses.forEach((id, response) -> {
-                    String giver = response.getGiver().getIdentifier();
+                    String giver = ResponseEntityHelper.getIdentifier(response.getGiver());
                     if (giver != null && giver.contains("@") && !isValidTestEmail(giver)) {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid response giver email: " + giver);
                     }
 
-                    String recipient = response.getRecipient().getIdentifier();
+                    String recipient = ResponseEntityHelper.getIdentifier(response.getRecipient());
                     if (recipient != null && recipient.contains("@") && !isValidTestEmail(recipient)) {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid response recipient email: " + recipient);

--- a/src/main/java/teammates/common/datatransfer/CourseRoster.java
+++ b/src/main/java/teammates/common/datatransfer/CourseRoster.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,11 +30,11 @@ public class CourseRoster {
     }
 
     public List<Student> getStudents() {
-        return students;
+        return Collections.unmodifiableList(students);
     }
 
     public List<Instructor> getInstructors() {
-        return instructors;
+        return Collections.unmodifiableList(instructors);
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/CourseRoster.java
+++ b/src/main/java/teammates/common/datatransfer/CourseRoster.java
@@ -1,13 +1,14 @@
 package teammates.common.datatransfer;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
-import teammates.common.util.Const;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.Team;
@@ -19,165 +20,39 @@ import teammates.storage.entity.Team;
  */
 public class CourseRoster {
 
-    private final Map<String, Student> emailToStudents = new HashMap<>();
-    private final Map<String, Instructor> emailToInstructors = new HashMap<>();
-    private final Map<String, Team> teamNameToTeam = new HashMap<>();
-    private final Map<String, List<Student>> teamToMembers;
-    private final Map<UUID, Team> teamIdToTeam = new HashMap<>();
+    private final List<Student> students;
+    private final List<Instructor> instructors;
 
     public CourseRoster(List<Student> students, List<Instructor> instructors) {
-        populateStudentList(students);
-        populateInstructorList(instructors);
-        teamToMembers = buildTeamToMembersTable(getStudents());
+        this.students = students == null ? new ArrayList<>() : students;
+        this.instructors = instructors == null ? new ArrayList<>() : instructors;
     }
 
     public List<Student> getStudents() {
-        return new ArrayList<>(emailToStudents.values());
+        return students;
     }
 
     public List<Instructor> getInstructors() {
-        return new ArrayList<>(emailToInstructors.values());
-    }
-
-    public Map<String, List<Student>> getTeamToMembers() {
-        return teamToMembers;
-    }
-
-    public Map<String, Team> getTeamNameToTeam() {
-        return teamNameToTeam;
-    }
-
-    public Map<UUID, Team> getTeamIdToTeam() {
-        return teamIdToTeam;
+        return instructors;
     }
 
     /**
-     * Checks whether a student is in course.
+     * Gets all teams that have at least one student in the course.
      */
-    public boolean isStudentInCourse(String studentEmail) {
-        return emailToStudents.containsKey(normalizeEmail(studentEmail));
-    }
-
-    /**
-     * Checks whether a team is in course.
-     */
-    public boolean isTeamInCourse(String teamName) {
-        return teamToMembers.containsKey(teamName);
-    }
-
-    /**
-     * Returns the student object for the given email.
-     */
-    public Student getStudentForEmail(String email) {
-        return emailToStudents.get(normalizeEmail(email));
-    }
-
-    /**
-     * Returns the instructor object for the given email.
-     */
-    public Instructor getInstructorForEmail(String email) {
-        return emailToInstructors.get(normalizeEmail(email));
-    }
-
-    private void populateStudentList(List<Student> students) {
-        if (students == null) {
-            return;
-        }
-
-        for (Student s : students) {
-            emailToStudents.put(normalizeEmail(s.getEmail()), s);
-            teamIdToTeam.put(s.getTeamId(), s.getTeam());
-            teamNameToTeam.put(s.getTeamName(), s.getTeam());
-        }
-    }
-
-    private void populateInstructorList(List<Instructor> instructors) {
-        if (instructors == null) {
-            return;
-        }
-
-        for (Instructor i : instructors) {
-            emailToInstructors.put(normalizeEmail(i.getEmail()), i);
-        }
-    }
-
-    private static String normalizeEmail(String email) {
-        return email == null ? null : email.toLowerCase(Locale.ROOT);
-    }
-
-    /**
-     * Builds a Map from team name to team members.
-     */
-    public static Map<String, List<Student>> buildTeamToMembersTable(List<Student> students) {
-        Map<String, List<Student>> teamToMembersTable = new HashMap<>();
-        // group students by team
+    public Collection<Team> getTeams() {
+        Map<UUID, Team> teams = new LinkedHashMap<>();
         for (Student student : students) {
-            teamToMembersTable.computeIfAbsent(student.getTeamName(), key -> new ArrayList<>())
-                    .add(student);
+            teams.putIfAbsent(student.getTeamId(), student.getTeam());
         }
-        return teamToMembersTable;
+        return teams.values();
     }
 
     /**
-     * Gets info of a participant associated with an identifier in the course.
-     *
-     * @return an object {@link ParticipantInfo} containing the name, teamName and the sectionName.
+     * Gets the students belonging to the team with the given ID.
      */
-    public ParticipantInfo getInfoForIdentifier(String identifier) {
-        String name = Const.USER_NOBODY_TEXT;
-        String teamName = Const.USER_NOBODY_TEXT;
-        String sectionName = Const.DEFAULT_SECTION;
-
-        boolean isStudent = getStudentForEmail(identifier) != null;
-        boolean isInstructor = getInstructorForEmail(identifier) != null;
-        boolean isTeam = getTeamToMembers().containsKey(identifier);
-        if (isStudent) {
-            Student student = getStudentForEmail(identifier);
-
-            name = student.getName();
-            teamName = student.getTeamName();
-            sectionName = student.getSectionName();
-        } else if (isInstructor) {
-            Instructor instructor = getInstructorForEmail(identifier);
-
-            name = instructor.getName();
-            teamName = Const.USER_TEAM_FOR_INSTRUCTOR;
-        } else if (isTeam) {
-            Student teamMember = getTeamToMembers().get(identifier).iterator().next();
-
-            name = identifier;
-            teamName = identifier;
-            sectionName = teamMember.getSectionName();
-        }
-
-        return new ParticipantInfo(name, teamName, sectionName);
-    }
-
-    /**
-     * Simple data transfer object containing the information of a participant.
-     */
-    public static final class ParticipantInfo {
-
-        private final String name;
-        private final String teamName;
-        private final String sectionName;
-
-        private ParticipantInfo(String name, String teamName, String sectionName) {
-            this.name = name;
-            this.teamName = teamName;
-            this.sectionName = sectionName;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getTeamName() {
-            return teamName;
-        }
-
-        public String getSectionName() {
-            return sectionName;
-        }
+    public List<Student> getTeamMembers(UUID teamId) {
+        return students.stream()
+                .filter(student -> Objects.equals(student.getTeamId(), teamId))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -80,18 +81,27 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
 
         boolean isStudent = studentEmail != null;
 
+        // Build team-name based views from the roster's student list (the contribution computation
+        // and its output are keyed by email/team name).
+        Map<String, List<Student>> teamNameToMembers = new LinkedHashMap<>();
+        Map<String, String> emailToTeamName = new HashMap<>();
+        for (Student student : bundle.getRoster().getStudents()) {
+            teamNameToMembers.computeIfAbsent(student.getTeamName(), key -> new ArrayList<>()).add(student);
+            emailToTeamName.put(student.getEmail().toLowerCase(Locale.ROOT), student.getTeamName());
+        }
+
         List<String> teamNames;
         if (isStudent) {
-            teamNames = getTeamsWithAtLeastOneResponse(responses, bundle);
+            teamNames = getTeamsWithAtLeastOneResponse(responses);
         } else {
-            teamNames = new ArrayList<>(bundle.getRoster().getTeamToMembers().keySet());
+            teamNames = new ArrayList<>(teamNameToMembers.keySet());
         }
 
         // Each team's member (email) list
-        Map<String, List<String>> teamMembersEmail = getTeamMembersEmail(bundle, teamNames);
+        Map<String, List<String>> teamMembersEmail = getTeamMembersEmail(teamNameToMembers, teamNames);
 
         // Each team's responses
-        Map<String, List<FeedbackResponse>> teamResponses = getTeamResponses(responses, bundle, teamNames);
+        Map<String, List<FeedbackResponse>> teamResponses = getTeamResponses(responses, teamNames);
 
         // Get each team's submission array. -> int[teamSize][teamSize]
         // Where int[0][1] refers points from student 0 to student 1
@@ -103,7 +113,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         ContributionStatistics output = new ContributionStatistics();
 
         if (isStudent) {
-            String currentUserTeam = bundle.getRoster().getInfoForIdentifier(studentEmail).getTeamName();
+            String currentUserTeam = emailToTeamName.get(studentEmail.toLowerCase(Locale.ROOT));
             TeamEvalResult currentUserTeamResults = teamResults.get(currentUserTeam);
             if (currentUserTeamResults != null) {
                 List<String> teamEmails = teamMembersEmail.get(currentUserTeam);
@@ -152,7 +162,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             for (Map.Entry<String, int[]> entry : studentResults.entrySet()) {
                 int[] summary = entry.getValue();
                 String email = entry.getKey();
-                String team = bundle.getRoster().getStudentForEmail(email).getTeamName();
+                String team = emailToTeamName.get(email.toLowerCase(Locale.ROOT));
                 List<String> teamEmails = teamMembersEmail.get(team);
                 TeamEvalResult teamResult = teamResults.get(team);
                 int studentIndex = teamEmails.indexOf(email);
@@ -233,14 +243,13 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
     }
 
     private Map<String, List<FeedbackResponse>> getTeamResponses(
-            List<FeedbackResponse> responses, SessionResultsBundle bundle, List<String> teamNames) {
+            List<FeedbackResponse> responses, List<String> teamNames) {
         Map<String, List<FeedbackResponse>> teamResponses = new LinkedHashMap<>();
         for (String teamName : teamNames) {
             teamResponses.put(teamName, new ArrayList<>());
         }
         for (FeedbackResponse response : responses) {
-            String team = bundle.getRoster()
-                    .getInfoForIdentifier(response.getGiver().getGiverUser().getEmail()).getTeamName();
+            String team = response.getGiver().getTeamName();
             if (teamResponses.containsKey(team)) {
                 teamResponses.get(team).add(response);
             }
@@ -249,10 +258,10 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
     }
 
     private Map<String, List<String>> getTeamMembersEmail(
-            SessionResultsBundle bundle, List<String> teamNames) {
+            Map<String, List<Student>> teamNameToMembers, List<String> teamNames) {
         Map<String, List<String>> teamMembersEmail = new LinkedHashMap<>();
         for (String teamName : teamNames) {
-            List<String> memberEmails = bundle.getRoster().getTeamToMembers().get(teamName)
+            List<String> memberEmails = teamNameToMembers.getOrDefault(teamName, List.of())
                     .stream().map(Student::getEmail)
                     .collect(Collectors.toList());
             teamMembersEmail.put(teamName, memberEmails);
@@ -260,14 +269,10 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         return teamMembersEmail;
     }
 
-    private List<String> getTeamsWithAtLeastOneResponse(
-            List<FeedbackResponse> responses, SessionResultsBundle bundle) {
+    private List<String> getTeamsWithAtLeastOneResponse(List<FeedbackResponse> responses) {
         Set<String> teamNames = new HashSet<>();
         for (FeedbackResponse response : responses) {
-            String teamNameOfResponseGiver = bundle.getRoster()
-                    .getInfoForIdentifier(response.getGiver().getGiverUser().getEmail())
-                    .getTeamName();
-            teamNames.add(teamNameOfResponseGiver);
+            teamNames.add(response.getGiver().getTeamName());
         }
         return new ArrayList<>(teamNames);
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -220,8 +220,8 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             List<FeedbackResponse> teamResponseList = teamResponses.get(team);
             List<String> memberEmailList = teamMembersEmail.get(team);
             for (FeedbackResponse response : teamResponseList) {
-                int giverIndx = memberEmailList.indexOf(response.getGiver().getIdentifier());
-                int recipientIndx = memberEmailList.indexOf(response.getRecipient().getIdentifier());
+                int giverIndx = memberEmailList.indexOf(response.getGiver().getGiverUser().getEmail());
+                int recipientIndx = memberEmailList.indexOf(response.getRecipient().getRecipientUser().getEmail());
                 if (giverIndx == -1 || recipientIndx == -1) {
                     continue;
                 }
@@ -239,7 +239,8 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             teamResponses.put(teamName, new ArrayList<>());
         }
         for (FeedbackResponse response : responses) {
-            String team = bundle.getRoster().getInfoForIdentifier(response.getGiver().getIdentifier()).getTeamName();
+            String team = bundle.getRoster()
+                    .getInfoForIdentifier(response.getGiver().getGiverUser().getEmail()).getTeamName();
             if (teamResponses.containsKey(team)) {
                 teamResponses.get(team).add(response);
             }
@@ -264,7 +265,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         Set<String> teamNames = new HashSet<>();
         for (FeedbackResponse response : responses) {
             String teamNameOfResponseGiver = bundle.getRoster()
-                    .getInfoForIdentifier(response.getGiver().getIdentifier())
+                    .getInfoForIdentifier(response.getGiver().getGiverUser().getEmail())
                     .getTeamName();
             teamNames.add(teamNameOfResponseGiver);
         }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -25,6 +25,7 @@ import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.Student;
+import teammates.storage.entity.User;
 
 /**
  * Contains specific structure and processing logic for contribution feedback questions.
@@ -230,8 +231,13 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             List<FeedbackResponse> teamResponseList = teamResponses.get(team);
             List<String> memberEmailList = teamMembersEmail.get(team);
             for (FeedbackResponse response : teamResponseList) {
-                int giverIndx = memberEmailList.indexOf(response.getGiver().getGiverUser().getEmail());
-                int recipientIndx = memberEmailList.indexOf(response.getRecipient().getRecipientUser().getEmail());
+                User giverUser = response.getGiver().getGiverUser();
+                User recipientUser = response.getRecipient().getRecipientUser();
+                if (giverUser == null || recipientUser == null) {
+                    continue;
+                }
+                int giverIndx = memberEmailList.indexOf(giverUser.getEmail());
+                int recipientIndx = memberEmailList.indexOf(recipientUser.getEmail());
                 if (giverIndx == -1 || recipientIndx == -1) {
                     continue;
                 }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -620,7 +620,7 @@ public final class FeedbackQuestionsLogic {
 
             return instructorRecipients;
         case TEAMS, TEAMS_EXCLUDING_SELF, TEAMS_IN_SAME_SECTION:
-            Collection<Team> teams = courseRoster.getTeamIdToTeam().values();
+            Collection<Team> teams = courseRoster.getTeams();
 
             Team giverTeamToExclude = null;
             if (generateOptionsFor != QuestionRecipientType.TEAMS) {
@@ -671,16 +671,14 @@ public final class FeedbackQuestionsLogic {
 
             return Set.of();
         case OWN_TEAM_MEMBERS:
-            String teamName = responseGiver.getTeamName();
-            List<Student> teamMembers = courseRoster.getTeamToMembers().getOrDefault(teamName, Collections.emptyList());
+            List<Student> teamMembers = courseRoster.getTeamMembers(responseGiver.getTeamId());
 
             return teamMembers.stream()
                     .filter(student -> !Objects.equals(student, responseGiver.getGiverUser()))
                     .map(ResponseRecipient::new)
                     .collect(Collectors.toSet());
         case OWN_TEAM_MEMBERS_INCLUDING_SELF:
-            teamName = responseGiver.getTeamName();
-            teamMembers = courseRoster.getTeamToMembers().getOrDefault(teamName, Collections.emptyList());
+            teamMembers = courseRoster.getTeamMembers(responseGiver.getTeamId());
 
             return teamMembers.stream()
                     .map(ResponseRecipient::new)
@@ -817,7 +815,7 @@ public final class FeedbackQuestionsLogic {
                     .toList();
             break;
         case TEAMS:
-            possibleGivers = courseRoster.getTeamIdToTeam().values()
+            possibleGivers = courseRoster.getTeams()
                     .stream()
                     .map(ResponseGiver::new)
                     .toList();

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -296,8 +296,8 @@ public final class FeedbackResponsesLogic {
 
         Set<ResponseRecipient> recipientsOfTheQuestion = fqLogic.getRecipientsOfQuestion(
                 feedbackQuestion, responseGiver);
-        Map<String, ResponseRecipient> recipientsByIdentifier = recipientsOfTheQuestion.stream()
-                .collect(Collectors.toMap(ResponseRecipient::getIdentifier, recipient -> recipient));
+        Map<String, ResponseRecipient> recipientsByKey = recipientsOfTheQuestion.stream()
+                .collect(Collectors.toMap(ResponseRecipient::getKey, recipient -> recipient));
 
         Map<UUID, FeedbackResponse> existingResponsesById = new HashMap<>();
         existingResponses.forEach(response -> existingResponsesById.put(response.getId(), response));
@@ -307,7 +307,7 @@ public final class FeedbackResponsesLogic {
                 .toList();
 
         for (String recipient : recipients) {
-            if (recipient == null || !recipientsByIdentifier.containsKey(recipient)) {
+            if (recipient == null || !recipientsByKey.containsKey(recipient)) {
                 throw new InvalidOperationException(
                         "The recipient " + recipient + " is not a valid recipient of the question");
             }
@@ -318,7 +318,7 @@ public final class FeedbackResponsesLogic {
 
         for (FeedbackResponseRequest responseRequest : submitResponses) {
             String recipient = responseRequest.getRecipient();
-            ResponseRecipient responseRecipient = recipientsByIdentifier.get(recipient);
+            ResponseRecipient responseRecipient = recipientsByKey.get(recipient);
             FeedbackResponseDetails responseDetails = responseRequest.getResponseDetails();
             UUID responseId = responseRequest.getResponseId();
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -595,11 +595,11 @@ public final class FeedbackResponsesLogic {
             }
         }
 
-        Set<String> studentsEmailInTeam = new HashSet<>();
+        Set<UUID> teamMemberUserIds = new HashSet<>();
         if (user instanceof Student student) {
             for (Student studentInTeam
                     : roster.getTeamToMembers().getOrDefault(student.getTeamName(), Collections.emptyList())) {
-                studentsEmailInTeam.add(studentInTeam.getEmail());
+                teamMemberUserIds.add(studentInTeam.getId());
             }
         }
 
@@ -622,7 +622,7 @@ public final class FeedbackResponsesLogic {
             }
             // check visibility of response
             boolean isVisibleResponse = isResponseVisibleForUser(
-                    user, studentsEmailInTeam,
+                    user, teamMemberUserIds,
                     response.getGiver(), response.getRecipient(),
                     correspondingQuestion);
             if (!isVisibleResponse) {
@@ -989,7 +989,7 @@ public final class FeedbackResponsesLogic {
 
     private boolean isResponseVisibleForUser(
             User user,
-            Set<String> studentsEmailInTeam,
+            Set<UUID> teamMemberUserIds,
             ResponseGiver giver,
             ResponseRecipient recipient,
             FeedbackQuestion relatedQuestion
@@ -1033,21 +1033,21 @@ public final class FeedbackResponsesLogic {
         boolean isVisibleToReceiverTeamMembers = false;
         if (user instanceof Student student) {
             isVisibleToStudents = relatedQuestion.isResponseVisibleTo(ViewerType.STUDENTS);
-            isVisibleToTeamRecipient = studentsEmailInTeam != null
+            isVisibleToTeamRecipient = teamMemberUserIds != null
                     && (relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS
                         || relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS_IN_SAME_SECTION
                         || relatedQuestion.getRecipientType() == QuestionRecipientType.TEAMS_EXCLUDING_SELF)
                     && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER)
                     && Objects.equals(recipient.getRecipientTeam(), student.getTeam());
-            isVisibleToTeamGiver = studentsEmailInTeam != null
+            isVisibleToTeamGiver = teamMemberUserIds != null
                     && relatedQuestion.getGiverType() == QuestionGiverType.TEAMS
                     && Objects.equals(giver.getGiverTeam(), student.getTeam());
-            isVisibleToOwnTeamMembers = studentsEmailInTeam != null
+            isVisibleToOwnTeamMembers = teamMemberUserIds != null
                     && relatedQuestion.isResponseVisibleTo(ViewerType.OWN_TEAM_MEMBERS)
-                    && studentsEmailInTeam.contains(giver.getIdentifier());
-            isVisibleToReceiverTeamMembers = studentsEmailInTeam != null
+                    && teamMemberUserIds.contains(giver.getGiverUserId());
+            isVisibleToReceiverTeamMembers = teamMemberUserIds != null
                     && relatedQuestion.isResponseVisibleTo(ViewerType.RECEIVER_TEAM_MEMBERS)
-                    && studentsEmailInTeam.contains(recipient.getIdentifier());
+                    && teamMemberUserIds.contains(recipient.getRecipientUserId());
         }
 
         return isVisibleToInstructor || isVisibleToRecipient || isVisibleToGiver

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -191,7 +191,7 @@ public final class FeedbackResponsesLogic {
         List<FeedbackResponse> responses = new ArrayList<>();
         List<Student> studentsInTeam = courseRoster == null
                 ? usersLogic.getStudentsForTeam(team.getName(), courseId)
-                : courseRoster.getTeamToMembers().get(team.getName());
+                : courseRoster.getTeamMembers(team.getId());
 
         for (Student student : studentsInTeam) {
             responses.addAll(frDb.getFeedbackResponsesFromGiverForQuestion(
@@ -476,13 +476,10 @@ public final class FeedbackResponsesLogic {
             }
             break;
         case TEAMS:
-            Map<String, List<Student>> teams = roster.getTeamToMembers();
-            for (Map.Entry<String, List<Student>> entry : teams.entrySet()) {
-                String teamName = entry.getKey();
-                ResponseGiver teamResponseGiver = new ResponseGiver(roster.getTeamNameToTeam().get(teamName));
+            for (Team team : roster.getTeams()) {
+                ResponseGiver teamResponseGiver = new ResponseGiver(team);
                 numberOfRecipients =
                         fqLogic.getRecipientsOfQuestion(question, teamResponseGiver, roster).size();
-                Team team = roster.getTeamNameToTeam().get(teamName);
                 responses =
                         getFeedbackResponsesFromTeamForQuestion(
                                 question.getId(), question.getCourseId(), team, roster);
@@ -597,8 +594,7 @@ public final class FeedbackResponsesLogic {
 
         Set<UUID> teamMemberUserIds = new HashSet<>();
         if (user instanceof Student student) {
-            for (Student studentInTeam
-                    : roster.getTeamToMembers().getOrDefault(student.getTeamName(), Collections.emptyList())) {
+            for (Student studentInTeam : roster.getTeamMembers(student.getTeamId())) {
                 teamMemberUserIds.add(studentInTeam.getId());
             }
         }
@@ -1202,7 +1198,7 @@ public final class FeedbackResponsesLogic {
         }
 
         if (question.isResponseVisibleTo(ViewerType.RECEIVER_TEAM_MEMBERS)) {
-            for (Student studentInTeam : courseRoster.getTeamToMembers().get(student.getTeamName())) {
+            for (Student studentInTeam : courseRoster.getTeamMembers(student.getTeamId())) {
                 if (Objects.equals(studentInTeam, student)) {
                     continue;
                 }

--- a/src/main/java/teammates/storage/entity/ResponseGiver.java
+++ b/src/main/java/teammates/storage/entity/ResponseGiver.java
@@ -146,19 +146,6 @@ public class ResponseGiver {
     }
 
     /**
-     * Gets the giver identifier: team name for team givers, user email for user givers.
-     */
-    public String getIdentifier() {
-        if (giverTeam != null) {
-            return giverTeam.getName();
-        }
-        if (giverUser != null) {
-            return giverUser.getEmail();
-        }
-        return Const.UNKNOWN_USER;
-    }
-
-    /**
      * Gets the giver key: a stable identifier composed of the giver type and UUID
      * (team ID for teams, user ID for users).
      */

--- a/src/main/java/teammates/storage/entity/ResponseGiver.java
+++ b/src/main/java/teammates/storage/entity/ResponseGiver.java
@@ -159,6 +159,20 @@ public class ResponseGiver {
     }
 
     /**
+     * Gets the giver key: a stable identifier composed of the giver type and UUID
+     * (team ID for teams, user ID for users).
+     */
+    public String getKey() {
+        if (isGiverTeam()) {
+            return "TEAM:" + getGiverTeamId();
+        }
+        if (isGiverInstructor()) {
+            return "INSTRUCTOR:" + getGiverUserId();
+        }
+        return "STUDENT:" + getGiverUserId();
+    }
+
+    /**
      * Gets the giver display name: team name for team givers, user name for user givers.
      */
     public String getDisplayName() {

--- a/src/main/java/teammates/storage/entity/ResponseGiver.java
+++ b/src/main/java/teammates/storage/entity/ResponseGiver.java
@@ -114,6 +114,20 @@ public class ResponseGiver {
     }
 
     /**
+     * Gets the team ID of the giver: the team's own ID for team givers, the student's team ID for
+     * student givers, or {@code null} for instructor givers.
+     */
+    public UUID getTeamId() {
+        if (isGiverTeam()) {
+            return getGiverTeamId();
+        }
+        if (giverUser instanceof Student student) {
+            return student.getTeamId();
+        }
+        return null;
+    }
+
+    /**
      * Gets the section ID of the giver.
      */
     public UUID getSectionId() {

--- a/src/main/java/teammates/storage/entity/ResponseRecipient.java
+++ b/src/main/java/teammates/storage/entity/ResponseRecipient.java
@@ -189,6 +189,22 @@ public class ResponseRecipient {
     }
 
     /**
+     * Gets the recipient key: a stable identifier composed of the recipient type and UUID
+     * (team ID for teams, user ID for users, or none for no specific recipient).
+     */
+    public String getKey() {
+        switch (recipientType) {
+        case TEAM:
+            return recipientType + ":" + recipientTeamId;
+        case STUDENT, INSTRUCTOR:
+            return recipientType + ":" + recipientUserId;
+        case NO_SPECIFIC_RECIPIENT:
+        default:
+            return recipientType + ":" + null;
+        }
+    }
+
+    /**
      * Gets the recipient display name: team name for team recipients, user name for user recipients.
      */
     public String getDisplayName() {

--- a/src/main/java/teammates/storage/entity/ResponseRecipient.java
+++ b/src/main/java/teammates/storage/entity/ResponseRecipient.java
@@ -174,21 +174,6 @@ public class ResponseRecipient {
     }
 
     /**
-     * Gets the recipient identifier: team name for team recipients, user email for user recipients.
-     */
-    public String getIdentifier() {
-        switch (recipientType) {
-        case TEAM:
-            return recipientTeam == null ? Const.UNKNOWN_TEAM : recipientTeam.getName();
-        case STUDENT, INSTRUCTOR:
-            return recipientUser == null ? Const.UNKNOWN_USER : recipientUser.getEmail();
-        case NO_SPECIFIC_RECIPIENT:
-        default:
-            return Const.GENERAL_QUESTION;
-        }
-    }
-
-    /**
      * Gets the recipient key: a stable identifier composed of the recipient type and UUID
      * (team ID for teams, user ID for users, or none for no specific recipient).
      */

--- a/src/main/java/teammates/ui/output/FeedbackQuestionRecipientData.java
+++ b/src/main/java/teammates/ui/output/FeedbackQuestionRecipientData.java
@@ -14,7 +14,7 @@ public class FeedbackQuestionRecipientData implements ApiOutput {
 
     public FeedbackQuestionRecipientData(ResponseRecipient recipient) {
         this.name = recipient.getDisplayName();
-        this.identifier = recipient.getIdentifier();
+        this.identifier = recipient.getKey();
         this.section = recipient.getSectionName();
         this.team = recipient.getTeamName();
     }

--- a/src/main/java/teammates/ui/output/FeedbackResponseData.java
+++ b/src/main/java/teammates/ui/output/FeedbackResponseData.java
@@ -37,8 +37,8 @@ public class FeedbackResponseData implements ApiOutput {
 
     public FeedbackResponseData(FeedbackResponse feedbackResponse) {
         this.feedbackResponseId = feedbackResponse.getId();
-        this.giverIdentifier = feedbackResponse.getGiver().getIdentifier();
-        this.recipientIdentifier = feedbackResponse.getRecipient().getIdentifier();
+        this.giverIdentifier = feedbackResponse.getGiver().getKey();
+        this.recipientIdentifier = feedbackResponse.getRecipient().getKey();
         this.responseDetails = feedbackResponse.getFeedbackResponseDetailsCopy();
         this.giverComment = feedbackResponse.getGiverComment();
     }

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -228,9 +228,7 @@ public class SessionResultsData implements ApiOutput {
                 userIdForModeration = responseGiver.getGiverUser().getId().toString();
             } else {
                 // team giver, userIdForModeration is any team member's user ID
-                String teamName = responseGiver.getTeamName();
-                List<Student> teamMembers =
-                        bundle.getRoster().getTeamToMembers().getOrDefault(teamName, Collections.emptyList());
+                List<Student> teamMembers = bundle.getRoster().getTeamMembers(responseGiver.getTeamId());
                 userIdForModeration = teamMembers.isEmpty() ? null : teamMembers.iterator().next().getId().toString();
                 giverEmail = null;
             }
@@ -301,9 +299,7 @@ public class SessionResultsData implements ApiOutput {
                 userIdForModeration = responseGiver.getGiverUser().getId().toString();
             } else {
                 // team giver, userIdForModeration is any team member's user ID
-                String teamName = responseGiver.getTeamName();
-                List<Student> teamMembers =
-                        bundle.getRoster().getTeamToMembers().getOrDefault(teamName, Collections.emptyList());
+                List<Student> teamMembers = bundle.getRoster().getTeamMembers(responseGiver.getTeamId());
                 userIdForModeration = teamMembers.stream().findFirst()
                         .map(student -> student.getId().toString()).orElse(null);
                 giverEmail = null;

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -248,7 +248,7 @@ public class SessionResultsData implements ApiOutput {
 
         if (bundle.isResponseRecipientVisible(response.getId(), responseRecipient.getRecipientType())
                 && responseRecipient.isRecipientUser()) {
-            recipientEmail = responseRecipient.getIdentifier();
+            recipientEmail = responseRecipient.getRecipientUser().getEmail();
         }
 
         // process comments
@@ -322,7 +322,7 @@ public class SessionResultsData implements ApiOutput {
 
         if (bundle.isResponseRecipientVisible(response.id(), responseRecipient.getRecipientType())
                 && responseRecipient.isRecipientUser()) {
-            recipientEmail = responseRecipient.getIdentifier();
+            recipientEmail = responseRecipient.getRecipientUser().getEmail();
         }
 
         FeedbackTextResponseDetails responseDetails = new FeedbackTextResponseDetails(Const.MISSING_RESPONSE_TEXT);

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -439,8 +439,8 @@ public abstract class AbstractBackDoor {
         FeedbackResponsesData responsesData = JsonUtils.fromJson(response.responseBody, FeedbackResponsesData.class);
         return responsesData.getResponses()
                 .stream()
-            .filter(r -> r.getGiverIdentifier().equals(giver.getIdentifier())
-                && r.getRecipientIdentifier().equals(recipient.getIdentifier()))
+            .filter(r -> r.getGiverIdentifier().equals(giver.getKey())
+                && r.getRecipientIdentifier().equals(recipient.getKey()))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/test/java/teammates/test/ResponseEntityHelper.java
+++ b/src/test/java/teammates/test/ResponseEntityHelper.java
@@ -1,0 +1,49 @@
+package teammates.test;
+
+import teammates.common.util.Const;
+import teammates.storage.entity.ResponseGiver;
+import teammates.storage.entity.ResponseRecipient;
+
+/**
+ * Test-only helper for computing the legacy email/team-name identifier of a response giver or recipient.
+ *
+ * <p>Production code identifies givers/recipients by UUID and type (see
+ * {@link ResponseGiver#getKey()} / {@link ResponseRecipient#getKey()}); this helper exists only so
+ * that tests can keep matching responses against expected email/team-name based test data.
+ */
+public final class ResponseEntityHelper {
+
+    private ResponseEntityHelper() {
+        // utility class
+    }
+
+    /**
+     * Gets the giver identifier: team name for team givers, user email for user givers.
+     */
+    public static String getIdentifier(ResponseGiver giver) {
+        if (giver.getGiverTeam() != null) {
+            return giver.getGiverTeam().getName();
+        }
+        if (giver.getGiverUser() != null) {
+            return giver.getGiverUser().getEmail();
+        }
+        return Const.UNKNOWN_USER;
+    }
+
+    /**
+     * Gets the recipient identifier: team name for team recipients, user email for user recipients.
+     */
+    public static String getIdentifier(ResponseRecipient recipient) {
+        switch (recipient.getRecipientType()) {
+        case TEAM:
+            return recipient.getRecipientTeam() == null
+                    ? Const.UNKNOWN_TEAM : recipient.getRecipientTeam().getName();
+        case STUDENT, INSTRUCTOR:
+            return recipient.getRecipientUser() == null
+                    ? Const.UNKNOWN_USER : recipient.getRecipientUser().getEmail();
+        case NO_SPECIFIC_RECIPIENT:
+        default:
+            return Const.GENERAL_QUESTION;
+        }
+    }
+}

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -183,35 +183,53 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         return students.stream().map(Student::getTeamName).distinct().toList();
     }
 
-    private FeedbackResponsesRequest buildRequestBodyWithStudentRecipientsEmail(
-            List<Student> recipients) {
-        List<String> emails = extractStudentEmails(recipients);
-        return buildRequestBody(emails);
-    }
-
-    private FeedbackResponsesRequest buildRequestBodyWithStudentRecipientsTeam(
-            List<Student> recipients) {
-        List<String> teams = extractStudentTeams(recipients);
-        return buildRequestBody(teams);
-    }
-
     private List<String> extractInstructorEmails(
             List<Instructor> students) {
         return students.stream().map(User::getEmail).toList();
     }
 
-    private FeedbackResponsesRequest buildRequestBodyWithInstructorRecipients(List<Instructor> recipients) {
-        List<String> emails = extractInstructorEmails(recipients);
-        return buildRequestBody(emails);
+    // The recipient key format must stay consistent with ResponseRecipient#getKey() / ResponseGiver#getKey().
+    private List<Recipient> studentEmailRecipients(List<Student> students) {
+        return students.stream()
+                .map(s -> new Recipient("STUDENT:" + s.getId(), s.getEmail()))
+                .toList();
     }
 
-    private FeedbackResponsesRequest buildRequestBody(List<String> values) {
+    private List<Recipient> studentTeamRecipients(List<Student> students) {
+        return students.stream()
+                .map(s -> new Recipient("TEAM:" + s.getTeamId(), s.getTeamName()))
+                .distinct()
+                .toList();
+    }
+
+    private List<Recipient> instructorRecipientsList(List<Instructor> instructors) {
+        return instructors.stream()
+                .map(i -> new Recipient("INSTRUCTOR:" + i.getId(), i.getEmail()))
+                .toList();
+    }
+
+    private FeedbackResponsesRequest buildRequestBodyWithStudentRecipientsEmail(
+            List<Student> recipients) {
+        return buildRequestBody(studentEmailRecipients(recipients));
+    }
+
+    private FeedbackResponsesRequest buildRequestBodyWithStudentRecipientsTeam(
+            List<Student> recipients) {
+        return buildRequestBody(studentTeamRecipients(recipients));
+    }
+
+    private FeedbackResponsesRequest buildRequestBodyWithInstructorRecipients(List<Instructor> recipients) {
+        return buildRequestBody(instructorRecipientsList(recipients));
+    }
+
+    private FeedbackResponsesRequest buildRequestBody(List<Recipient> recipients) {
         List<FeedbackResponsesRequest.FeedbackResponseRequest> responses = new ArrayList<>();
 
-        for (String value : values) {
-            FeedbackTextResponseDetails responseDetails = new FeedbackTextResponseDetails("Response for " + value);
+        for (Recipient recipient : recipients) {
+            FeedbackTextResponseDetails responseDetails =
+                    new FeedbackTextResponseDetails("Response for " + recipient.label());
             FeedbackResponsesRequest.FeedbackResponseRequest response =
-                    new FeedbackResponsesRequest.FeedbackResponseRequest(value, responseDetails);
+                    new FeedbackResponsesRequest.FeedbackResponseRequest(recipient.key(), responseDetails);
 
             responses.add(response);
         }
@@ -232,46 +250,43 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
                 .toList();
     }
 
-    private void validateOutputForStudentRecipientsByEmail(List<FeedbackResponseData> responses, String giverEmail,
+    private void validateOutputForStudentRecipientsByEmail(List<FeedbackResponseData> responses, String giverKey,
                                                            List<Student> recipients) {
-        int responsesSize = responses.size();
-        assertEquals(recipients.size(), responsesSize);
+        List<Recipient> expected = studentEmailRecipients(recipients);
+        assertEquals(expected.size(), responses.size());
 
-        List<String> recipientEmails = extractStudentEmails(recipients);
-
-        validateOutput(responses, giverEmail, recipientEmails);
+        validateOutput(responses, giverKey, expected);
     }
 
-    private void validateOutputForStudentRecipientsByTeam(List<FeedbackResponseData> responses, String giverTeam,
+    private void validateOutputForStudentRecipientsByTeam(List<FeedbackResponseData> responses, String giverKey,
                                                           List<Student> recipients) {
-        List<String> recipientTeams = extractStudentTeams(recipients);
-        int responsesSize = responses.size();
-        assertEquals(recipientTeams.size(), responsesSize);
+        List<Recipient> expected = studentTeamRecipients(recipients);
+        assertEquals(expected.size(), responses.size());
 
-        validateOutput(responses, giverTeam, recipientTeams);
+        validateOutput(responses, giverKey, expected);
     }
 
-    private void validateOutputForInstructorRecipients(List<FeedbackResponseData> responses, String giverEmail,
+    private void validateOutputForInstructorRecipients(List<FeedbackResponseData> responses, String giverKey,
                                                        List<Instructor> recipients) {
-        int responsesSize = responses.size();
-        assertEquals(recipients.size(), responsesSize);
+        List<Recipient> expected = instructorRecipientsList(recipients);
+        assertEquals(expected.size(), responses.size());
 
-        List<String> recipientEmails = extractInstructorEmails(recipients);
-
-        validateOutput(responses, giverEmail, recipientEmails);
+        validateOutput(responses, giverKey, expected);
     }
 
-    private void validateOutput(List<FeedbackResponseData> responses, String giverValue, List<String> recipientValues) {
-        for (int i = 0; i < recipientValues.size(); i++) {
-            FeedbackResponseData response = responses.get(i);
-            String recipientValue = recipientValues.get(i);
+    private void validateOutput(List<FeedbackResponseData> responses, String giverKey, List<Recipient> recipients) {
+        for (Recipient expected : recipients) {
+            FeedbackResponseData response = responses.stream()
+                    .filter(r -> expected.key().equals(r.getRecipientIdentifier()))
+                    .findFirst()
+                    .orElseThrow();
 
-            assertEquals(giverValue, response.getGiverIdentifier());
-            assertEquals(recipientValue, response.getRecipientIdentifier());
+            assertEquals(giverKey, response.getGiverIdentifier());
+            assertEquals(expected.key(), response.getRecipientIdentifier());
 
             FeedbackResponseDetails responseDetails = response.getResponseDetails();
             assertEquals(StringEscapeUtils.unescapeHtml(
-                            SanitizationHelper.sanitizeForRichText("Response for " + recipientValue)),
+                            SanitizationHelper.sanitizeForRichText("Response for " + expected.label())),
                     StringEscapeUtils.unescapeHtml(responseDetails.getAnswerString()));
         }
     }
@@ -632,13 +647,13 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         questionNumber = 4;
         submissionParams = buildSubmissionParams(session, questionNumber, Intent.INSTRUCTOR_SUBMISSION);
 
-        // Null recipient
-        List<String> nullEmail = Collections.singletonList(null);
-        FeedbackResponsesRequest requestBody = buildRequestBody(nullEmail);
+        // Null recipient key
+        FeedbackResponsesRequest requestBody = buildRequestBody(
+                Collections.singletonList(new Recipient(null, "no key")));
         verifyHttpRequestBodyFailure(requestBody, submissionParams);
 
-        // Empty String recipient
-        requestBody = buildRequestBody(Collections.singletonList(""));
+        // Empty recipient key
+        requestBody = buildRequestBody(Collections.singletonList(new Recipient("", "empty key")));
         verifyHttpRequestBodyFailure(requestBody, submissionParams);
 
         ______TS("Success: question has no existing responses");
@@ -652,7 +667,8 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         requestBody = buildRequestBodyWithInstructorRecipients(instructorRecipients);
 
         List<FeedbackResponseData> outputResponses = callExecute(requestBody, submissionParams);
-        validateOutputForInstructorRecipients(outputResponses, instructorGiver.getEmail(), instructorRecipients);
+        validateOutputForInstructorRecipients(
+                outputResponses, "INSTRUCTOR:" + instructorGiver.getId(), instructorRecipients);
         validateInstructorDatabaseByEmail(session, question, instructorGiver.getEmail(), instructorRecipients);
 
         ______TS("Success: instructor is a valid giver of the question to student team");
@@ -666,7 +682,8 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         requestBody = buildRequestBodyWithStudentRecipientsTeam(studentRecipients);
 
         outputResponses = callExecute(requestBody, submissionParams);
-        validateOutputForStudentRecipientsByTeam(outputResponses, instructorGiver.getEmail(), studentRecipients);
+        validateOutputForStudentRecipientsByTeam(
+                outputResponses, "INSTRUCTOR:" + instructorGiver.getId(), studentRecipients);
         validateStudentDatabaseByTeam(session, question, instructorGiver.getEmail(), studentRecipients);
 
         ______TS("Success: question has existing responses");
@@ -680,7 +697,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         requestBody = buildRequestBodyWithStudentRecipientsEmail(studentRecipients);
 
         outputResponses = callExecute(requestBody, submissionParams);
-        validateOutputForStudentRecipientsByEmail(outputResponses, studentGiver.getEmail(), studentRecipients);
+        validateOutputForStudentRecipientsByEmail(outputResponses, "STUDENT:" + studentGiver.getId(), studentRecipients);
         validateStudentDatabaseByEmail(session, question, studentGiver.getEmail(), studentRecipients);
 
         ______TS("Failure: student is a invalid giver of the question");
@@ -704,7 +721,16 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
         requestBody = buildRequestBodyWithStudentRecipientsEmail(studentRecipients);
 
         outputResponses = callExecute(requestBody, submissionParams);
-        validateOutputForStudentRecipientsByEmail(outputResponses, studentGiver.getEmail(), studentRecipients);
+        validateOutputForStudentRecipientsByEmail(outputResponses, "STUDENT:" + studentGiver.getId(), studentRecipients);
         validateStudentDatabaseByEmail(session, question, studentGiver.getEmail(), studentRecipients);
+    }
+
+    /**
+     * A recipient's submission key and the email/team label used for its response text.
+     *
+     * @param key the recipient key, in the same format as {@code ResponseRecipient#getKey()}
+     * @param label the email (or team name) used to label the response text
+     */
+    private record Recipient(String key, String label) {
     }
 }

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -30,6 +30,7 @@ import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.User;
 import teammates.test.GroupNames;
+import teammates.test.ResponseEntityHelper;
 import teammates.ui.output.FeedbackQuestionResponsesData;
 import teammates.ui.output.FeedbackResponseData;
 import teammates.ui.request.FeedbackResponsesRequest;
@@ -321,16 +322,16 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
                 .toList());
         for (String recipientEmail : recipientEmails) {
             List<FeedbackResponse> feedbackResponses = responses.stream()
-                    .filter(response -> response.getGiver().getIdentifier().equals(giverEmail))
-                    .filter(response -> response.getRecipient().getIdentifier().equals(recipientEmail))
+                    .filter(response -> ResponseEntityHelper.getIdentifier(response.getGiver()).equals(giverEmail))
+                    .filter(response -> ResponseEntityHelper.getIdentifier(response.getRecipient()).equals(recipientEmail))
                     .toList();
 
             for (FeedbackResponse feedbackResponse : feedbackResponses) {
                 FeedbackQuestion frFeedbackQuestion = feedbackResponse.getFeedbackQuestion();
 
                 assertEquals(frFeedbackQuestion, feedbackQuestion);
-                assertEquals(feedbackResponse.getGiver().getIdentifier(), giverEmail);
-                assertEquals(feedbackResponse.getRecipient().getIdentifier(), recipientEmail);
+                assertEquals(ResponseEntityHelper.getIdentifier(feedbackResponse.getGiver()), giverEmail);
+                assertEquals(ResponseEntityHelper.getIdentifier(feedbackResponse.getRecipient()), recipientEmail);
 
                 assertEquals(session.getName(), feedbackQuestion.getFeedbackSessionName());
                 assertEquals(session.getCourseId(), feedbackQuestion.getCourseId());

--- a/src/web/services/submission-receipt.service.ts
+++ b/src/web/services/submission-receipt.service.ts
@@ -115,7 +115,8 @@ export class SubmissionReceiptService {
   private appendQuestionContent(fileContent: string[], entry: QuestionResponses): void {
     const question: QuestionSubmissionFormModel = entry.question;
     const questionResponses: FeedbackResponse[] = [...entry.responses].sort(
-      (a: FeedbackResponse, b: FeedbackResponse) => a.recipientIdentifier.localeCompare(b.recipientIdentifier),
+      (a: FeedbackResponse, b: FeedbackResponse) =>
+        this.getRecipientLabel(question, a).localeCompare(this.getRecipientLabel(question, b)),
     );
 
     fileContent.push(`Question ${question.questionNumber}`, `${question.questionBrief}`, '');
@@ -150,8 +151,6 @@ export class SubmissionReceiptService {
     const recipient: FeedbackResponseRecipient | undefined = question.recipientList.find(
       (item: FeedbackResponseRecipient) => item.recipientIdentifier === response.recipientIdentifier,
     );
-    return recipient?.recipientName
-      ? `${recipient.recipientName} [${response.recipientIdentifier}]`
-      : response.recipientIdentifier;
+    return recipient?.recipientName ?? 'Unknown Recipient';
   }
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

As part of SQL migration, we are switching to using stable UUIDs to identify entities rather than natural keys which may change. In this case, using UUIDs instead of email/teamName for response recipient. 

Also cleaned up CourseRoster to remove instances where email or teamName was being used as a key.