### PR TITLE
[#13721] Add entity-based GateKeeper verify methods

### DIFF
--- a/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/BinFeedbackSessionAction.java
@@ -23,11 +23,7 @@ public class BinFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateFeedbackQuestionAction.java
@@ -29,12 +29,7 @@ public class CreateFeedbackQuestionAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackQuestionAction.java
@@ -4,8 +4,6 @@ import java.util.UUID;
 
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
-import teammates.storage.entity.FeedbackSession;
-import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
 /**
@@ -20,19 +18,8 @@ public class DeleteFeedbackQuestionAction extends Action {
 
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
-        UUID questionId;
-        FeedbackQuestion question = null;
-
-        questionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        question = logic.getFeedbackQuestion(questionId);
-
-        if (question == null) {
-            throw new EntityNotFoundException("Unknown question id");
-        }
-
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(question.getFeedbackSession().getName(),
-                question.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        UUID questionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackQuestion(requestContext, questionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
 
     }

--- a/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/DeleteFeedbackSessionAction.java
@@ -3,7 +3,6 @@ package teammates.ui.webapi;
 import java.util.UUID;
 
 import teammates.common.util.Const;
-import teammates.storage.entity.FeedbackSession;
 import teammates.ui.exception.UnauthorizedAccessException;
 
 /**
@@ -20,11 +19,7 @@ public class DeleteFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new UnauthorizedAccessException("The feedback session does not exist.");
-        }
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -136,6 +136,28 @@ final class GateKeeper {
     }
 
     /**
+     * Verifies the instructor has the privileges specified by privilegeNames for the course
+     * of the specified feedback session.
+     */
+    void verifyInstructorHasPrivilegeInFeedbackSession(RequestContext requestContext, UUID feedbackSessionId,
+            String... privilegeNames) throws UnauthorizedAccessException {
+        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
+        verifyNotNull(feedbackSession, "feedback session");
+        verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(), privilegeNames);
+    }
+
+    /**
+     * Verifies the instructor has the privileges specified by privilegeNames for the course
+     * of the specified feedback question.
+     */
+    void verifyInstructorHasPrivilegeInFeedbackQuestion(RequestContext requestContext, UUID feedbackQuestionId,
+            String... privilegeNames) throws UnauthorizedAccessException {
+        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+        verifyNotNull(feedbackQuestion, "feedback question");
+        verifyInstructorHasPrivilege(requestContext, feedbackQuestion.getCourseId(), privilegeNames);
+    }
+
+    /**
      * Verifies the instructor for the specified course has the privileges specified by privilegeNames.
      */
     void verifyInstructorHasPrivilege(RequestContext requestContext, String courseId, String... privilegeNames)

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -6,6 +6,8 @@ import teammates.common.datatransfer.RequestContext;
 import teammates.logic.api.Logic;
 import teammates.logic.core.AuthLogic;
 import teammates.logic.core.UsersLogic;
+import teammates.storage.entity.FeedbackQuestion;
+import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -101,6 +103,36 @@ final class GateKeeper {
             throw new UnauthorizedAccessException("Course [" + courseId + "] is not accessible to instructor ["
                     + instructor.getEmail() + "]");
         }
