### PR TITLE
[#13870] Add DateTimePicker component and replace existing usages

### DIFF
--- a/src/web/app/components/datetimepicker/datetimepicker.component.html
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.html
@@ -1,0 +1,23 @@
+<div class="row align-items-center">
+  <div class="col-md-7 col-xs-center">
+    <tm-datepicker
+      [isDisabled]="isDisabled"
+      [date]="date"
+      [minDate]="minDate!"
+      [maxDate]="maxDate!"
+      (dateChangeCallback)="onDateChange($event)"
+    ></tm-datepicker>
+  </div>
+  <div class="col-md-5">
+    <tm-timepicker
+      [isDisabled]="isDisabled"
+      [time]="time"
+      [date]="date"
+      [minDate]="minDateTime"
+      [maxDate]="maxDateTime"
+      [minTime]="minTime"
+      [maxTime]="maxTime"
+      (timeChange)="onTimeChange($event)"
+    ></tm-timepicker>
+  </div>
+</div>

--- a/src/web/app/components/datetimepicker/datetimepicker.component.ts
+++ b/src/web/app/components/datetimepicker/datetimepicker.component.ts
@@ -1,0 +1,60 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
+import { DateFormat, TimeFormat, getDefaultDateFormat, getDefaultTimeFormat } from '../../../types/datetime-const';
+import { DatepickerComponent } from '../datepicker/datepicker.component';
+import { TimepickerComponent } from '../timepicker/timepicker.component';
+
+/**
+ * Combined date and time picker component.
+ *
+ * <p>Wraps {@link DatepickerComponent} and {@link TimepickerComponent} into a single
+ * component so that consumers have one consistent place to manage date+time input
+ * without having to wire the two pickers together themselves.
+ */
+@Component({
+  selector: 'tm-datetimepicker',
+  templateUrl: './datetimepicker.component.html',
+  imports: [DatepickerComponent, TimepickerComponent],
+})
+export class DatetimepickerComponent {
+  @Input()
+  isDisabled = false;
+
+  @Input()
+  date: DateFormat = getDefaultDateFormat();
+
+  @Input()
+  time: TimeFormat = getDefaultTimeFormat();
+
+  @Input()
+  minDate?: NgbDateStruct;
+
+  @Input()
+  maxDate?: NgbDateStruct;
+
+  @Input()
+  minDateTime?: DateFormat;
+
+  @Input()
+  maxDateTime?: DateFormat;
+
+  @Input()
+  minTime?: TimeFormat;
+
+  @Input()
+  maxTime?: TimeFormat;
+
+  @Output()
+  dateChangeCallback: EventEmitter<DateFormat> = new EventEmitter<DateFormat>();
+
+  @Output()
+  timeChange: EventEmitter<TimeFormat> = new EventEmitter<TimeFormat>();
+
+  onDateChange(newDate: DateFormat): void {
+    this.dateChangeCallback.emit(newDate);
+  }
+
+  onTimeChange(newTime: TimeFormat): void {
+    this.timeChange.emit(newTime);
+  }
+}

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -275,29 +275,20 @@
                 </label>
               </div>
             </div>
-            <div class="row text-center align-items-center">
-              <div id="submission-start-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
-                  [isDisabled]="!model.isEditable"
-                  (dateChangeCallback)="triggerSubmissionOpeningDateModelChange('submissionStartDate', $event)"
-                  [minDate]="minDateForSubmissionStart"
-                  [maxDate]="maxDateForSubmissionStart"
-                  [date]="model.submissionStartDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="submission-start-time"
-                  [isDisabled]="!model.isEditable"
-                  (timeChange)="triggerSubmissionOpeningTimeModelChange('submissionStartTime', $event)"
-                  [minDate]="minDateForSubmissionStart"
-                  [maxDate]="maxDateForSubmissionStart"
-                  [date]="model.submissionStartDate"
-                  [minTime]="minTimeForSubmissionStart"
-                  [maxTime]="maxTimeForSubmissionStart"
-                  [time]="model.submissionStartTime"
-                ></tm-timepicker>
-              </div>
+            <div id="submission-start-date">
+              <tm-datetimepicker
+                [isDisabled]="!model.isEditable"
+                [date]="model.submissionStartDate"
+                [time]="model.submissionStartTime"
+                [minDate]="minDateForSubmissionStart"
+                [maxDate]="maxDateForSubmissionStart"
+                [minDateTime]="minDateForSubmissionStart"
+                [maxDateTime]="maxDateForSubmissionStart"
+                [minTime]="minTimeForSubmissionStart"
+                [maxTime]="maxTimeForSubmissionStart"
+                (dateChangeCallback)="triggerSubmissionOpeningDateModelChange('submissionStartDate', $event)"
+                (timeChange)="triggerSubmissionOpeningTimeModelChange('submissionStartTime', $event)"
+              ></tm-datetimepicker>
             </div>
           </div>
           <div class="col-md-4 border-left-gray">
@@ -309,27 +300,20 @@
               </div>
             </div>
             <div class="row align-items-center">
-              <div id="submission-end-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
+              <div id="submission-end-date">
+                <tm-datetimepicker
                   [isDisabled]="!model.isEditable"
-                  (dateChangeCallback)="triggerModelChange('submissionEndDate', $event)"
+                  [date]="model.submissionEndDate"
+                  [time]="model.submissionEndTime"
                   [minDate]="minDateForSubmissionEnd"
                   [maxDate]="maxDateForSubmissionEnd"
-                  [date]="model.submissionEndDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="submission-end-time"
-                  [isDisabled]="!model.isEditable"
-                  (timeChange)="triggerModelChange('submissionEndTime', $event)"
-                  [minDate]="minDateForSubmissionEnd"
-                  [maxDate]="maxDateForSubmissionEnd"
-                  [date]="model.submissionEndDate"
+                  [minDateTime]="minDateForSubmissionEnd"
+                  [maxDateTime]="maxDateForSubmissionEnd"
                   [minTime]="minTimeForSubmissionEnd"
                   [maxTime]="maxTimeForSubmissionEnd"
-                  [time]="model.submissionEndTime"
-                ></tm-timepicker>
+                  (dateChangeCallback)="triggerModelChange('submissionEndDate', $event)"
+                  (timeChange)="triggerModelChange('submissionEndTime', $event)"
+                ></tm-datetimepicker>
               </div>
             </div>
           </div>
@@ -436,27 +420,20 @@
                   </label>
                 </div>
               </div>
-              <div id="session-visibility-date" class="col-md-6">
-                <tm-datepicker
+              <div id="session-visibility-date">
+                <tm-datetimepicker
                   [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
-                  (dateChangeCallback)="triggerModelChange('customSessionVisibleDate', $event)"
+                  [date]="model.customSessionVisibleDate"
+                  [time]="model.customSessionVisibleTime"
                   [minDate]="minDateForSessionVisible"
                   [maxDate]="maxDateForSessionVisible"
-                  [date]="model.customSessionVisibleDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-4">
-                <tm-timepicker
-                  id="session-visibility-time"
-                  [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"
-                  (timeChange)="triggerModelChange('customSessionVisibleTime', $event)"
-                  [minDate]="minDateForSessionVisible"
-                  [maxDate]="maxDateForSessionVisible"
-                  [date]="model.customSessionVisibleDate"
+                  [minDateTime]="minDateForSessionVisible"
+                  [maxDateTime]="maxDateForSessionVisible"
                   [minTime]="minTimeForSessionVisible"
                   [maxTime]="maxTimeForSessionVisible"
-                  [time]="model.customSessionVisibleTime"
-                ></tm-timepicker>
+                  (dateChangeCallback)="triggerModelChange('customSessionVisibleDate', $event)"
+                  (timeChange)="triggerModelChange('customSessionVisibleTime', $event)"
+                ></tm-datetimepicker>
               </div>
             </div>
             <div class="row mt-md-1 ms-md-3">
@@ -505,24 +482,17 @@
                   </label>
                 </div>
               </div>
-              <div id="response-visibility-date" class="col-md-6">
-                <tm-datepicker
+              <div id="response-visibility-date">
+                <tm-datetimepicker
                   [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
-                  (dateChangeCallback)="triggerModelChange('customResponseVisibleDate', $event)"
-                  [minDate]="minDateForResponseVisible"
                   [date]="model.customResponseVisibleDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-4">
-                <tm-timepicker
-                  id="response-visibility-time"
-                  [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"
-                  (timeChange)="triggerModelChange('customResponseVisibleTime', $event)"
-                  [minDate]="minDateForResponseVisible"
-                  [date]="model.customResponseVisibleDate"
-                  [minTime]="minTimeForResponseVisible"
                   [time]="model.customResponseVisibleTime"
-                ></tm-timepicker>
+                  [minDate]="minDateForResponseVisible"
+                  [minDateTime]="minDateForResponseVisible"
+                  [minTime]="minTimeForResponseVisible"
+                  (dateChangeCallback)="triggerModelChange('customResponseVisibleDate', $event)"
+                  (timeChange)="triggerModelChange('customResponseVisibleTime', $event)"
+                ></tm-datetimepicker>
               </div>
             </div>
             <div class="row mt-md-2 ms-md-1">

--- a/src/web/app/components/session-edit-form/session-edit-form.component.ts
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.ts
@@ -25,15 +25,12 @@ import {
 } from '../../../types/datetime-const';
 import { FEEDBACK_SESSION_NAME_MAX_LENGTH } from '../../../types/field-validator';
 import { AjaxLoadingComponent } from '../ajax-loading/ajax-loading.component';
-import { DatePickerFormatter } from '../datepicker/datepicker-formatter';
-import { DatepickerComponent } from '../datepicker/datepicker.component';
+import { DatetimepickerComponent } from '../datetimepicker/datetimepicker.component';
 import { RichTextEditorComponent } from '../rich-text-editor/rich-text-editor.component';
 import { SimpleModalType } from '../simple-modal/simple-modal-type';
 import { PublishStatusNamePipe } from '../teammates-common/publish-status-name.pipe';
 import { SubmissionStatusNamePipe } from '../teammates-common/submission-status-name.pipe';
 import { TeammatesRouterDirective } from '../teammates-router/teammates-router.directive';
-import { TimepickerComponent } from '../timepicker/timepicker.component';
-
 /**
  * Form to Add/Edit feedback sessions.
  */
@@ -49,8 +46,7 @@ import { TimepickerComponent } from '../timepicker/timepicker.component';
     NgbTooltip,
     NgClass,
     RichTextEditorComponent,
-    DatepickerComponent,
-    TimepickerComponent,
+    DatetimepickerComponent,
     SubmissionStatusNamePipe,
     PublishStatusNamePipe,
     NgbCollapse,

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.html
@@ -130,20 +130,13 @@
                 </label>
               </div>
             </div>
-            <div class="row text-center align-items-center">
-              <div id="notification-start-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
-                  (dateChangeCallback)="triggerModelChange('startDate', $event)"
-                  [date]="model.startDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="notification-start-time"
-                  [time]="model.startTime"
-                  (timeChange)="triggerModelChange('startTime', $event)"
-                ></tm-timepicker>
-              </div>
+            <div id="notification-start-date">
+              <tm-datetimepicker
+                [date]="model.startDate"
+                [time]="model.startTime"
+                (dateChangeCallback)="triggerModelChange('startDate', $event)"
+                (timeChange)="triggerModelChange('startTime', $event)"
+              ></tm-datetimepicker>
             </div>
           </div>
           <div class="col-md-6 border-left-gray">
@@ -157,21 +150,14 @@
                 </label>
               </div>
             </div>
-            <div class="row align-items-center">
-              <div id="notification-end-date" class="col-md-7 col-xs-center">
-                <tm-datepicker
-                  (dateChangeCallback)="triggerModelChange('endDate', $event)"
-                  [minDate]="model.startDate"
-                  [date]="model.endDate"
-                ></tm-datepicker>
-              </div>
-              <div class="col-md-5">
-                <tm-timepicker
-                  id="notification-end-time"
-                  [time]="model.endTime"
-                  (timeChange)="triggerModelChange('endTime', $event)"
-                ></tm-timepicker>
-              </div>
+            <div id="notification-end-date">
+              <tm-datetimepicker
+                [date]="model.endDate"
+                [time]="model.endTime"
+                [minDate]="model.startDate"
+                (dateChangeCallback)="triggerModelChange('endDate', $event)"
+                (timeChange)="triggerModelChange('endTime', $event)"
+              ></tm-datetimepicker>
             </div>
           </div>
         </div>

--- a/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
+++ b/src/web/app/pages-admin/admin-notifications-page/notification-edit-form/notification-edit-form.component.ts
@@ -11,12 +11,11 @@ import { NotificationTargetUser, NotificationStyle } from '../../../../types/api
 import { getDefaultTimeFormat, getDefaultDateFormat } from '../../../../types/datetime-const';
 import { AjaxLoadingComponent } from '../../../components/ajax-loading/ajax-loading.component';
 import { DatePickerFormatter } from '../../../components/datepicker/datepicker-formatter';
-import { DatepickerComponent } from '../../../components/datepicker/datepicker.component';
+import { DatetimepickerComponent } from '../../../components/datetimepicker/datetimepicker.component';
 import { RichTextEditorComponent } from '../../../components/rich-text-editor/rich-text-editor.component';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { NotificationStyleClassPipe } from '../../../components/teammates-common/notification-style-class.pipe';
 import { NotificationStyleDescriptionPipe } from '../../../components/teammates-common/notification-style-description.pipe';
-import { TimepickerComponent } from '../../../components/timepicker/timepicker.component';
 
 @Component({
   selector: 'tm-notification-edit-form',
@@ -28,8 +27,7 @@ import { TimepickerComponent } from '../../../components/timepicker/timepicker.c
     FormsModule,
     NgClass,
     RichTextEditorComponent,
-    DatepickerComponent,
-    TimepickerComponent,
+    DatetimepickerComponent,
     AjaxLoadingComponent,
     KeyValuePipe,
     NotificationStyleDescriptionPipe,

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
@@ -54,23 +54,14 @@
     <div>
       <small>The new deadline of the feedback session will be:</small>
       <div id="submission-start-date">
-        <div class="input-group">
-          <tm-datepicker
-            id="submission-end-date"
-            [date]="extendToDatePicker"
-            (dateChangeCallback)="onChangeDateTime($event, DateTime.DATE)"
-            [minDate]="getDateFormat(feedbackSessionEndingTimestamp)"
-          >
-          </tm-datepicker>
-          <div class="col-md-5">
-            <tm-timepicker
-              id="submission-end-time"
-              [time]="extendToTimePicker"
-              (timeChange)="onChangeDateTime($event, DateTime.TIME)"
-            >
-            </tm-timepicker>
-          </div>
-        </div>
+        <tm-datetimepicker
+          id="submission-end-datetime"
+          [date]="extendToDatePicker"
+          [time]="extendToTimePicker"
+          [minDate]="getDateFormat(feedbackSessionEndingTimestamp)"
+          (dateChangeCallback)="onChangeDateTime($event, DateTime.DATE)"
+          (timeChange)="onChangeDateTime($event, DateTime.TIME)"
+        ></tm-datetimepicker>
       </div>
     </div>
   }

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
@@ -13,10 +13,9 @@ import {
   Hours,
   Milliseconds,
 } from '../../../../types/datetime-const';
-import { DatepickerComponent } from '../../../components/datepicker/datepicker.component';
+import { DatetimepickerComponent } from '../../../components/datetimepicker/datetimepicker.component';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { FormatDateDetailPipe } from '../../../components/teammates-common/format-date-detail.pipe';
-import { TimepickerComponent } from '../../../components/timepicker/timepicker.component';
 import { DateFormatService } from '../../../../services/date-format.service';
 
 export enum RadioOptions {
@@ -32,7 +31,7 @@ enum DateTime {
 @Component({
   selector: 'tm-individual-extension-date-modal',
   templateUrl: './individual-extension-date-modal.component.html',
-  imports: [FormsModule, DatepickerComponent, TimepickerComponent, KeyValuePipe],
+  imports: [FormsModule, DatetimepickerComponent, KeyValuePipe],
   providers: [FormatDateDetailPipe],
 })
 export class IndividualExtensionDateModalComponent {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -165,12 +165,8 @@
 >
   <div *tmIsLoading="isFeedbackSessionQuestionsLoading">
     @if (currentSelectedSessionView === allSessionViews.GROUP_RECIPIENTS) {
+      @if (recipientQuestionMap.size > 0) {
       <h1 class="my-3">Grouped Questions</h1>
-      @if (recipientQuestionMap.size === 0) {
-        <div class="card">
-          <h2 class="my-2 mx-2">There are no groupable questions</h2>
-        </div>
-      }
       @for (entry of recipientQuestionMap | keyvalue; track entry) {
         <div class="card px-4">
           <h2 class="my-4">{{ getRecipientName(entry.key) }}</h2>
@@ -214,12 +210,9 @@
           </div>
         </div>
       }
-      <h1 class="my-3">Ungrouped Questions</h1>
-      @if (ungroupableQuestionsSorted.length === 0) {
-        <div class="card">
-          <h2 class="my-2 mx-2">There are no ungroupable questions</h2>
-        </div>
       }
+      @if (ungroupableQuestionsSorted.length > 0) {
+      <h1 class="my-3">Ungrouped Questions</h1>
       @for (
         questionSubmissionForm of questionSubmissionForms;
         track questionSubmissionForm.feedbackQuestionId;
@@ -238,6 +231,7 @@
             [isQuestionCountOne]="isQuestionCountOne"
           ></tm-question-submission-form>
         }
+      }
       }
     }
     @if (currentSelectedSessionView === allSessionViews.DEFAULT) {
@@ -262,7 +256,7 @@
     }
     @if (questionsNeedingSubmission.length === 0) {
       <div class="text-center">
-        <div class="alert alert-info" role="alert">There are no questions for you to answer here!</div>
+        <div class="alert alert-info" role="alert">There are no questions for you to answer.</div>
       </div>
     } @else {
       <div class="d-flex justify-content-center gap-2 flex-wrap">


### PR DESCRIPTION
Fixes #13870

### Changes made
- Created new `tm-datetimepicker` component at `src/web/app/components/datetimepicker/` that wraps `tm-datepicker` and `tm-timepicker` into a single reusable component
- The new component forwards all relevant inputs: `date`, `time`, `isDisabled`, `minDate`, `maxDate`, `minDateTime`, `maxDateTime`, `minTime`, `maxTime`
- The new component exposes both outputs: `dateChangeCallback` and `timeChange`
- Replaced all paired `tm-datepicker` + `tm-timepicker` usages with `tm-datetimepicker` across 3 components:
  - `session-edit-form` — 4 pairs (submission start, submission end, session visible, response visible)
  - `notification-edit-form` — 2 pairs (notification start, notification end)
  - `individual-extension-date-modal` — 1 pair (extension deadline)
- Standalone `tm-timepicker` usages (e.g. in `instructor-student-activity-logs`) were left unchanged as they are not paired with a datepicker

### Steps to test
1. Open the session edit form and verify submission start/end, session visible, and response visible date+time inputs work correctly
2. Open the admin notifications page and verify notification start/end date+time inputs work correctly
3. Open the individual extension deadline modal and verify the date+time picker works correctly