### PR TITLE
[#14128] Make Sections and Teams explicit during enrollment

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -49,7 +49,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     private static final String NO_RESPONSE_LABEL = "No Response";
     private static final String NO_TEAM_LABEL = "No Specific Team";
-    private static final String NO_SECTION_LABEL = "No specific section";
+    private static final String NO_SECTION_LABEL = "Instructors / General Recipients";
     private static final String NO_USER_LABEL = "No Specific User";
 
     private static final String MCQ_OTHER = "Other";

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -25,7 +25,7 @@ public final class Const {
     public static final String UNKNOWN_USER = "Unknown User";
     public static final String UNKNOWN_TEAM = "Unknown Team";
     public static final String UNKNOWN_SECTION = "Unknown Section";
-    public static final String DEFAULT_SECTION = "None";
+    public static final String NO_SPECIFIC_SECTION = "No Specific Section";
 
     public static final String UNKNOWN_INSTITUTION = "Unknown Institution";
 
@@ -138,7 +138,7 @@ public final class Const {
         public static final String FEEDBACK_RESPONSE_COMMENT_ID = "responsecommentid";
 
         public static final String FEEDBACK_RESULTS_GROUPBYSECTION = "frgroupbysection";
-        public static final String IS_DEFAULT_SECTION = "isdefaultsection";
+        public static final String IS_NO_SPECIFIC_SECTION = "isnospecificsection";
 
         public static final String PREVIEWAS = "previewas";
 

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1050,7 +1050,7 @@ public class Logic {
      * If it does not exist, create and return it.
      */
     public Section getDefaultSectionOrCreate(String courseId) {
-        return usersLogic.getSectionOrCreate(courseId, Const.DEFAULT_SECTION);
+        return usersLogic.getSectionOrCreate(courseId, Const.NO_SPECIFIC_SECTION);
     }
 
     /**
@@ -1234,9 +1234,9 @@ public class Logic {
      */
     public SessionResultsBundle getSessionResults(
             FeedbackSession feedbackSession, Instructor instructor,
-            @Nullable UUID questionId, @Nullable UUID sectionId, boolean isDefaultSection) {
+            @Nullable UUID questionId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
         return feedbackResponsesLogic.getSessionResults(
-                feedbackSession, instructor, questionId, sectionId, isDefaultSection);
+                feedbackSession, instructor, questionId, sectionId, isNoSpecificSection);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -852,7 +852,7 @@ public final class FeedbackResponsesLogic {
                     UUID recipientSectionId = recipient.getSectionId();
                     if (isNoSpecificSection && giverSectionId != null && recipientSectionId != null) {
                         // if isNoSpecificSection is true, either giver or recipient needs
-                        // to be in the default section (i.e. no section)
+                        // to not have a section
                         continue;
                     }
 
@@ -1068,7 +1068,7 @@ public final class FeedbackResponsesLogic {
      * @param feedbackSession the session
      * @param courseId the course ID of the session
      * @param sectionId if null, will retrieve all responses in the session
-     * @param isNoSpecificSection true if the section is the default section
+     * @param isNoSpecificSection true if filtering for no specific section
      * @return a list of responses
      */
     public List<FeedbackResponse> getFeedbackResponsesForSessionInSection(
@@ -1086,7 +1086,7 @@ public final class FeedbackResponsesLogic {
      *
      * @param feedbackQuestionId the question UUID
      * @param sectionId if null, will retrieve all responses for the question
-     * @param isNoSpecificSection true if the section is the default section
+     * @param isNoSpecificSection true if filtering for no specific section
      * @return a list of responses
      */
     public List<FeedbackResponse> getFeedbackResponsesForQuestionInSection(

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -579,7 +579,7 @@ public final class FeedbackResponsesLogic {
     }
 
     private SessionResultsBundle buildResultsBundle(
-            boolean isCourseWide, UUID sectionId, boolean isDefaultSection, User user,
+            boolean isCourseWide, UUID sectionId, boolean isNoSpecificSection, User user,
             CourseRoster roster, List<FeedbackQuestion> relatedQuestions,
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
         List<FeedbackResponse> relatedResponses = new ArrayList<>();
@@ -683,7 +683,7 @@ public final class FeedbackResponsesLogic {
         if (isCourseWide && user instanceof Instructor instructor) {
             missingResponses = buildMissingResponses(
                     instructor, responseGiverVisibilityTable, responseRecipientVisibilityTable, relatedQuestions,
-                    existingResponses, roster, sectionId, isDefaultSection);
+                    existingResponses, roster, sectionId, isNoSpecificSection);
         }
         RequestTracer.checkRemainingTime();
 
@@ -700,12 +700,12 @@ public final class FeedbackResponsesLogic {
      * @param instructor the instructor viewing the feedback session
      * @param questionId if not null, will only return partial bundle for the question
      * @param sectionId if not null, will only return partial bundle for the section
-     * @param isDefaultSection true if the section is the default section
+     * @param isNoSpecificSection true if the section is the default section
      * @return the session result bundle
      */
     public SessionResultsBundle getSessionResults(
             FeedbackSession feedbackSession, Instructor instructor,
-            @Nullable UUID questionId, @Nullable UUID sectionId, boolean isDefaultSection) {
+            @Nullable UUID questionId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
 
         String courseId = feedbackSession.getCourseId();
         CourseRoster roster = new CourseRoster(
@@ -720,14 +720,16 @@ public final class FeedbackResponsesLogic {
         List<FeedbackResponse> allResponses;
         // load all response for instructors and passively filter them later
         if (questionId == null) {
-            allResponses = getFeedbackResponsesForSessionInSection(feedbackSession, courseId, sectionId, isDefaultSection);
+            allResponses = getFeedbackResponsesForSessionInSection(
+                    feedbackSession, courseId, sectionId, isNoSpecificSection);
         } else {
-            allResponses = getFeedbackResponsesForQuestionInSection(questionId, sectionId, isDefaultSection);
+            allResponses = getFeedbackResponsesForQuestionInSection(questionId, sectionId, isNoSpecificSection);
         }
 
         RequestTracer.checkRemainingTime();
 
-        return buildResultsBundle(true, sectionId, isDefaultSection, instructor, roster, allQuestions, allResponses, false);
+        return buildResultsBundle(true, sectionId, isNoSpecificSection,
+                instructor, roster, allQuestions, allResponses, false);
     }
 
     /**
@@ -810,7 +812,7 @@ public final class FeedbackResponsesLogic {
             Instructor instructor, Map<UUID, Boolean> responseGiverVisibilityTable,
             Map<UUID, Boolean> responseRecipientVisibilityTable, List<FeedbackQuestion> relatedQuestions,
             List<FeedbackResponse> existingResponses, CourseRoster courseRoster, @Nullable UUID sectionId,
-            boolean isDefaultSection) {
+            boolean isNoSpecificSection) {
 
         // get all possible giver recipient pairs
         Map<FeedbackQuestion, Map<ResponseGiver, Set<ResponseRecipient>>> questionCompleteGiverRecipientMap =
@@ -848,8 +850,8 @@ public final class FeedbackResponsesLogic {
                 for (ResponseRecipient recipient : giverRecipientEntry.getValue()) {
                     UUID giverSectionId = giver.getSectionId();
                     UUID recipientSectionId = recipient.getSectionId();
-                    if (isDefaultSection && giverSectionId != null && recipientSectionId != null) {
-                        // if isDefaultSection is true, either giver or recipient needs
+                    if (isNoSpecificSection && giverSectionId != null && recipientSectionId != null) {
+                        // if isNoSpecificSection is true, either giver or recipient needs
                         // to be in the default section (i.e. no section)
                         continue;
                     }
@@ -1066,16 +1068,16 @@ public final class FeedbackResponsesLogic {
      * @param feedbackSession the session
      * @param courseId the course ID of the session
      * @param sectionId if null, will retrieve all responses in the session
-     * @param isDefaultSection true if the section is the default section
+     * @param isNoSpecificSection true if the section is the default section
      * @return a list of responses
      */
     public List<FeedbackResponse> getFeedbackResponsesForSessionInSection(
-            FeedbackSession feedbackSession, String courseId, @Nullable UUID sectionId, boolean isDefaultSection) {
+            FeedbackSession feedbackSession, String courseId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
         List<FeedbackResponse> responses = frDb.getFeedbackResponsesForSession(feedbackSession, courseId);
-        if (sectionId == null && !isDefaultSection) {
+        if (sectionId == null && !isNoSpecificSection) {
             return responses;
         } else {
-            return filterResponsesBySection(responses, sectionId, isDefaultSection);
+            return filterResponsesBySection(responses, sectionId, isNoSpecificSection);
         }
     }
 
@@ -1084,21 +1086,21 @@ public final class FeedbackResponsesLogic {
      *
      * @param feedbackQuestionId the question UUID
      * @param sectionId if null, will retrieve all responses for the question
-     * @param isDefaultSection true if the section is the default section
+     * @param isNoSpecificSection true if the section is the default section
      * @return a list of responses
      */
     public List<FeedbackResponse> getFeedbackResponsesForQuestionInSection(
-            UUID feedbackQuestionId, @Nullable UUID sectionId, boolean isDefaultSection) {
+            UUID feedbackQuestionId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
         List<FeedbackResponse> responses = frDb.getResponsesForQuestion(feedbackQuestionId);
-        if (sectionId == null && !isDefaultSection) {
+        if (sectionId == null && !isNoSpecificSection) {
             return responses;
         } else {
-            return filterResponsesBySection(responses, sectionId, isDefaultSection);
+            return filterResponsesBySection(responses, sectionId, isNoSpecificSection);
         }
     }
 
     private List<FeedbackResponse> filterResponsesBySection(List<FeedbackResponse> responses,
-            UUID sectionId, boolean isDefaultSection) {
+            UUID sectionId, boolean isNoSpecificSection) {
         List<FeedbackResponse> filteredResponses = new ArrayList<>();
         for (FeedbackResponse response : responses) {
             ResponseGiver giver = response.getGiver();
@@ -1108,14 +1110,14 @@ public final class FeedbackResponsesLogic {
             UUID recipientSectionId = recipient.getSectionId();
 
             boolean isGiverInSection;
-            if (isDefaultSection) {
+            if (isNoSpecificSection) {
                 isGiverInSection = giverSectionId == null;
             } else {
                 isGiverInSection = giverSectionId != null && giverSectionId.equals(sectionId);
             }
 
             boolean isRecipientInSection;
-            if (isDefaultSection) {
+            if (isNoSpecificSection) {
                 isRecipientInSection = recipientSectionId == null;
             } else {
                 isRecipientInSection = recipientSectionId != null && recipientSectionId.equals(sectionId);

--- a/src/main/java/teammates/storage/entity/ResponseGiver.java
+++ b/src/main/java/teammates/storage/entity/ResponseGiver.java
@@ -154,7 +154,7 @@ public class ResponseGiver {
             return student.getSectionName();
         }
         if (giverUser instanceof Instructor) {
-            return Const.DEFAULT_SECTION;
+            return Const.NO_SPECIFIC_SECTION;
         }
         return Const.UNKNOWN_SECTION;
     }

--- a/src/main/java/teammates/storage/entity/ResponseRecipient.java
+++ b/src/main/java/teammates/storage/entity/ResponseRecipient.java
@@ -152,7 +152,7 @@ public class ResponseRecipient {
         if (recipientType == ResponseRecipientType.TEAM) {
             return recipientTeam != null ? recipientTeam.getSection().getName() : Const.UNKNOWN_SECTION;
         } else if (recipientType == ResponseRecipientType.NO_SPECIFIC_RECIPIENT || recipientUser instanceof Instructor) {
-            return Const.DEFAULT_SECTION;
+            return Const.NO_SPECIFIC_SECTION;
         } else if (recipientUser instanceof Student student) {
             return student.getSectionName();
         } else {

--- a/src/main/java/teammates/ui/request/StudentEnrollRequest.java
+++ b/src/main/java/teammates/ui/request/StudentEnrollRequest.java
@@ -4,7 +4,6 @@ import java.util.Locale;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import teammates.common.util.Const;
 import teammates.ui.exception.InvalidHttpRequestBodyException;
 
 /**
@@ -32,7 +31,7 @@ public class StudentEnrollRequest extends BasicRequest {
         validateTrue(name != null && !name.isEmpty(), "Student name cannot be empty");
         validateTrue(email != null && !email.isEmpty(), "Student email cannot be empty");
         validateTrue(team != null && !team.isEmpty(), "Team cannot be empty");
-        validateTrue(section != null, "Section cannot be null");
+        validateTrue(section != null && !section.isEmpty(), "Section cannot be empty");
         validateTrue(comments != null, "Comments cannot be null");
     }
 

--- a/src/main/java/teammates/ui/request/StudentEnrollRequest.java
+++ b/src/main/java/teammates/ui/request/StudentEnrollRequest.java
@@ -49,7 +49,7 @@ public class StudentEnrollRequest extends BasicRequest {
     }
 
     public String getSection() {
-        return this.section.isEmpty() ? Const.NO_SPECIFIC_SECTION : this.section;
+        return this.section;
     }
 
     public String getComments() {

--- a/src/main/java/teammates/ui/request/StudentEnrollRequest.java
+++ b/src/main/java/teammates/ui/request/StudentEnrollRequest.java
@@ -49,7 +49,7 @@ public class StudentEnrollRequest extends BasicRequest {
     }
 
     public String getSection() {
-        return this.section.isEmpty() ? Const.DEFAULT_SECTION : this.section;
+        return this.section.isEmpty() ? Const.NO_SPECIFIC_SECTION : this.section;
     }
 
     public String getComments() {

--- a/src/main/java/teammates/ui/request/StudentUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/StudentUpdateRequest.java
@@ -54,7 +54,7 @@ public class StudentUpdateRequest extends BasicRequest {
     }
 
     public String getSection() {
-        return this.section.isEmpty() ? Const.DEFAULT_SECTION : SanitizationHelper.sanitizeName(this.section);
+        return this.section.isEmpty() ? Const.NO_SPECIFIC_SECTION : SanitizationHelper.sanitizeName(this.section);
     }
 
     public String getComments() {

--- a/src/main/java/teammates/ui/request/StudentUpdateRequest.java
+++ b/src/main/java/teammates/ui/request/StudentUpdateRequest.java
@@ -1,6 +1,5 @@
 package teammates.ui.request;
 
-import teammates.common.util.Const;
 import teammates.common.util.SanitizationHelper;
 import teammates.ui.exception.InvalidHttpRequestBodyException;
 
@@ -20,7 +19,7 @@ public class StudentUpdateRequest extends BasicRequest {
     }
 
     public StudentUpdateRequest(String name, String email, String team, String section, String comments,
-                                Boolean isSessionSummarySendEmail) {
+            Boolean isSessionSummarySendEmail) {
         this.name = name;
         this.email = email;
         this.team = team;
@@ -54,7 +53,7 @@ public class StudentUpdateRequest extends BasicRequest {
     }
 
     public String getSection() {
-        return this.section.isEmpty() ? Const.NO_SPECIFIC_SECTION : SanitizationHelper.sanitizeName(this.section);
+        return SanitizationHelper.sanitizeName(this.section);
     }
 
     public String getComments() {

--- a/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
@@ -33,7 +33,8 @@ public class GetCourseSessionResultsAction extends Action {
 
         UUID questionId = getNullableUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
         UUID selectedSection = getNullableUuidRequestParamValue(Const.ParamsNames.FEEDBACK_RESULTS_GROUPBYSECTION);
-        Optional<Boolean> isDefaultSection = getNullableBooleanRequestParamValue(Const.ParamsNames.IS_DEFAULT_SECTION);
+        Optional<Boolean> isNoSpecificSection =
+                getNullableBooleanRequestParamValue(Const.ParamsNames.IS_NO_SPECIFIC_SECTION);
 
         FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
         if (feedbackSession == null) {
@@ -42,7 +43,7 @@ public class GetCourseSessionResultsAction extends Action {
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
         SessionResultsBundle bundle = logic.getSessionResults(feedbackSession, instructor,
-                questionId, selectedSection, isDefaultSection.orElse(false));
+                questionId, selectedSection, isNoSpecificSection.orElse(false));
 
         return new JsonResult(SessionResultsData.init(bundle));
     }

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -10,11 +10,6 @@
     }
   },
   "sections": {
-    "sectionNone": {
-      "id": "00000000-0000-4000-8000-000000000200",
-      "name": "None",
-      "courseId": "demo.course"
-    },
     "section1": {
       "id": "00000000-0000-4000-8000-000000000201",
       "name": "Tutorial Group 1",

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
@@ -211,7 +211,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
     }
 
     @Test(groups = GroupNames.INTEGRATION)
-    public void testExecute_sectionFull_failure() throws Exception {
+    public void testExecute_sectionFull_failure() {
         Student studentToJoinMaxSection = typicalBundle.students.get("student1InCourse1");
 
         Course course = typicalBundle.courses.get("course1");
@@ -257,7 +257,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
         Team originalTeam = student4.getTeam();
 
         StudentUpdateRequest emptySectionUpdateRequest = new StudentUpdateRequest(student4.getName(), student4.getEmail(),
-                student4.getTeamName(), "", student4.getComments(), true);
+                student4.getTeamName(), "Section Name", student4.getComments(), true);
 
         String[] emptySectionSubmissionParams = new String[] {
                 Const.ParamsNames.USER_ID, student4.getId().toString(),
@@ -275,7 +275,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
             assertEquals(student4.getName(), actualStudent.getName());
             assertEquals(student4.getEmail(), actualStudent.getEmail());
             assertEquals(student4.getTeamName(), actualStudent.getTeamName());
-            assertEquals(Const.NO_SPECIFIC_SECTION, actualStudent.getSectionName());
+            assertEquals("Section Name", actualStudent.getSectionName());
             assertEquals(student4.getComments(), actualStudent.getComments());
         });
 

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
@@ -275,7 +275,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
             assertEquals(student4.getName(), actualStudent.getName());
             assertEquals(student4.getEmail(), actualStudent.getEmail());
             assertEquals(student4.getTeamName(), actualStudent.getTeamName());
-            assertEquals(Const.DEFAULT_SECTION, actualStudent.getSectionName());
+            assertEquals(Const.NO_SPECIFIC_SECTION, actualStudent.getSectionName());
             assertEquals(student4.getComments(), actualStudent.getComments());
         });
 

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
@@ -250,38 +250,6 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
         verifyNoTasksAdded();
     }
 
-    @Test(groups = GroupNames.INTEGRATION)
-    public void testExecute_renameEmptySectionNameToDefault_success() {
-        Student student4 = typicalBundle.students.get("student4InCourse1");
-
-        Team originalTeam = student4.getTeam();
-
-        StudentUpdateRequest emptySectionUpdateRequest = new StudentUpdateRequest(student4.getName(), student4.getEmail(),
-                student4.getTeamName(), "Section Name", student4.getComments(), true);
-
-        String[] emptySectionSubmissionParams = new String[] {
-                Const.ParamsNames.USER_ID, student4.getId().toString(),
-        };
-
-        UpdateStudentAction updateEmptySectionAction = getAction(emptySectionUpdateRequest, emptySectionSubmissionParams);
-        JsonResult emptySectionActionOutput = getJsonResult(updateEmptySectionAction);
-
-        MessageOutput emptySectionMsgOutput = (MessageOutput) emptySectionActionOutput.getOutput();
-        assertEquals("Student has been updated and email sent", emptySectionMsgOutput.getMessage());
-
-        inTransaction(() -> {
-            Student actualStudent = logic.getStudentForEmail(student4.getCourseId(), student4.getEmail());
-            assertEquals(student4.getCourse().getId(), actualStudent.getCourse().getId());
-            assertEquals(student4.getName(), actualStudent.getName());
-            assertEquals(student4.getEmail(), actualStudent.getEmail());
-            assertEquals(student4.getTeamName(), actualStudent.getTeamName());
-            assertEquals("Section Name", actualStudent.getSectionName());
-            assertEquals(student4.getComments(), actualStudent.getComments());
-        });
-
-        resetStudent(student4.getId(), student4.getEmail(), originalTeam, student4.getComments());
-    }
-
     @Override
     @Test(groups = GroupNames.INTEGRATION)
     protected void testAccessControl() throws Exception {

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -13,7 +13,7 @@ import {
   SessionVisibleSetting,
 } from '../../../../types/api-output';
 import { InstructorSessionResultSectionType } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
-import { DEFAULT_SECTION_ID } from '../../../pages-instructor/instructor-session-result-page/instructor-session-tab.model';
+import { NO_SPECIFIC_SECTION_ID } from '../../../pages-instructor/instructor-session-result-page/instructor-session-tab.model';
 import { ResponseModerationButtonComponent } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component';
 import { PanelChevronComponent } from '../../panel-chevron/panel-chevron.component';
 import { QuestionTextWithInfoComponent } from '../../question-text-with-info/question-text-with-info.component';
@@ -249,6 +249,6 @@ export class GqrRqgViewResponsesComponent extends InstructorResponsesViewBase im
   }
 
   private isResponseSection(responseSectionId: string | null | undefined, sectionId: string): boolean {
-    return sectionId === DEFAULT_SECTION_ID ? !responseSectionId : responseSectionId === sectionId;
+    return sectionId === NO_SPECIFIC_SECTION_ID ? !responseSectionId : responseSectionId === sectionId;
   }
 }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -12,7 +12,7 @@ import {
   SessionVisibleSetting,
 } from '../../../../types/api-output';
 import { InstructorSessionResultSectionType } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
-import { DEFAULT_SECTION_ID } from '../../../pages-instructor/instructor-session-result-page/instructor-session-tab.model';
+import { NO_SPECIFIC_SECTION_ID } from '../../../pages-instructor/instructor-session-result-page/instructor-session-tab.model';
 import { ResponseModerationButtonComponent } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component';
 import { PanelChevronComponent } from '../../panel-chevron/panel-chevron.component';
 import { GroupedResponsesComponent } from '../grouped-responses/grouped-responses.component';
@@ -213,6 +213,6 @@ export class GrqRgqViewResponsesComponent extends InstructorResponsesViewBase im
   }
 
   private isResponseSection(responseSectionId: string | null | undefined, sectionId: string): boolean {
-    return sectionId === DEFAULT_SECTION_ID ? !responseSectionId : responseSectionId === sectionId;
+    return sectionId === NO_SPECIFIC_SECTION_ID ? !responseSectionId : responseSectionId === sectionId;
   }
 }

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -288,22 +288,18 @@
           <span class="more-info-point-title">Columns Information</span>
           <ul>
             <li class="more-info-column-info">
-              <samp>Section</samp> [Required]: Section name/ID
+              <samp>Section</samp> [Auto-filled if empty]: Section name
               <ul>
-                <li class="more-info-sub-point-details">
-                  This column is required. Empty cells will be set to "Default Section".
-                </li>
+                <li class="more-info-sub-point-details">Empty cells will be set to "Default Section".</li>
               </ul>
             </li>
             <li class="more-info-column-info">
-              <samp>Team</samp> [Required]: Team name/ID
+              <samp>Team</samp> [Auto-filled if empty]: Team name
               <ul>
                 <li class="more-info-sub-point-details">
                   A team must be unique within a course. A team cannot be in 2 different sections.
                 </li>
-                <li class="more-info-sub-point-details">
-                  This column is required. Empty cells will be set to "Default Team".
-                </li>
+                <li class="more-info-sub-point-details">Empty cells will be set to "Default Team".</li>
               </ul>
             </li>
             <li class="more-info-column-info"><samp>Name</samp> [Required]: Student name</li>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -23,6 +23,8 @@
             <br />
             <i class="fas fa-info-circle"></i> If you want to enroll more than <strong>100</strong> students into one
             course, divide students into sections containing no more than <strong>100</strong> students.<br />
+            <i class="fas fa-info-circle"></i> If a section or team is left empty, students will be assigned to "Default
+            Section" or "Default Team", respectively.<br />
           </div>
           <div class="col-md-12">
             <tm-status-message [messages]="statusMessage"></tm-status-message>
@@ -286,24 +288,28 @@
           <span class="more-info-point-title">Columns Information</span>
           <ul>
             <li class="more-info-column-info">
-              <samp>Section</samp> [Compulsory for courses having more than 100 students]: Section name/ID
+              <samp>Section</samp> [Required]: Section name/ID
+              <ul>
+                <li class="more-info-sub-point-details">
+                  This column is required. Empty cells will be set to "Default Section".
+                </li>
+              </ul>
             </li>
             <li class="more-info-column-info">
-              <samp>Team</samp> [Compulsory]: Team name/ID
+              <samp>Team</samp> [Required]: Team name/ID
               <ul>
                 <li class="more-info-sub-point-details">
                   A team must be unique within a course. A team cannot be in 2 different sections.
                 </li>
                 <li class="more-info-sub-point-details">
-                  If you do not have teams in your course, use “N/A” as the team name for all students.
+                  This column is required. Empty cells will be set to "Default Team".
                 </li>
               </ul>
             </li>
-            <li class="more-info-column-info"><samp>Name</samp> [Compulsory]: Student name</li>
+            <li class="more-info-column-info"><samp>Name</samp> [Required]: Student name</li>
             <li class="more-info-column-info">
-              <samp>Email</samp> [Compulsory]: The email address used to contact the student.<br />
+              <samp>Email</samp> [Required]: The email address used to contact the student.<br />
               <ul>
-                <li class="more-info-sub-point-details">This need not be a Gmail address.</li>
                 <li class="more-info-sub-point-details">
                   It should be unique for each student. If two students are given the same email, they will be
                   considered the same student.

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -152,9 +152,11 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     // Parse the user input to be requests.
     data.forEach((row: CellValue[], index: number) => {
       if (!row.every((cell: CellValue) => normalizeCell(cell) === '')) {
+        const section = normalizeCell(row[0]) || 'Default Section';
+        const team = normalizeCell(row[1]) || 'Default Team';
         studentEnrollRequests.set(index, {
-          section: normalizeCell(row[0]),
-          team: normalizeCell(row[1]),
+          section: section,
+          team: team,
           name: normalizeCell(row[2]),
           email: normalizeCell(row[3]),
           comments: normalizeCell(row[4]),
@@ -333,17 +335,14 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
         return;
       }
 
-      if (
-        (studentEnrollRequests.size >= 100 && request.section === '') ||
-        request.team === '' ||
-        request.name === '' ||
-        request.email === ''
-      ) {
+      // Section and team are compulsory, however they should have been set to "Default Section" and "Default Team" if left empty.
+      // Therefore, we only check for the presence of name, and email.
+      if (request.name === '' || request.email === '') {
         this.invalidRowsIndex.add(key);
       }
     });
     if (this.invalidRowsIndex.size > invalidRowsOriginalSize) {
-      this.enrollErrorMessage += 'Found empty compulsory fields and/or sections with more than 100 students. ';
+      this.enrollErrorMessage += 'Found empty compulsory fields.';
     }
   }
 

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -155,8 +155,8 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
         const section = normalizeCell(row[0]) || 'Default Section';
         const team = normalizeCell(row[1]) || 'Default Team';
         studentEnrollRequests.set(index, {
-          section: section,
-          team: team,
+          section,
+          team,
           name: normalizeCell(row[2]),
           email: normalizeCell(row[3]),
           comments: normalizeCell(row[4]),

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -15,8 +15,8 @@ import { InstructorSessionResultViewType } from './instructor-session-result-vie
 import {
   SectionTabModel,
   QuestionTabModel,
-  DEFAULT_SECTION_ID,
-  DEFAULT_SECTION_NAME,
+  NO_SPECIFIC_SECTION_ID,
+  NO_SPECIFIC_SECTION_NAME,
 } from './instructor-session-tab.model';
 import { CourseService } from '../../../services/course.service';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
@@ -240,10 +240,10 @@ export class InstructorSessionResultPageComponent implements OnInit {
           // load section tabs
           this.courseService.getCourseSections(this.courseId).subscribe({
             next: (courseSections) => {
-              this.sectionsModel[DEFAULT_SECTION_ID] = {
+              this.sectionsModel[NO_SPECIFIC_SECTION_ID] = {
                 section: {
-                  sectionId: DEFAULT_SECTION_ID,
-                  sectionName: DEFAULT_SECTION_NAME,
+                  sectionId: NO_SPECIFIC_SECTION_ID,
+                  sectionName: NO_SPECIFIC_SECTION_NAME,
                 },
                 questions: [],
                 hasPopulated: false,
@@ -407,8 +407,8 @@ export class InstructorSessionResultPageComponent implements OnInit {
           return this.feedbackSessionsService.getCourseSessionResults({
             questionId,
             feedbackSessionId: this.session.feedbackSessionId,
-            groupBySection: this.isDefaultSection(sectionId) ? undefined : sectionId,
-            isDefaultSection: this.isDefaultSection(sectionId),
+            groupBySection: this.isNoSpecificSection(sectionId) ? undefined : sectionId,
+            isNoSpecificSection: this.isNoSpecificSection(sectionId),
           });
         }),
       )
@@ -466,8 +466,8 @@ export class InstructorSessionResultPageComponent implements OnInit {
     this.feedbackSessionsService
       .getCourseSessionResults({
         feedbackSessionId: this.session.feedbackSessionId,
-        groupBySection: this.isDefaultSection(sectionId) ? undefined : sectionId,
-        isDefaultSection: this.isDefaultSection(sectionId),
+        groupBySection: this.isNoSpecificSection(sectionId) ? undefined : sectionId,
+        isNoSpecificSection: this.isNoSpecificSection(sectionId),
       })
       .subscribe({
         next: (resp: SessionResults) => {
@@ -501,8 +501,8 @@ export class InstructorSessionResultPageComponent implements OnInit {
     return this.sectionsModel[sectionId]?.section.sectionName ?? sectionId;
   }
 
-  private isDefaultSection(sectionId: string): boolean {
-    return sectionId === DEFAULT_SECTION_ID;
+  private isNoSpecificSection(sectionId: string): boolean {
+    return sectionId === NO_SPECIFIC_SECTION_ID;
   }
 
   /**

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-tab.model.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-tab.model.ts
@@ -1,7 +1,8 @@
 import { CourseSection, FeedbackQuestion, QuestionOutput, ResponseOutput } from '../../../types/api-output';
 
-export const DEFAULT_SECTION_ID = 'None';
-export const DEFAULT_SECTION_NAME = 'No specific section';
+// NO_SPECIFIC_SECTION_ID and NO_SPECIFIC_SECTION_NAME are used to represent instructors and general recipients not associated with any section.
+export const NO_SPECIFIC_SECTION_ID = 'No Specific Section';
+export const NO_SPECIFIC_SECTION_NAME = 'Instructors / General Recipients';
 
 /**
  * Per section view tab model.

--- a/src/web/services/feedback-responses.service.spec.ts
+++ b/src/web/services/feedback-responses.service.spec.ts
@@ -5,7 +5,7 @@ import { FeedbackResponsesService } from './feedback-responses.service';
 import { HttpRequestService } from './http-request.service';
 import { createMockHttpRequestService, type MockHttpRequestService } from '../test-helpers/mock-http-request';
 import { InstructorSessionResultSectionType } from '../app/pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
-import { DEFAULT_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
+import { NO_SPECIFIC_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
 import { ResourceEndpoints } from '../types/api-const';
 import {
   FeedbackConstantSumOptionsResponseDetails,
@@ -346,21 +346,21 @@ describe('FeedbackResponsesService', () => {
     expect(
       service.isFeedbackResponsesDisplayedOnSection(
         response,
-        DEFAULT_SECTION_ID,
+        NO_SPECIFIC_SECTION_ID,
         InstructorSessionResultSectionType.EITHER,
       ),
     ).toBeTruthy();
     expect(
       service.isFeedbackResponsesDisplayedOnSection(
         response,
-        DEFAULT_SECTION_ID,
+        NO_SPECIFIC_SECTION_ID,
         InstructorSessionResultSectionType.GIVER,
       ),
     ).toBeTruthy();
     expect(
       service.isFeedbackResponsesDisplayedOnSection(
         response,
-        DEFAULT_SECTION_ID,
+        NO_SPECIFIC_SECTION_ID,
         InstructorSessionResultSectionType.EVALUEE,
       ),
     ).toBeFalsy();

--- a/src/web/services/feedback-responses.service.ts
+++ b/src/web/services/feedback-responses.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { HttpRequestService } from './http-request.service';
 import { InstructorSessionResultSectionType } from '../app/pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
-import { DEFAULT_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
+import { NO_SPECIFIC_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
 import { ResourceEndpoints } from '../types/api-const';
 import {
   FeedbackConstantSumOptionsResponseDetails,
@@ -157,9 +157,9 @@ export class FeedbackResponsesService {
 
     if (sectionId) {
       const isGiverInSection =
-        sectionId === DEFAULT_SECTION_ID ? response.giverSectionId == null : response.giverSectionId === sectionId;
+        sectionId === NO_SPECIFIC_SECTION_ID ? response.giverSectionId == null : response.giverSectionId === sectionId;
       const isRecipientInSection =
-        sectionId === DEFAULT_SECTION_ID
+        sectionId === NO_SPECIFIC_SECTION_ID
           ? response.recipientSectionId == null
           : response.recipientSectionId === sectionId;
 

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -31,7 +31,7 @@ import {
   FeedbackSessionUpdateRequest,
   Intent,
 } from '../types/api-request';
-import { DEFAULT_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
+import { NO_SPECIFIC_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
 
 /**
  * Handles sessions related logic provision.
@@ -369,16 +369,16 @@ export class FeedbackSessionsService {
       sectionNameForCsv?: string;
     },
   ): Observable<string> {
-    const isDefaultSection = sectionOptions?.groupBySectionId
-      ? sectionOptions.groupBySectionId === DEFAULT_SECTION_ID
+    const isNoSpecificSection = sectionOptions?.groupBySectionId
+      ? sectionOptions.groupBySectionId === NO_SPECIFIC_SECTION_ID
       : undefined;
     const groupBySectionId =
-      sectionOptions?.groupBySectionId === DEFAULT_SECTION_ID ? undefined : sectionOptions?.groupBySectionId;
+      sectionOptions?.groupBySectionId === NO_SPECIFIC_SECTION_ID ? undefined : sectionOptions?.groupBySectionId;
     return this.getCourseSessionResults({
       feedbackSessionId,
       questionId,
       groupBySection: groupBySectionId,
-      isDefaultSection: isDefaultSection,
+      isNoSpecificSection: isNoSpecificSection,
     }).pipe(
       map((results: SessionResults) =>
         this.sessionResultCsvService.getCsvForSessionResult(
@@ -402,7 +402,7 @@ export class FeedbackSessionsService {
     feedbackSessionId: string;
     questionId?: string;
     groupBySection?: string;
-    isDefaultSection?: boolean;
+    isNoSpecificSection?: boolean;
   }): Observable<SessionResults> {
     const paramMap: Record<string, string> = {
       fsid: queryParams.feedbackSessionId,
@@ -416,8 +416,8 @@ export class FeedbackSessionsService {
       paramMap['frgroupbysection'] = queryParams.groupBySection;
     }
 
-    if (queryParams.isDefaultSection !== undefined) {
-      paramMap['isdefaultsection'] = queryParams.isDefaultSection.toString();
+    if (queryParams.isNoSpecificSection !== undefined) {
+      paramMap['isnospecificsection'] = queryParams.isNoSpecificSection.toString();
     }
 
     return this.httpRequestService.get(ResourceEndpoints.COURSE_SESSION_RESULTS, paramMap);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Fixes #14128

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

1. Renamed section label for instructors/general recipients to "Instructors / General Recipients". Also renamed isDefaultSection to isNoSpecificSection for consistency.
2. Set "Default Section" and "Default Team" when enrolling students if one is not assigned.