+    }
+
+    /**
+     * Verifies that the user has student privileges in the course of the specified feedback session.
+     */
+    void verifyStudentInFeedbackSession(RequestContext requestContext, UUID feedbackSessionId)
+            throws UnauthorizedAccessException {
+        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
+        verifyNotNull(feedbackSession, "feedback session");
+        verifyStudentInCourse(requestContext, feedbackSession.getCourseId());
+    }
+
+    /**
+     * Verifies that the user has instructor privileges in the course of the specified feedback session.
+     */
+    void verifyInstructorInFeedbackSession(RequestContext requestContext, UUID feedbackSessionId)
+            throws UnauthorizedAccessException {
+        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
+        verifyNotNull(feedbackSession, "feedback session");
+        verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
+    }
+
+    /**
+     * Verifies that the user has instructor privileges in the course of the specified feedback question.
+     */
+    void verifyInstructorInFeedbackQuestion(RequestContext requestContext, UUID feedbackQuestionId)
+            throws UnauthorizedAccessException {
+        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
+        verifyNotNull(feedbackQuestion, "feedback question");
+        verifyInstructorInCourse(requestContext, feedbackQuestion.getCourseId());
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
@@ -24,12 +24,7 @@ public class GetCourseSessionResultsAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInFeedbackSession(requestContext, feedbackSessionId);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetDeadlineExtensionsAction.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.storage.entity.DeadlineExtension;
-import teammates.storage.entity.FeedbackSession;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.DeadlineExtensionsData;
@@ -25,12 +24,7 @@ public class GetDeadlineExtensionsAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackQuestionsAction.java
@@ -47,7 +47,7 @@ public class GetFeedbackQuestionsAction extends BasicFeedbackSubmissionAction {
             break;
         case FULL_DETAIL:
             gateKeeper.verifyLoggedInUserPrivileges(requestContext);
-            gateKeeper.verifyInstructorInCourse(requestContext, courseId);
+            gateKeeper.verifyInstructorInFeedbackSession(requestContext, feedbackSessionId);
             break;
         case INSTRUCTOR_SUBMISSION:
             Instructor instructor = getInstructorOfCourseForSubmission(courseId, true);

--- a/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetAction.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import teammates.common.datatransfer.SubmittedGiverSetBundle;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
-import teammates.storage.entity.FeedbackSession;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.FeedbackSessionSubmittedGiverSet;
@@ -24,12 +23,7 @@ public class GetFeedbackSessionSubmittedGiverSetAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInFeedbackSession(requestContext, feedbackSessionId);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetHasResponsesAction.java
@@ -117,12 +117,6 @@ public class GetHasResponsesAction extends Action {
 
     private void checkInstructorAccessControlUsingQuestion() throws UnauthorizedAccessException {
         UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
-        if (feedbackQuestion == null) {
-            throw new EntityNotFoundException("Feedback Question not found");
-        }
-
-        String courseId = feedbackQuestion.getCourseId();
-        gateKeeper.verifyInstructorInCourse(requestContext, courseId);
+        gateKeeper.verifyInstructorInFeedbackQuestion(requestContext, feedbackQuestionId);
     }
 }

--- a/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetSessionResponseStatsAction.java
@@ -25,12 +25,7 @@ public class GetSessionResponseStatsAction extends Action {
         }
 
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorInCourse(requestContext, feedbackSession.getCourseId());
+        gateKeeper.verifyInstructorInFeedbackSession(requestContext, feedbackSessionId);
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -27,11 +27,7 @@ public class PublishFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -31,12 +31,7 @@ public class RemindFeedbackSessionResultAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -31,12 +31,7 @@ public class RemindFeedbackSessionSubmissionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/RestoreFeedbackSessionAction.java
@@ -23,12 +23,7 @@ public class RestoreFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("The feedback session does not exist.");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -27,11 +27,7 @@ public class UnpublishFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -30,12 +30,7 @@ public class UpdateDeadlineExtensionsAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackQuestionAction.java
@@ -6,7 +6,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.storage.entity.FeedbackQuestion;
-import teammates.storage.entity.FeedbackSession;
 import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.exception.UnauthorizedAccessException;
@@ -26,15 +25,7 @@ public class UpdateFeedbackQuestionAction extends Action {
     @Override
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackQuestionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        FeedbackQuestion feedbackQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
-
-        if (feedbackQuestion == null) {
-            throw new EntityNotFoundException("Unknown question id");
-        }
-
-        FeedbackSession feedbackSession = getNonNullFeedbackSession(
-                feedbackQuestion.getFeedbackSession().getName(), feedbackQuestion.getCourseId());
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackQuestion(requestContext, feedbackQuestionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateFeedbackSessionAction.java
@@ -26,12 +26,7 @@ public class UpdateFeedbackSessionAction extends Action {
     void checkSpecificAccessControl() throws UnauthorizedAccessException {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-
-        gateKeeper.verifyInstructorHasPrivilege(requestContext, feedbackSession.getCourseId(),
+        gateKeeper.verifyInstructorHasPrivilegeInFeedbackSession(requestContext, feedbackSessionId,
                 Const.InstructorPermissions.CAN_MODIFY_SESSION);
     }
 

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackQuestionActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackQuestionActionIT.java
@@ -126,7 +126,7 @@ public class CreateFeedbackQuestionActionIT extends BaseActionIT<CreateFeedbackQ
         };
 
         loginAsInstructor(instructor1OfCourse1.getGoogleId());
-        verifyEntityNotFoundAcl(submissionParams);
+        verifyCannotAccess(submissionParams);
 
         ______TS("inaccessible without ModifySessionPrivilege");
 

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackQuestionActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackQuestionActionIT.java
@@ -123,7 +123,7 @@ public class UpdateFeedbackQuestionActionIT extends BaseActionIT<UpdateFeedbackQ
 
         loginAsInstructor(instructor1OfCourse1.getAccount().getGoogleId());
 
-        verifyEntityNotFoundAcl(Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000");
+        verifyCannotAccess(Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000");
 
         ______TS("accessible only for instructor with ModifySessionPrivilege");
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Several actions fetch an entity by ID, derive the courseId then call verify methods with the courseId. 

Having entity specific methods would reduce boilerplate, clarify intent and centralise logic in GateKeeper where it can be extensively tested.