### PR TITLE
[#13721] Refactor contribution stats to be keyed by ID instead of email

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumOptionsQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 
@@ -42,7 +43,7 @@ public class FeedbackConstantSumOptionsQuestionDetails extends FeedbackQuestionD
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         return "";
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumRecipientsQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.util.FeedbackConstantSumQuestionDetailsHelper;
@@ -32,7 +33,7 @@ public class FeedbackConstantSumRecipientsQuestionDetails extends FeedbackQuesti
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         return "";
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -7,11 +7,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.datatransfer.TeamEvalResult;
@@ -21,11 +20,9 @@ import teammates.common.datatransfer.visibility.FeedbackVisibilityType;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.Logger;
-import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackResponse;
 import teammates.storage.entity.Student;
-import teammates.storage.entity.User;
 
 /**
  * Contains specific structure and processing logic for contribution feedback questions.
@@ -77,107 +74,89 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         List<FeedbackResponse> responses = bundle.getQuestionResponseMap().get(question);
+        boolean isStudent = currentUserId != null;
 
-        boolean isStudent = studentEmail != null;
-
-        // Build team-name based views from the roster's student list (the contribution computation
-        // and its output are keyed by email/team name).
-        Map<String, List<Student>> teamNameToMembers = new LinkedHashMap<>();
-        Map<String, String> emailToTeamName = new HashMap<>();
-        for (Student student : bundle.getRoster().getStudents()) {
-            teamNameToMembers.computeIfAbsent(student.getTeamName(), key -> new ArrayList<>()).add(student);
-            emailToTeamName.put(student.getEmail().toLowerCase(Locale.ROOT), student.getTeamName());
-        }
-
-        List<String> teamNames;
-        if (isStudent) {
-            teamNames = getTeamsWithAtLeastOneResponse(responses);
-        } else {
-            teamNames = new ArrayList<>(teamNameToMembers.keySet());
-        }
-
-        // Each team's member (email) list
-        Map<String, List<String>> teamMembersEmail = getTeamMembersEmail(teamNameToMembers, teamNames);
-
-        // Each team's responses
-        Map<String, List<FeedbackResponse>> teamResponses = getTeamResponses(responses, teamNames);
-
-        // Get each team's submission array. -> int[teamSize][teamSize]
-        // Where int[0][1] refers points from student 0 to student 1
-        // Where student 0 is the 0th student in the list in teamMembersEmail
-        Map<String, int[][]> teamSubmissionArray = getTeamSubmissionArray(teamNames, teamMembersEmail, teamResponses);
-
-        // Each team's contribution question results.
-        Map<String, TeamEvalResult> teamResults = getTeamResults(teamNames, teamSubmissionArray);
+        Map<UUID, List<Student>> teamIdToMembers = getTeamIdToMembers(bundle);
+        List<UUID> teamIds = isStudent
+                ? getTeamsWithAtLeastOneResponse(responses)
+                : new ArrayList<>(teamIdToMembers.keySet());
+        Map<UUID, List<FeedbackResponse>> teamResponses = getTeamResponses(responses, teamIds);
+        Map<UUID, int[][]> teamSubmissionArray = getTeamSubmissionArray(teamIds, teamIdToMembers, teamResponses);
+        Map<UUID, TeamEvalResult> teamResults = getTeamResults(teamIds, teamSubmissionArray);
         ContributionStatistics output = new ContributionStatistics();
 
         if (isStudent) {
-            String currentUserTeam = emailToTeamName.get(studentEmail.toLowerCase(Locale.ROOT));
-            TeamEvalResult currentUserTeamResults = teamResults.get(currentUserTeam);
-            if (currentUserTeamResults != null) {
-                List<String> teamEmails = teamMembersEmail.get(currentUserTeam);
-                int currentUserIndex = -1;
-                for (int i = 0; i < teamEmails.size(); i++) {
-                    if (SanitizationHelper.areEmailsEqual(teamEmails.get(i), studentEmail)) {
-                        currentUserIndex = i;
-                        break;
-                    }
-                }
-                if (currentUserIndex < 0) {
-                    return JsonUtils.toJson(output);
-                }
-                int[] claimedNumbers = currentUserTeamResults.claimed[currentUserIndex];
-                int[] perceivedNumbers = currentUserTeamResults.denormalizedAveragePerceived[currentUserIndex];
-
-                int claimed = 0;
-                int perceived = 0;
-                Map<String, Integer> claimedOthers = new HashMap<>();
-                List<Integer> perceivedOthers = new ArrayList<>();
-
-                for (int i = 0; i < claimedNumbers.length; i++) {
-                    if (i == currentUserIndex) {
-                        claimed = claimedNumbers[i];
-                    } else {
-                        claimedOthers.put(teamEmails.get(i), claimedNumbers[i]);
-                    }
-                }
-
-                for (int i = 0; i < perceivedNumbers.length; i++) {
-                    if (i == currentUserIndex) {
-                        perceived = perceivedNumbers[i];
-                    } else {
-                        perceivedOthers.add(perceivedNumbers[i]);
-                    }
-                }
-                perceivedOthers.sort(Comparator.reverseOrder());
-
-                output.results.put(studentEmail, new ContributionStatisticsEntry(claimed, perceived,
-                        claimedOthers,
-                        perceivedOthers.stream().mapToInt(i -> i).toArray()));
+            Student currentStudent = getStudentByUserId(bundle, currentUserId);
+            if (currentStudent == null) {
+                return JsonUtils.toJson(output);
             }
-        } else {
-            Map<String, int[]> studentResults = getStudentResults(teamMembersEmail, teamResults);
 
-            for (Map.Entry<String, int[]> entry : studentResults.entrySet()) {
+            UUID currentTeamId = currentStudent.getTeamId();
+            TeamEvalResult currentUserTeamResults = teamResults.get(currentTeamId);
+            List<Student> teamMembers = teamIdToMembers.get(currentTeamId);
+            int currentUserIndex = teamMembers == null ? -1 : indexOfStudent(teamMembers, currentUserId);
+            if (currentUserTeamResults == null || currentUserIndex < 0) {
+                return JsonUtils.toJson(output);
+            }
+
+            int[] claimedNumbers = currentUserTeamResults.claimed[currentUserIndex];
+            int[] perceivedNumbers = currentUserTeamResults.denormalizedAveragePerceived[currentUserIndex];
+
+            int claimed = 0;
+            int perceived = 0;
+            Map<String, Integer> claimedOthers = new LinkedHashMap<>();
+            List<Integer> perceivedOthers = new ArrayList<>();
+
+            for (int i = 0; i < claimedNumbers.length; i++) {
+                if (i == currentUserIndex) {
+                    claimed = claimedNumbers[i];
+                } else {
+                    claimedOthers.put(teamMembers.get(i).getId().toString(), claimedNumbers[i]);
+                }
+            }
+
+            for (int i = 0; i < perceivedNumbers.length; i++) {
+                if (i == currentUserIndex) {
+                    perceived = perceivedNumbers[i];
+                } else {
+                    perceivedOthers.add(perceivedNumbers[i]);
+                }
+            }
+            perceivedOthers.sort(Comparator.reverseOrder());
+
+            output.results.put(currentUserId.toString(), new ContributionStatisticsEntry(
+                    claimed, perceived, claimedOthers, perceivedOthers.stream().mapToInt(i -> i).toArray()));
+        } else {
+            Map<UUID, int[]> studentResults = getStudentResults(teamIdToMembers, teamResults);
+
+            for (Map.Entry<UUID, int[]> entry : studentResults.entrySet()) {
                 int[] summary = entry.getValue();
-                String email = entry.getKey();
-                String team = emailToTeamName.get(email.toLowerCase(Locale.ROOT));
-                List<String> teamEmails = teamMembersEmail.get(team);
-                TeamEvalResult teamResult = teamResults.get(team);
-                int studentIndex = teamEmails.indexOf(email);
-                Map<String, Integer> claimedOthers = new HashMap<>();
+                UUID studentId = entry.getKey();
+                Student student = getStudentByUserId(bundle, studentId);
+                if (student == null) {
+                    continue;
+                }
+                List<Student> teamMembers = teamIdToMembers.get(student.getTeamId());
+                TeamEvalResult teamResult = teamResults.get(student.getTeamId());
+                int studentIndex = teamMembers == null ? -1 : indexOfStudent(teamMembers, studentId);
+                if (teamResult == null || studentIndex < 0) {
+                    continue;
+                }
+
+                Map<String, Integer> claimedOthers = new LinkedHashMap<>();
                 List<Integer> perceivedOthers = new ArrayList<>();
                 for (int i = 0; i < teamResult.normalizedPeerContributionRatio.length; i++) {
                     if (i != studentIndex) {
-                        claimedOthers.put(teamEmails.get(i), teamResult.normalizedPeerContributionRatio[studentIndex][i]);
+                        claimedOthers.put(teamMembers.get(i).getId().toString(),
+                                teamResult.normalizedPeerContributionRatio[studentIndex][i]);
                         perceivedOthers.add(teamResult.normalizedPeerContributionRatio[i][studentIndex]);
                     }
                 }
                 perceivedOthers.sort(Comparator.reverseOrder());
 
-                output.results.put(email, new ContributionStatisticsEntry(summary[SUMMARY_INDEX_CLAIMED],
+                output.results.put(studentId.toString(), new ContributionStatisticsEntry(summary[SUMMARY_INDEX_CLAIMED],
                         summary[SUMMARY_INDEX_PERCEIVED],
                         claimedOthers, perceivedOthers.stream().mapToInt(i -> i).toArray()));
             }
@@ -186,101 +165,112 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         return JsonUtils.toJson(output);
     }
 
-    private Map<String, int[]> getStudentResults(
-            Map<String, List<String>> teamMembersEmail,
-            Map<String, TeamEvalResult> teamResults) {
-        Map<String, int[]> studentResults = new LinkedHashMap<>();
-        teamResults.forEach((key, teamResult) -> {
-            List<String> teamEmails = teamMembersEmail.get(key);
-            for (int i = 0; i < teamEmails.size(); i++) {
-                String studentEmail = teamEmails.get(i);
+    private Map<UUID, List<Student>> getTeamIdToMembers(SessionResultsBundle bundle) {
+        Map<UUID, List<Student>> teamIdToMembers = new LinkedHashMap<>();
+        for (Student student : bundle.getRoster().getStudents()) {
+            teamIdToMembers.computeIfAbsent(student.getTeamId(), key -> new ArrayList<>()).add(student);
+        }
+        return teamIdToMembers;
+    }
+
+    private Student getStudentByUserId(SessionResultsBundle bundle, UUID studentId) {
+        return bundle.getRoster().getStudents().stream()
+                .filter(student -> Objects.equals(student.getId(), studentId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private int indexOfStudent(List<Student> students, UUID studentId) {
+        for (int i = 0; i < students.size(); i++) {
+            if (Objects.equals(students.get(i).getId(), studentId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private Map<UUID, int[]> getStudentResults(
+            Map<UUID, List<Student>> teamIdToMembers,
+            Map<UUID, TeamEvalResult> teamResults) {
+        Map<UUID, int[]> studentResults = new LinkedHashMap<>();
+        teamResults.forEach((teamId, teamResult) -> {
+            List<Student> teamMembers = teamIdToMembers.get(teamId);
+            for (int i = 0; i < teamMembers.size(); i++) {
                 int[] summary = new int[2];
                 summary[SUMMARY_INDEX_CLAIMED] = teamResult.normalizedClaimed[i][i];
                 summary[SUMMARY_INDEX_PERCEIVED] = teamResult.normalizedAveragePerceived[i];
 
-                studentResults.put(studentEmail, summary);
+                studentResults.put(teamMembers.get(i).getId(), summary);
             }
         });
         return studentResults;
     }
 
-    private Map<String, TeamEvalResult> getTeamResults(List<String> teamNames,
-            Map<String, int[][]> teamSubmissionArray) {
-        Map<String, TeamEvalResult> teamResults = new LinkedHashMap<>();
-        for (String team : teamNames) {
-            TeamEvalResult teamEvalResult = new TeamEvalResult(teamSubmissionArray.get(team));
-            teamResults.put(team, teamEvalResult);
+    private Map<UUID, TeamEvalResult> getTeamResults(List<UUID> teamIds,
+            Map<UUID, int[][]> teamSubmissionArray) {
+        Map<UUID, TeamEvalResult> teamResults = new LinkedHashMap<>();
+        for (UUID teamId : teamIds) {
+            TeamEvalResult teamEvalResult = new TeamEvalResult(teamSubmissionArray.get(teamId));
+            teamResults.put(teamId, teamEvalResult);
         }
         return teamResults;
     }
 
-    private Map<String, int[][]> getTeamSubmissionArray(List<String> teamNames,
-                                                        Map<String, List<String>> teamMembersEmail,
-                                                        Map<String, List<FeedbackResponse>> teamResponses) {
-        Map<String, int[][]> teamSubmissionArray = new LinkedHashMap<>();
-        for (String team : teamNames) {
-            int teamSize = teamMembersEmail.get(team).size();
-            teamSubmissionArray.put(team, new int[teamSize][teamSize]);
+    private Map<UUID, int[][]> getTeamSubmissionArray(List<UUID> teamIds,
+                                                      Map<UUID, List<Student>> teamIdToMembers,
+                                                      Map<UUID, List<FeedbackResponse>> teamResponses) {
+        Map<UUID, int[][]> teamSubmissionArray = new LinkedHashMap<>();
+        for (UUID teamId : teamIds) {
+            List<Student> teamMembers = teamIdToMembers.getOrDefault(teamId, List.of());
+            int teamSize = teamMembers.size();
+            teamSubmissionArray.put(teamId, new int[teamSize][teamSize]);
             //Initialize all as not submitted.
             for (int i = 0; i < teamSize; i++) {
                 for (int j = 0; j < teamSize; j++) {
-                    teamSubmissionArray.get(team)[i][j] = Const.POINTS_NOT_SUBMITTED;
+                    teamSubmissionArray.get(teamId)[i][j] = Const.POINTS_NOT_SUBMITTED;
                 }
             }
             //Fill in submitted points
-            List<FeedbackResponse> teamResponseList = teamResponses.get(team);
-            List<String> memberEmailList = teamMembersEmail.get(team);
+            List<FeedbackResponse> teamResponseList = teamResponses.getOrDefault(teamId, List.of());
             for (FeedbackResponse response : teamResponseList) {
-                User giverUser = response.getGiver().getGiverUser();
-                User recipientUser = response.getRecipient().getRecipientUser();
-                if (giverUser == null || recipientUser == null) {
+                UUID giverUserId = response.getGiver().getGiverUserId();
+                UUID recipientUserId = response.getRecipient().getRecipientUserId();
+                if (giverUserId == null || recipientUserId == null) {
                     continue;
                 }
-                int giverIndx = memberEmailList.indexOf(giverUser.getEmail());
-                int recipientIndx = memberEmailList.indexOf(recipientUser.getEmail());
+                int giverIndx = indexOfStudent(teamMembers, giverUserId);
+                int recipientIndx = indexOfStudent(teamMembers, recipientUserId);
                 if (giverIndx == -1 || recipientIndx == -1) {
                     continue;
                 }
                 int points = ((FeedbackContributionResponseDetails) response.getFeedbackResponseDetailsCopy()).getAnswer();
-                teamSubmissionArray.get(team)[giverIndx][recipientIndx] = points;
+                teamSubmissionArray.get(teamId)[giverIndx][recipientIndx] = points;
             }
         }
         return teamSubmissionArray;
     }
 
-    private Map<String, List<FeedbackResponse>> getTeamResponses(
-            List<FeedbackResponse> responses, List<String> teamNames) {
-        Map<String, List<FeedbackResponse>> teamResponses = new LinkedHashMap<>();
-        for (String teamName : teamNames) {
-            teamResponses.put(teamName, new ArrayList<>());
+    private Map<UUID, List<FeedbackResponse>> getTeamResponses(
+            List<FeedbackResponse> responses, List<UUID> teamIds) {
+        Map<UUID, List<FeedbackResponse>> teamResponses = new LinkedHashMap<>();
+        for (UUID teamId : teamIds) {
+            teamResponses.put(teamId, new ArrayList<>());
         }
         for (FeedbackResponse response : responses) {
-            String team = response.getGiver().getTeamName();
-            if (teamResponses.containsKey(team)) {
-                teamResponses.get(team).add(response);
+            UUID teamId = response.getGiver().getTeamId();
+            if (teamResponses.containsKey(teamId)) {
+                teamResponses.get(teamId).add(response);
             }
         }
         return teamResponses;
     }
 
-    private Map<String, List<String>> getTeamMembersEmail(
-            Map<String, List<Student>> teamNameToMembers, List<String> teamNames) {
-        Map<String, List<String>> teamMembersEmail = new LinkedHashMap<>();
-        for (String teamName : teamNames) {
-            List<String> memberEmails = teamNameToMembers.getOrDefault(teamName, List.of())
-                    .stream().map(Student::getEmail)
-                    .collect(Collectors.toList());
-            teamMembersEmail.put(teamName, memberEmails);
-        }
-        return teamMembersEmail;
-    }
-
-    private List<String> getTeamsWithAtLeastOneResponse(List<FeedbackResponse> responses) {
-        Set<String> teamNames = new HashSet<>();
+    private List<UUID> getTeamsWithAtLeastOneResponse(List<FeedbackResponse> responses) {
+        Set<UUID> teamIds = new HashSet<>();
         for (FeedbackResponse response : responses) {
-            teamNames.add(response.getGiver().getTeamName());
+            teamIds.add(response.getGiver().getTeamId());
         }
-        return new ArrayList<>(teamNames);
+        return new ArrayList<>(teamIds);
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
@@ -51,7 +52,7 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
@@ -71,7 +72,7 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -5,6 +5,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.storage.entity.FeedbackQuestion;
@@ -36,7 +37,7 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -1,6 +1,7 @@
 package teammates.common.datatransfer.questions;
 
 import java.util.List;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -51,7 +52,7 @@ public abstract class FeedbackQuestionDetails {
     * Get question result statistics as JSON string.
     */
     public abstract String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle);
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle);
 
     /**
      * Checks whether the changes to the question details require deletion of corresponding responses.

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.util.Const;
@@ -40,7 +41,7 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.common.util.Const;
@@ -24,7 +25,7 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
 import teammates.storage.entity.FeedbackQuestion;
@@ -51,7 +52,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer.questions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 
@@ -33,7 +34,7 @@ public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
 
     @Override
     public String getQuestionResultStatisticsJson(
-            FeedbackQuestion question, String studentEmail, SessionResultsBundle bundle) {
+            FeedbackQuestion question, UUID currentUserId, SessionResultsBundle bundle) {
         // Statistics are calculated in the frontend as they depend on the responses being filtered.
         return "";
     }

--- a/src/main/java/teammates/storage/entity/ResponseRecipient.java
+++ b/src/main/java/teammates/storage/entity/ResponseRecipient.java
@@ -133,6 +133,20 @@ public class ResponseRecipient {
     }
 
     /**
+     * Gets the team ID of the recipient: the team's own ID for team recipients, the student's team ID for
+     * student recipients, or {@code null} otherwise.
+     */
+    public UUID getTeamId() {
+        if (recipientType == ResponseRecipientType.TEAM) {
+            return getRecipientTeamId();
+        }
+        if (recipientUser instanceof Student student) {
+            return student.getTeamId();
+        }
+        return null;
+    }
+
+    /**
      * Gets the section ID of the recipient.
      */
     public UUID getSectionId() {

--- a/src/main/java/teammates/ui/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/output/SessionResultsData.java
@@ -83,7 +83,7 @@ public class SessionResultsData implements ApiOutput {
 
             String questionStatistics = hasResponseButNotVisibleForPreview
                     ? ""
-                    : questionDetails.getQuestionResultStatisticsJson(question, user.getEmail(), bundle);
+                    : questionDetails.getQuestionResultStatisticsJson(question, user.getId(), bundle);
             QuestionOutput qnOutput = new QuestionOutput(question,
                     questionStatistics,
                     hasResponseButNotVisibleForPreview,
@@ -185,11 +185,15 @@ public class SessionResultsData implements ApiOutput {
         return ResponseOutput.builder()
                 .withResponseId(response.getId().toString())
                 .withGiver(giverName)
+                .withGiverUserId(giver.getGiverUserId())
+                .withGiverTeamId(giver.getTeamId())
                 .withGiverTeam(giverTeam)
                 .withGiverEmail(null)
                 .withGiverSectionName(giver.getSectionName())
                 .withGiverSectionId(giver.getSectionId())
                 .withRecipient(recipientName)
+                .withRecipientUserId(recipient.getRecipientUserId())
+                .withRecipientTeamId(recipient.getTeamId())
                 .withRecipientTeam(recipientTeam)
                 .withRecipientEmail(null)
                 .withRecipientSectionName(recipient.getSectionName())
@@ -259,12 +263,16 @@ public class SessionResultsData implements ApiOutput {
                 .withIsMissingResponse(false)
                 .withResponseId(response.getId().toString())
                 .withGiver(giverName)
+                .withGiverUserId(responseGiver.getGiverUserId())
+                .withGiverTeamId(responseGiver.getTeamId())
                 .withGiverTeam(giverTeam)
                 .withGiverEmail(giverEmail)
                 .withUserIdForModeration(userIdForModeration)
                 .withGiverSectionName(giverSectionName)
                 .withGiverSectionId(responseGiver.getSectionId())
                 .withRecipient(recipientName)
+                .withRecipientUserId(responseRecipient.getRecipientUserId())
+                .withRecipientTeamId(responseRecipient.getTeamId())
                 .withRecipientTeam(recipientTeam)
                 .withRecipientEmail(recipientEmail)
                 .withRecipientSectionName(recipientSectionName)
@@ -326,12 +334,16 @@ public class SessionResultsData implements ApiOutput {
                 .withIsMissingResponse(true)
                 .withResponseId(response.id().toString())
                 .withGiver(giverName)
+                .withGiverUserId(responseGiver.getGiverUserId())
+                .withGiverTeamId(responseGiver.getTeamId())
                 .withGiverTeam(giverTeam)
                 .withGiverEmail(giverEmail)
                 .withUserIdForModeration(userIdForModeration)
                 .withGiverSectionName(giverSectionName)
                 .withGiverSectionId(responseGiver.getSectionId())
                 .withRecipient(recipientName)
+                .withRecipientUserId(responseRecipient.getRecipientUserId())
+                .withRecipientTeamId(responseRecipient.getTeamId())
                 .withRecipientTeam(recipientTeam)
                 .withRecipientEmail(recipientEmail)
                 .withRecipientSectionName(recipientSectionName)
@@ -456,6 +468,10 @@ public class SessionResultsData implements ApiOutput {
         private String giver;
         @Nullable
         private String userIdForModeration;
+        @Nullable
+        private String giverUserId;
+        @Nullable
+        private UUID giverTeamId;
         private String giverTeam;
         @Nullable
         private String giverEmail;
@@ -464,7 +480,11 @@ public class SessionResultsData implements ApiOutput {
         private String giverSection;
         private String recipient;
         @Nullable
+        private String recipientUserId;
+        @Nullable
         private UUID recipientSectionId;
+        @Nullable
+        private UUID recipientTeamId;
         private String recipientTeam;
         @Nullable
         private String recipientEmail;
@@ -500,6 +520,11 @@ public class SessionResultsData implements ApiOutput {
         }
 
         @Nullable
+        public String getGiverUserId() {
+            return giverUserId;
+        }
+
+        @Nullable
         public String getGiverEmail() {
             return giverEmail;
         }
@@ -511,6 +536,11 @@ public class SessionResultsData implements ApiOutput {
 
         public String getGiverTeam() {
             return giverTeam;
+        }
+
+        @Nullable
+        public UUID getGiverTeamId() {
+            return giverTeamId;
         }
 
         public String getGiverSection() {
@@ -525,8 +555,18 @@ public class SessionResultsData implements ApiOutput {
             return recipient;
         }
 
+        @Nullable
+        public String getRecipientUserId() {
+            return recipientUserId;
+        }
+
         public String getRecipientTeam() {
             return recipientTeam;
+        }
+
+        @Nullable
+        public UUID getRecipientTeamId() {
+            return recipientTeamId;
         }
 
         @Nullable
@@ -585,6 +625,16 @@ public class SessionResultsData implements ApiOutput {
                 return this;
             }
 
+            Builder withGiverUserId(@Nullable UUID giverUserId) {
+                responseOutput.giverUserId = giverUserId == null ? null : giverUserId.toString();
+                return this;
+            }
+
+            Builder withGiverTeamId(@Nullable UUID giverTeamId) {
+                responseOutput.giverTeamId = giverTeamId;
+                return this;
+            }
+
             Builder withGiverTeam(String giverTeam) {
                 responseOutput.giverTeam = giverTeam;
                 return this;
@@ -607,6 +657,16 @@ public class SessionResultsData implements ApiOutput {
 
             Builder withRecipient(String recipientName) {
                 responseOutput.recipient = recipientName;
+                return this;
+            }
+
+            Builder withRecipientUserId(@Nullable UUID recipientUserId) {
+                responseOutput.recipientUserId = recipientUserId == null ? null : recipientUserId.toString();
+                return this;
+            }
+
+            Builder withRecipientTeamId(@Nullable UUID recipientTeamId) {
+                responseOutput.recipientTeamId = recipientTeamId;
                 return this;
             }
 

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetailsTest.java
@@ -3,13 +3,14 @@ package teammates.common.datatransfer.questions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static teammates.test.AssertHelper.assertJsonEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -20,8 +21,12 @@ import teammates.common.datatransfer.participanttypes.QuestionGiverType;
 import teammates.common.datatransfer.participanttypes.QuestionRecipientType;
 import teammates.common.datatransfer.visibility.FeedbackVisibilityType;
 import teammates.common.util.Const;
+import teammates.common.util.JsonUtils;
+import teammates.storage.entity.Student;
 import teammates.storage.entity.questions.FeedbackContributionQuestion;
 import teammates.test.BaseTestCase;
+
+import tools.jackson.core.type.TypeReference;
 
 /**
  * SUT: {@link FeedbackContributionQuestionDetails}.
@@ -378,366 +383,109 @@ public class FeedbackContributionQuestionDetailsTest extends BaseTestCase {
                         new ArrayList<>(responseBundle.instructors.values())));
 
         FeedbackContributionQuestion fqa;
+        Student student1 = responseBundle.students.get("student1InCourse1");
+        Student student2 = responseBundle.students.get("student2InCourse1");
+        Student student3 = responseBundle.students.get("student3InCourse1");
+        Student student5 = responseBundle.students.get("student5InCourse1");
+        Student student6 = responseBundle.students.get("student6InCourse1");
+        Student student7 = responseBundle.students.get("student7InCourse1");
+        Student student8 = responseBundle.students.get("student8InCourse1");
 
-        ______TS("(student email specified): all students have response");
+        ______TS("(student user ID specified): all students have response");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        assertJsonEquals("""
-                        {
-                          "results": {
-                            "student1incourse1@gmail.tmt": {
-                              "claimed": 10,
-                              "perceived": 17,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": 20,
-                                "student3incourse1@gmail.tmt": 30
-                              },
-                              "perceivedOthers": [
-                                24,
-                                19
-                              ]
-                            }
-                          }
-                        }""",
-                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa,
-                        "student1incourse1@gmail.tmt", resultsBundle));
+        Map<String, Map<String, Object>> studentStats = getContributionResults(
+                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, student1.getId(), resultsBundle));
+        assertEquals(1, studentStats.size());
+        Map<String, Object> student1Entry = studentStats.get(student1.getId().toString());
+        assertEquals(10, intField(student1Entry, "claimed"));
+        assertEquals(17, intField(student1Entry, "perceived"));
+        assertEquals(Map.of(student2.getId().toString(), 20, student3.getId().toString(), 30),
+                intMapField(student1Entry, "claimedOthers"));
+        assertEquals(List.of(24, 19), intListField(student1Entry, "perceivedOthers"));
 
-        ______TS("(student email specified): mix of students with responses and students without responses");
+        ______TS("(student user ID specified): mix of students with responses and students without responses");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        assertJsonEquals("""
-                        {
-                          "results": {
-                            "student5incourse1@gmail.tmt": {
-                              "claimed": 10,
-                              "perceived": 15,
-                              "claimedOthers": {
-                                "student4incourse1@gmail.tmt": -999,
-                                "student6incourse1@gmail.tmt": 20
-                              },
-                              "perceivedOthers": [
-                                15,
-                                -9999
-                              ]
-                            }
-                          }
-                        }""",
-                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa,
-                        "student5incourse1@gmail.tmt", resultsBundle));
+        studentStats = getContributionResults(
+                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, student5.getId(), resultsBundle));
+        assertEquals(1, studentStats.size());
+        Map<String, Object> student5Entry = studentStats.get(student5.getId().toString());
+        assertEquals(10, intField(student5Entry, "claimed"));
+        assertEquals(15, intField(student5Entry, "perceived"));
+        assertEquals(Map.of(student6.getId().toString(), 20),
+                intMapField(student5Entry, "claimedOthers"));
+        assertEquals(List.of(15), intListField(student5Entry, "perceivedOthers"));
 
-        ______TS("(student email specified): all students do not have responses");
+        ______TS("(student user ID specified): all students do not have responses");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        assertJsonEquals("""
-                        {
-                          "results": {}
-                        }""",
-                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa,
-                        "student8incourse1@gmail.tmt", resultsBundle));
+        studentStats = getContributionResults(
+                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, student8.getId(), resultsBundle));
+        assertTrue(studentStats.isEmpty());
 
-        ______TS("(student email not specified): qn1");
+        ______TS("(student user ID not specified): qn1");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn1InSession1InCourse1");
-        assertJsonEquals("""
-                        {
-                          "results": {
-                            "student8incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student7incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999
-                              ]
-                            },
-                            "student2incourse1@gmail.tmt": {
-                              "claimed": 100,
-                              "perceived": 93,
-                              "claimedOthers": {
-                                "student1incourse1@gmail.tmt": 80,
-                                "student3incourse1@gmail.tmt": 120
-                              },
-                              "perceivedOthers": [
-                                107,
-                                80
-                              ]
-                            },
-                            "student5incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student4incourse1@gmail.tmt": -9999,
-                                "student6incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student1incourse1@gmail.tmt": {
-                              "claimed": 50,
-                              "perceived": 87,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": 80,
-                                "student3incourse1@gmail.tmt": 120
-                              },
-                              "perceivedOthers": [
-                                93,
-                                80
-                              ]
-                            },
-                            "student4incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student5incourse1@gmail.tmt": -9999,
-                                "student6incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student3incourse1@gmail.tmt": {
-                              "claimed": 113,
-                              "perceived": 120,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": 107,
-                                "student1incourse1@gmail.tmt": 93
-                              },
-                              "perceivedOthers": [
-                                120,
-                                120
-                              ]
-                            },
-                            "student6incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student5incourse1@gmail.tmt": -9999,
-                                "student4incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student7incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student8incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999
-                              ]
-                            }
-                          }
-                        }""",
-                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null,
-                        resultsBundle));
+        Map<String, Map<String, Object>> instructorStats = getContributionResults(
+                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null, resultsBundle));
+        assertEquals(8, instructorStats.size());
+        Map<String, Object> student2Entry = instructorStats.get(student2.getId().toString());
+        assertEquals(100, intField(student2Entry, "claimed"));
+        assertEquals(93, intField(student2Entry, "perceived"));
+        assertEquals(Map.of(student1.getId().toString(), 80, student3.getId().toString(), 120),
+                intMapField(student2Entry, "claimedOthers"));
+        assertEquals(List.of(107, 80), intListField(student2Entry, "perceivedOthers"));
+        Map<String, Object> student8Entry = instructorStats.get(student8.getId().toString());
+        assertEquals(-999, intField(student8Entry, "claimed"));
+        assertEquals(-9999, intField(student8Entry, "perceived"));
+        assertEquals(Map.of(student7.getId().toString(), -9999), intMapField(student8Entry, "claimedOthers"));
 
-        ______TS("(student email not specified): qn2");
+        ______TS("(student user ID not specified): qn2");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn2InSession1InCourse1");
-        assertJsonEquals("""
-                        {
-                          "results": {
-                            "student8incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student7incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999
-                              ]
-                            },
-                            "student2incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student1incourse1@gmail.tmt": -9999,
-                                "student3incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student5incourse1@gmail.tmt": {
-                              "claimed": 67,
-                              "perceived": 100,
-                              "claimedOthers": {
-                                "student4incourse1@gmail.tmt": -9999,
-                                "student6incourse1@gmail.tmt": 100
-                              },
-                              "perceivedOthers": [
-                                100,
-                                -9999
-                              ]
-                            },
-                            "student1incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": -9999,
-                                "student3incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student4incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student5incourse1@gmail.tmt": -9999,
-                                "student6incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student3incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": -9999,
-                                "student1incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student6incourse1@gmail.tmt": {
-                              "claimed": 114,
-                              "perceived": 100,
-                              "claimedOthers": {
-                                "student5incourse1@gmail.tmt": 100,
-                                "student4incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                100,
-                                -9999
-                              ]
-                            },
-                            "student7incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student8incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999
-                              ]
-                            }
-                          }
-                        }""",
-                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null,
-                        resultsBundle));
+        instructorStats = getContributionResults(
+                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null, resultsBundle));
+        assertEquals(8, instructorStats.size());
+        student5Entry = instructorStats.get(student5.getId().toString());
+        assertEquals(67, intField(student5Entry, "claimed"));
+        assertEquals(100, intField(student5Entry, "perceived"));
+        assertEquals(Map.of(student6.getId().toString(), 100),
+                intMapField(student5Entry, "claimedOthers"));
+        Map<String, Object> student6Entry = instructorStats.get(student6.getId().toString());
+        assertEquals(114, intField(student6Entry, "claimed"));
+        assertEquals(100, intField(student6Entry, "perceived"));
+        assertEquals(Map.of(student5.getId().toString(), 100),
+                intMapField(student6Entry, "claimedOthers"));
 
-        ______TS("(student email not specified): qn3");
+        ______TS("(student user ID not specified): qn3");
         fqa = (FeedbackContributionQuestion) responseBundle.feedbackQuestions.get("qn3InSession1InCourse1");
-        assertJsonEquals("""
-                        {
-                          "results": {
-                            "student8incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student7incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999
-                              ]
-                            },
-                            "student2incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student1incourse1@gmail.tmt": -9999,
-                                "student3incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student5incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student4incourse1@gmail.tmt": -9999,
-                                "student6incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student1incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": -9999,
-                                "student3incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student4incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student5incourse1@gmail.tmt": -9999,
-                                "student6incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student3incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student2incourse1@gmail.tmt": -9999,
-                                "student1incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student6incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student5incourse1@gmail.tmt": -9999,
-                                "student4incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999,
-                                -9999
-                              ]
-                            },
-                            "student7incourse1@gmail.tmt": {
-                              "claimed": -999,
-                              "perceived": -9999,
-                              "claimedOthers": {
-                                "student8incourse1@gmail.tmt": -9999
-                              },
-                              "perceivedOthers": [
-                                -9999
-                              ]
-                            }
-                          }
-                        }""",
-                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null,
-                        resultsBundle));
+        instructorStats = getContributionResults(
+                feedbackContributionQuestionDetails.getQuestionResultStatisticsJson(fqa, null, resultsBundle));
+        assertEquals(8, instructorStats.size());
+        assertTrue(instructorStats.values().stream()
+                .allMatch(entry -> intField(entry, "claimed") == -999 && intField(entry, "perceived") == -9999));
 
+    }
+
+    private Map<String, Map<String, Object>> getContributionResults(String json) {
+        Map<String, Map<String, Map<String, Object>>> stats = JsonUtils.fromJson(
+                json, new TypeReference<>() { });
+        return stats.get("results");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Integer> intMapField(Map<String, Object> entry, String field) {
+        Map<String, Object> rawMap = (Map<String, Object>) entry.get(field);
+        Map<String, Integer> parsedMap = new LinkedHashMap<>();
+        rawMap.forEach((key, value) -> parsedMap.put(key, ((Number) value).intValue()));
+        return parsedMap;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Integer> intListField(Map<String, Object> entry, String field) {
+        return ((List<Object>) entry.get(field)).stream()
+                .map(value -> ((Number) value).intValue())
+                .toList();
+    }
+
+    private int intField(Map<String, Object> entry, String field) {
+        return ((Number) entry.get(field)).intValue();
     }
 
 }

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -46,8 +46,8 @@
                   [class.color-neutral]="response.allResponses[0].isMissingResponse"
                   [responseDetails]="response.allResponses[0].responseDetails"
                   [questionDetails]="response.feedbackQuestion.questionDetails"
-                  [giverEmail]="response.allResponses[0].giverEmail!"
-                  [recipientEmail]="response.allResponses[0].recipientEmail!"
+                  [giverUserId]="response.allResponses[0].giverUserId!"
+                  [recipientUserId]="response.allResponses[0].recipientUserId!"
                   [statistics]="response.questionStatistics"
                 ></tm-single-response>
                 @if (

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -120,8 +120,8 @@
               <tm-single-response
                 [responseDetails]="response.responseDetails"
                 [questionDetails]="question.questionDetails"
-                [giverEmail]="response.giverEmail!"
-                [recipientEmail]="response.recipientEmail!"
+                [giverUserId]="response.giverUserId!"
+                [recipientUserId]="response.recipientUserId!"
                 [statistics]="statistics"
               ></tm-single-response>
             </td>

--- a/src/web/app/components/question-responses/single-response/single-response.component.html
+++ b/src/web/app/components/question-responses/single-response/single-response.component.html
@@ -2,8 +2,8 @@
   <tm-contribution-question-response
     [responseDetails]="responseDetails"
     [statistics]="statistics"
-    [giverEmail]="giverEmail"
-    [recipientEmail]="recipientEmail"
+    [giverUserId]="giverUserId"
+    [recipientUserId]="recipientUserId"
   ></tm-contribution-question-response>
 }
 

--- a/src/web/app/components/question-responses/single-response/single-response.component.ts
+++ b/src/web/app/components/question-responses/single-response/single-response.component.ts
@@ -52,8 +52,8 @@ export class SingleResponseComponent {
 
   @Input() isStudentPage = false;
   @Input() statistics = '';
-  @Input() giverEmail = '';
-  @Input() recipientEmail = '';
+  @Input() giverUserId = '';
+  @Input() recipientUserId = '';
 
   constructor() {
     this.QuestionDetailsTypeChecker = QuestionDetailsTypeChecker;

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.html
@@ -15,8 +15,8 @@
                 [responseDetails]="response.responseDetails"
                 [questionDetails]="feedbackQuestion.questionDetails"
                 [isStudentPage]="true"
-                [giverEmail]="response.giverEmail!"
-                [recipientEmail]="response.recipientEmail!"
+                [giverUserId]="response.giverUserId!"
+                [recipientUserId]="response.recipientUserId!"
                 [statistics]="statistics"
               ></tm-single-response>
             </td>

--- a/src/web/app/components/question-types/question-response/contribution-question-response.component.ts
+++ b/src/web/app/components/question-types/question-response/contribution-question-response.component.ts
@@ -7,7 +7,6 @@ import {
   CONTRIBUTION_POINT_NOT_SUBMITTED,
   CONTRIBUTION_POINT_NOT_SURE,
 } from '../../../../types/feedback-response-details';
-import { areEmailsEqual } from '../../teammates-common/email-utils';
 
 /**
  * Contribution question response.
@@ -21,8 +20,8 @@ import { areEmailsEqual } from '../../teammates-common/email-utils';
 export class ContributionQuestionResponseComponent implements OnInit {
   @Input() responseDetails: FeedbackContributionResponseDetails = DEFAULT_CONTRIBUTION_RESPONSE_DETAILS();
   @Input() statistics = '';
-  @Input() giverEmail = '';
-  @Input() recipientEmail = '';
+  @Input() giverUserId = '';
+  @Input() recipientUserId = '';
 
   answer = 100;
 
@@ -40,12 +39,15 @@ export class ContributionQuestionResponseComponent implements OnInit {
 
   ngOnInit(): void {
     this.answer = this.responseDetails.answer;
-    if (this.statistics) {
+    if (this.statistics && this.giverUserId && this.recipientUserId) {
       const statisticsObject: ContributionStatistics = JSON.parse(this.statistics);
-      if (areEmailsEqual(this.giverEmail, this.recipientEmail)) {
-        this.answer = statisticsObject.results[this.giverEmail].claimed;
-      } else {
-        this.answer = statisticsObject.results[this.giverEmail].claimedOthers[this.recipientEmail];
+      const giverStats = statisticsObject.results[this.giverUserId];
+      if (giverStats) {
+        if (this.giverUserId === this.recipientUserId) {
+          this.answer = giverStats.claimed;
+        } else if (giverStats.claimedOthers[this.recipientUserId] !== undefined) {
+          this.answer = giverStats.claimedOthers[this.recipientUserId];
+        }
       }
     }
   }

--- a/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/contribution-question-statistics/contribution-question-statistics.component.ts
@@ -92,39 +92,41 @@ export class ContributionQuestionStatisticsComponent implements OnChanges {
       { header: 'Ratings Received', headerToolTip: 'The list of points that this student received from others' },
     ];
 
-    this.rowsData = Object.keys(stats.emailToName).map((email: string) => {
+    this.rowsData = Object.keys(stats.userIdToName).map((userId: string) => {
+      const email = stats.userIdToEmail[userId];
+      const recipientLabel = email ? `${stats.userIdToName[userId]} (${email})` : stats.userIdToName[userId];
       return [
-        { value: stats.emailToTeamName[email] },
-        { value: `${stats.emailToName[email]} (${email})` },
+        { value: stats.userIdToTeamName[userId] },
+        { value: recipientLabel },
         {
-          value: statistics.results[email].claimed,
+          value: statistics.results[userId].claimed,
           customComponent: {
             component: ContributionComponent,
             componentData: () => {
               return {
-                value: statistics.results[email].claimed,
+                value: statistics.results[userId].claimed,
               };
             },
           },
         },
         {
-          value: statistics.results[email].perceived,
+          value: statistics.results[userId].perceived,
           customComponent: {
             component: ContributionComponent,
             componentData: () => {
               return {
-                value: statistics.results[email].perceived,
+                value: statistics.results[userId].perceived,
               };
             },
           },
         },
         {
-          value: stats.emailToDiff[email],
+          value: stats.userIdToDiff[userId],
           customComponent: {
             component: ContributionComponent,
             componentData: () => {
               return {
-                value: stats.emailToDiff[email],
+                value: stats.userIdToDiff[userId],
                 diffOnly: true,
               };
             },
@@ -135,7 +137,7 @@ export class ContributionQuestionStatisticsComponent implements OnChanges {
             component: ContributionRatingsListComponent,
             componentData: () => {
               return {
-                ratingsList: statistics.results[email].perceivedOthers,
+                ratingsList: statistics.results[userId].perceivedOthers,
               };
             },
           },

--- a/src/web/app/utils/question-statistics.util.spec.ts
+++ b/src/web/app/utils/question-statistics.util.spec.ts
@@ -922,6 +922,9 @@ describe('Question Statistics Utility Functions', () => {
   });
 
   describe('calculateContributionQuestionStatistics', () => {
+    const bobUserId = 'bob-user-id';
+    const charlieUserId = 'charlie-user-id';
+
     it('should return empty stats when statistics string is empty', () => {
       const responses: Response<FeedbackContributionResponseDetails>[] = [];
       const statistics = '';
@@ -933,9 +936,9 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToTeamName).toEqual({});
-      expect(stats.emailToName).toEqual({});
-      expect(stats.emailToDiff).toEqual({});
+      expect(stats.userIdToTeamName).toEqual({});
+      expect(stats.userIdToName).toEqual({});
+      expect(stats.userIdToDiff).toEqual({});
       expect(stats.questionOverallStatistics?.results).toEqual({});
     });
 
@@ -948,9 +951,9 @@ describe('Question Statistics Utility Functions', () => {
         false,
       );
 
-      expect(statsWithNull.emailToTeamName).toEqual({});
-      expect(statsWithNull.emailToName).toEqual({});
-      expect(statsWithNull.emailToDiff).toEqual({});
+      expect(statsWithNull.userIdToTeamName).toEqual({});
+      expect(statsWithNull.userIdToName).toEqual({});
+      expect(statsWithNull.userIdToDiff).toEqual({});
     });
 
     it('should calculate statistics correctly for student view', () => {
@@ -983,8 +986,8 @@ describe('Question Statistics Utility Functions', () => {
         'peer2@example.com': 55,
       });
       expect(stats.questionStatisticsForStudent?.claimedOthersValues).toEqual([55, 20]);
-      expect(stats.emailToTeamName).toEqual({});
-      expect(stats.emailToName).toEqual({});
+      expect(stats.userIdToTeamName).toEqual({});
+      expect(stats.userIdToName).toEqual({});
     });
 
     it('should calculate statistics correctly for instructor view with positive differences', () => {
@@ -995,6 +998,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'bob@example.com',
           recipientSection: '',
@@ -1009,6 +1013,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'charlie@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'bob@example.com',
           recipientSection: '',
@@ -1020,7 +1025,7 @@ describe('Question Statistics Utility Functions', () => {
       ];
       const statistics = JSON.stringify({
         results: {
-          'bob@example.com': {
+          [bobUserId]: {
             claimed: 20,
             perceived: 35,
             claimedOthers: {},
@@ -1036,17 +1041,20 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToTeamName).toEqual({
-        'bob@example.com': 'Team B',
+      expect(stats.userIdToTeamName).toEqual({
+        [bobUserId]: 'Team B',
       });
-      expect(stats.emailToName).toEqual({
-        'bob@example.com': 'Bob',
+      expect(stats.userIdToName).toEqual({
+        [bobUserId]: 'Bob',
       });
-      expect(stats.emailToDiff).toEqual({
-        'bob@example.com': 15, // 35 - 20
+      expect(stats.userIdToDiff).toEqual({
+        [bobUserId]: 15,
+      });
+      expect(stats.userIdToEmail).toEqual({
+        [bobUserId]: 'bob@example.com',
       });
       expect(stats.questionOverallStatistics?.results).toEqual({
-        'bob@example.com': {
+        [bobUserId]: {
           claimed: 20,
           perceived: 35,
           claimedOthers: {},
@@ -1063,6 +1071,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'bob@example.com',
           recipientSection: '',
@@ -1074,7 +1083,7 @@ describe('Question Statistics Utility Functions', () => {
       ];
       const statistics = JSON.stringify({
         results: {
-          'bob@example.com': {
+          [bobUserId]: {
             claimed: -1,
             perceived: 35,
             claimedOthers: {},
@@ -1090,7 +1099,7 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToDiff['bob@example.com']).toBe(CONTRIBUTION_POINT_NOT_SUBMITTED); // CONTRIBUTION_POINT_NOT_SUBMITTED
+      expect(stats.userIdToDiff[bobUserId]).toBe(CONTRIBUTION_POINT_NOT_SUBMITTED);
     });
 
     it('should calculate statistics correctly for instructor view with negative perceived values', () => {
@@ -1101,6 +1110,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'bob@example.com',
           recipientSection: '',
@@ -1112,7 +1122,7 @@ describe('Question Statistics Utility Functions', () => {
       ];
       const statistics = JSON.stringify({
         results: {
-          'bob@example.com': {
+          [bobUserId]: {
             claimed: 25,
             perceived: -1,
             claimedOthers: {},
@@ -1128,7 +1138,7 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToDiff['bob@example.com']).toBe(CONTRIBUTION_POINT_NOT_SUBMITTED);
+      expect(stats.userIdToDiff[bobUserId]).toBe(CONTRIBUTION_POINT_NOT_SUBMITTED);
     });
 
     it('should handle responses without recipientEmail for instructor view', () => {
@@ -1139,6 +1149,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team B',
           recipientEmail: undefined,
           recipientSection: '',
@@ -1159,9 +1170,14 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToTeamName).toEqual({});
-      expect(stats.emailToName).toEqual({});
-      expect(stats.emailToDiff).toEqual({});
+      expect(stats.userIdToTeamName).toEqual({
+        [bobUserId]: 'Team B',
+      });
+      expect(stats.userIdToName).toEqual({
+        [bobUserId]: 'Bob',
+      });
+      expect(stats.userIdToEmail).toEqual({});
+      expect(stats.userIdToDiff).toEqual({});
     });
 
     it('should calculate statistics correctly for multiple recipients in instructor view', () => {
@@ -1172,6 +1188,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'bob@example.com',
           recipientSection: '',
@@ -1186,6 +1203,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Charlie',
+          recipientUserId: charlieUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'charlie@example.com',
           recipientSection: '',
@@ -1197,13 +1215,13 @@ describe('Question Statistics Utility Functions', () => {
       ];
       const statistics = JSON.stringify({
         results: {
-          'bob@example.com': {
+          [bobUserId]: {
             claimed: 20,
             perceived: 35,
             claimedOthers: {},
             perceivedOthers: [],
           },
-          'charlie@example.com': {
+          [charlieUserId]: {
             claimed: 30,
             perceived: 40,
             claimedOthers: {},
@@ -1219,17 +1237,17 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToTeamName).toEqual({
-        'bob@example.com': 'Team B',
-        'charlie@example.com': 'Team B',
+      expect(stats.userIdToTeamName).toEqual({
+        [bobUserId]: 'Team B',
+        [charlieUserId]: 'Team B',
       });
-      expect(stats.emailToName).toEqual({
-        'bob@example.com': 'Bob',
-        'charlie@example.com': 'Charlie',
+      expect(stats.userIdToName).toEqual({
+        [bobUserId]: 'Bob',
+        [charlieUserId]: 'Charlie',
       });
-      expect(stats.emailToDiff).toEqual({
-        'bob@example.com': 15, // 35 - 20
-        'charlie@example.com': 10, // 40 - 30
+      expect(stats.userIdToDiff).toEqual({
+        [bobUserId]: 15,
+        [charlieUserId]: 10,
       });
     });
 
@@ -1271,6 +1289,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Bob',
+          recipientUserId: bobUserId,
           recipientTeam: 'Team A',
           recipientEmail: 'bob@example.com',
           recipientSection: '',
@@ -1285,6 +1304,7 @@ describe('Question Statistics Utility Functions', () => {
           giverEmail: 'alice@example.com',
           giverSection: '',
           recipient: 'Charlie',
+          recipientUserId: charlieUserId,
           recipientTeam: 'Team B',
           recipientEmail: 'charlie@example.com',
           recipientSection: '',
@@ -1296,13 +1316,13 @@ describe('Question Statistics Utility Functions', () => {
       ];
       const statistics = JSON.stringify({
         results: {
-          'bob@example.com': {
+          [bobUserId]: {
             claimed: 20,
             perceived: 35,
             claimedOthers: {},
             perceivedOthers: [],
           },
-          'charlie@example.com': {
+          [charlieUserId]: {
             claimed: 30,
             perceived: 40,
             claimedOthers: {},
@@ -1318,10 +1338,10 @@ describe('Question Statistics Utility Functions', () => {
         isStudent,
       );
 
-      expect(stats.emailToTeamName['bob@example.com']).toBe('Team A');
-      expect(stats.emailToTeamName['charlie@example.com']).toBe('Team B');
-      expect(stats.emailToName['bob@example.com']).toBe('Bob');
-      expect(stats.emailToName['charlie@example.com']).toBe('Charlie');
+      expect(stats.userIdToTeamName[bobUserId]).toBe('Team A');
+      expect(stats.userIdToTeamName[charlieUserId]).toBe('Team B');
+      expect(stats.userIdToName[bobUserId]).toBe('Bob');
+      expect(stats.userIdToName[charlieUserId]).toBe('Charlie');
     });
   });
 });

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -130,9 +130,10 @@ export function calculateContributionQuestionStatistics(
   isStudent: boolean,
 ): ContributionQuestionStatistics {
   const stats: ContributionQuestionStatistics = {
-    emailToTeamName: {},
-    emailToName: {},
-    emailToDiff: {},
+    userIdToTeamName: {},
+    userIdToName: {},
+    userIdToEmail: {},
+    userIdToDiff: {},
     questionOverallStatistics: {
       results: {},
     },
@@ -160,29 +161,36 @@ export function calculateContributionQuestionStatistics(
     }
   } else {
     for (const response of responses) {
-      // the recipient email will always exist for contribution question when viewing by instructors
-      if (!response.recipientEmail) {
+      // the recipientId will always exist for contribution question when viewing by instructors
+      if (!response.recipientUserId) {
         continue;
       }
 
-      if (!stats.emailToTeamName[response.recipientEmail]) {
-        stats.emailToTeamName[response.recipientEmail] = response.recipientTeam;
+      if (!stats.userIdToTeamName[response.recipientUserId]) {
+        stats.userIdToTeamName[response.recipientUserId] = response.recipientTeam;
       }
-      if (!stats.emailToName[response.recipientEmail]) {
-        stats.emailToName[response.recipientEmail] = response.recipient;
+      if (!stats.userIdToName[response.recipientUserId]) {
+        stats.userIdToName[response.recipientUserId] = response.recipient;
+      }
+      if (response.recipientEmail && !stats.userIdToEmail[response.recipientUserId]) {
+        stats.userIdToEmail[response.recipientUserId] = response.recipientEmail;
       }
     }
 
     stats.questionOverallStatistics = statisticsObject;
 
-    for (const email of Object.keys(stats.emailToName)) {
-      const statisticsForEmail: ContributionStatisticsEntry = stats.questionOverallStatistics.results[email];
-      const { claimed }: { claimed: number } = statisticsForEmail;
-      const { perceived }: { perceived: number } = statisticsForEmail;
+    for (const userId of Object.keys(stats.userIdToName)) {
+      const statisticsForUser: ContributionStatisticsEntry | undefined =
+        stats.questionOverallStatistics.results[userId];
+      if (!statisticsForUser) {
+        continue;
+      }
+      const { claimed }: { claimed: number } = statisticsForUser;
+      const { perceived }: { perceived: number } = statisticsForUser;
       if (claimed < 0 || perceived < 0) {
-        stats.emailToDiff[email] = CONTRIBUTION_POINT_NOT_SUBMITTED;
+        stats.userIdToDiff[userId] = CONTRIBUTION_POINT_NOT_SUBMITTED;
       } else {
-        stats.emailToDiff[email] = perceived - claimed;
+        stats.userIdToDiff[userId] = perceived - claimed;
       }
     }
   }

--- a/src/web/services/test-data/feedback-session-results-contrib-results-restricted-sections.ts
+++ b/src/web/services/test-data/feedback-session-results-contrib-results-restricted-sections.ts
@@ -12,6 +12,9 @@ import {
   QuestionRecipientType,
 } from '../../types/api-output';
 
+const student3UserId = '09f330c2-8b2d-4dd4-a8e5-6ec511418ff2';
+const student4UserId = 'e4589528-3337-451a-9b47-3f851f834775';
+
 const feedbackSessionResultsContribResultsRestrictedSections: SessionResults = {
   questions: [
     {
@@ -36,33 +39,11 @@ const feedbackSessionResultsContribResultsRestrictedSections: SessionResults = {
       },
       questionStatistics: `{
   "results": {
-    "student3InCourseWithSections@gmail.tmt": {
+    "${student3UserId}": {
       "claimed": 100,
       "perceived": -9999,
       "claimedOthers": {},
       "perceivedOthers": []
-    },
-    "student1InCourseWithSections@gmail.tmt": {
-      "claimed": -999,
-      "perceived": -9999,
-      "claimedOthers": {},
-      "perceivedOthers": [
-        -9999
-      ]
-    },
-    "student4InCourseWithSections@gmail.tmt": {
-      "claimed": -999,
-      "perceived": -9999,
-      "claimedOthers": {},
-      "perceivedOthers": []
-    },
-    "student2InCourseWithSections@gmail.tmt": {
-      "claimed": -999,
-      "perceived": -9999,
-      "claimedOthers": {},
-      "perceivedOthers": [
-        -9999
-      ]
     }
   }
 }`,
@@ -71,11 +52,13 @@ const feedbackSessionResultsContribResultsRestrictedSections: SessionResults = {
           isMissingResponse: false,
           responseId: `agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGD8M%student3InCourseWithSections@gmail.tmt%student3InCourseWithSections@gmail.tmt`,
           giver: `student3 In Course With Sections`,
-          userIdForModeration: `09f330c2-8b2d-4dd4-a8e5-6ec511418ff2`,
+          userIdForModeration: student3UserId,
+          giverUserId: student3UserId,
           giverTeam: `Team 2`,
           giverEmail: `student3InCourseWithSections@gmail.tmt`,
           giverSection: `Section 2`,
           recipient: `student3 In Course With Sections`,
+          recipientUserId: student3UserId,
           recipientTeam: `Team 2`,
           recipientEmail: `student3InCourseWithSections@gmail.tmt`,
           recipientSection: `Section 2`,
@@ -89,11 +72,13 @@ const feedbackSessionResultsContribResultsRestrictedSections: SessionResults = {
           isMissingResponse: true,
           responseId: `agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGD8M%student4InCourseWithSections@gmail.tmt%student4InCourseWithSections@gmail.tmt`,
           giver: `student4 In Course With Sections`,
-          userIdForModeration: `e4589528-3337-451a-9b47-3f851f834775`,
+          userIdForModeration: student4UserId,
+          giverUserId: student4UserId,
           giverTeam: `Team 3`,
           giverEmail: `student4InCourseWithSections@gmail.tmt`,
           giverSection: `Section 3`,
           recipient: `student4 In Course With Sections`,
+          recipientUserId: student4UserId,
           recipientTeam: `Team 3`,
           recipientEmail: `student4InCourseWithSections@gmail.tmt`,
           recipientSection: `Section 3`,

--- a/src/web/services/test-data/feedback-session-results-contrib-results.ts
+++ b/src/web/services/test-data/feedback-session-results-contrib-results.ts
@@ -12,6 +12,11 @@ import {
   QuestionRecipientType,
 } from '../../types/api-output';
 
+const student1UserId = 'student1-user-id';
+const student2UserId = 'student2-user-id';
+const student3UserId = 'student3-user-id';
+const student4UserId = 'student4-user-id';
+
 const feedbackSessionResultsContribResults: SessionResults = {
   questions: [
     {
@@ -36,7 +41,7 @@ const feedbackSessionResultsContribResults: SessionResults = {
       },
       questionStatistics: `{
   "results": {
-    "student2InCourse1@gmail.tmt": {
+    "${student2UserId}": {
       "claimed": -999,
       "perceived": 75,
       "claimedOthers": {},
@@ -46,13 +51,7 @@ const feedbackSessionResultsContribResults: SessionResults = {
         -9999
       ]
     },
-    "student5InCourse1@gmail.tmt": {
-      "claimed": -999,
-      "perceived": -9999,
-      "claimedOthers": {},
-      "perceivedOthers": []
-    },
-    "student1InCourse1@gmail.tmt": {
+    "${student1UserId}": {
       "claimed": 95,
       "perceived": -9999,
       "claimedOthers": {},
@@ -62,7 +61,7 @@ const feedbackSessionResultsContribResults: SessionResults = {
         -9999
       ]
     },
-    "student4InCourse1@gmail.tmt": {
+    "${student4UserId}": {
       "claimed": -999,
       "perceived": 122,
       "claimedOthers": {},
@@ -72,7 +71,7 @@ const feedbackSessionResultsContribResults: SessionResults = {
         -9999
       ]
     },
-    "student3InCourse1@gmail.tmt": {
+    "${student3UserId}": {
       "claimed": -999,
       "perceived": 103,
       "claimedOthers": {},
@@ -89,11 +88,13 @@ const feedbackSessionResultsContribResults: SessionResults = {
           isMissingResponse: false,
           responseId: `agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGDYM%student1InCourse1@gmail.tmt%student3InCourse1@gmail.tmt`,
           giver: `student1 In Course1</td></div>'"`,
-          userIdForModeration: `c35dc7b8-ee63-48b3-93dc-d781803f9a03`,
+          userIdForModeration: student1UserId,
+          giverUserId: student1UserId,
           giverTeam: `Team 1.1</td></div>'"`,
           giverEmail: `student1InCourse1@gmail.tmt`,
           giverSection: `None`,
           recipient: `student3 In Course1`,
+          recipientUserId: student3UserId,
           recipientTeam: `Team 1.1</td></div>'"`,
           recipientEmail: `student3InCourse1@gmail.tmt`,
           recipientSection: `None`,
@@ -107,11 +108,13 @@ const feedbackSessionResultsContribResults: SessionResults = {
           isMissingResponse: false,
           responseId: `agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGDYM%student1InCourse1@gmail.tmt%student1InCourse1@gmail.tmt`,
           giver: `student1 In Course1</td></div>'"`,
-          userIdForModeration: `c35dc7b8-ee63-48b3-93dc-d781803f9a03`,
+          userIdForModeration: student1UserId,
+          giverUserId: student1UserId,
           giverTeam: `Team 1.1</td></div>'"`,
           giverEmail: `student1InCourse1@gmail.tmt`,
           giverSection: `None`,
           recipient: `student1 In Course1</td></div>'"`,
+          recipientUserId: student1UserId,
           recipientTeam: `Team 1.1</td></div>'"`,
           recipientEmail: `student1InCourse1@gmail.tmt`,
           recipientSection: `None`,
@@ -125,11 +128,13 @@ const feedbackSessionResultsContribResults: SessionResults = {
           isMissingResponse: false,
           responseId: `agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGDYM%student1InCourse1@gmail.tmt%student4InCourse1@gmail.tmt`,
           giver: `student1 In Course1</td></div>'"`,
-          userIdForModeration: `c35dc7b8-ee63-48b3-93dc-d781803f9a03`,
+          userIdForModeration: student1UserId,
+          giverUserId: student1UserId,
           giverTeam: `Team 1.1</td></div>'"`,
           giverEmail: `student1InCourse1@gmail.tmt`,
           giverSection: `None`,
           recipient: `student4 In Course1`,
+          recipientUserId: student4UserId,
           recipientTeam: `Team 1.1</td></div>'"`,
           recipientEmail: `student4InCourse1@gmail.tmt`,
           recipientSection: `None`,
@@ -144,11 +149,13 @@ const feedbackSessionResultsContribResults: SessionResults = {
           isMissingResponse: false,
           responseId: `agR0ZXN0chYLEhBGZWVkYmFja1F1ZXN0aW9uGDYM%student1InCourse1@gmail.tmt%student2InCourse1@gmail.tmt`,
           giver: `student1 In Course1</td></div>'"`,
-          userIdForModeration: `c35dc7b8-ee63-48b3-93dc-d781803f9a03`,
+          userIdForModeration: student1UserId,
+          giverUserId: student1UserId,
           giverTeam: `Team 1.1</td></div>'"`,
           giverEmail: `student1InCourse1@gmail.tmt`,
           giverSection: `None`,
           recipient: `student2 In Course1`,
+          recipientUserId: student2UserId,
           recipientTeam: `Team 1.1</td></div>'"`,
           recipientEmail: `student2InCourse1@gmail.tmt`,
           recipientSection: `None`,

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -489,12 +489,16 @@ export interface ResponseOutput {
   responseId: string;
   giver: string;
   userIdForModeration?: string;
+  giverUserId?: string;
+  giverTeamId?: string;
   giverTeam: string;
   giverEmail?: string;
   giverSectionId?: string;
   giverSection: string;
   recipient: string;
+  recipientUserId?: string;
   recipientSectionId?: string;
+  recipientTeamId?: string;
   recipientTeam: string;
   recipientEmail?: string;
   recipientSection: string;

--- a/src/web/types/question-details-impl/feedback-contribution-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-contribution-question-details.impl.ts
@@ -62,14 +62,15 @@ export class FeedbackContributionQuestionDetailsImpl
       perceivedStr: string;
       ratingsReceivedStr: string[];
     }[] = [];
-    for (const email of Object.keys(statsCalculation.emailToName)) {
-      const teamName: string = statsCalculation.emailToTeamName[email];
-      const name: string = statsCalculation.emailToName[email];
-      const claimed: number = statsCalculation.questionOverallStatistics.results[email].claimed;
+    for (const userId of Object.keys(statsCalculation.userIdToName)) {
+      const teamName: string = statsCalculation.userIdToTeamName[userId];
+      const name: string = statsCalculation.userIdToName[userId];
+      const email: string = statsCalculation.userIdToEmail[userId] ?? '';
+      const claimed: number = statsCalculation.questionOverallStatistics.results[userId].claimed;
       const claimedStr: string = this.getContributionPointToText(claimed);
-      const perceived: number = statsCalculation.questionOverallStatistics.results[email].perceived;
+      const perceived: number = statsCalculation.questionOverallStatistics.results[userId].perceived;
       const perceivedStr: string = this.getContributionPointToText(perceived);
-      const ratingsReceivedStr: string[] = statsCalculation.questionOverallStatistics.results[email].perceivedOthers
+      const ratingsReceivedStr: string[] = statsCalculation.questionOverallStatistics.results[userId].perceivedOthers
         .concat()
         .sort((a: number, b: number) => b - a)
         .map(this.getContributionPointToText);

--- a/src/web/types/question-statistics.model.ts
+++ b/src/web/types/question-statistics.model.ts
@@ -9,11 +9,15 @@ import { ContributionStatistics, ContributionStatisticsEntry, FeedbackResponseDe
  */
 export interface Response<R extends FeedbackResponseDetails> {
   giver: string;
+  giverUserId?: string;
   giverEmail?: string;
+  giverTeamId?: string;
   giverTeam: string;
   giverSection: string;
   recipient: string;
+  recipientUserId?: string;
   recipientEmail?: string;
+  recipientTeamId?: string;
   recipientTeam: string;
   recipientSection: string;
   responseDetails: R;
@@ -35,9 +39,10 @@ export interface ConstsumRecipientsQuestionStatistics {
 }
 
 export interface ContributionQuestionStatistics {
-  emailToTeamName: Record<string, string>;
-  emailToName: Record<string, string>;
-  emailToDiff: Record<string, number>;
+  userIdToTeamName: Record<string, string>;
+  userIdToName: Record<string, string>;
+  userIdToEmail: Record<string, string>;
+  userIdToDiff: Record<string, number>;
   questionOverallStatistics?: ContributionStatistics;
   questionStatisticsForStudent?: ContributionStatisticsEntry & { claimedOthersValues: number[] };
 }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Currently, contribution statistics are keyed by student name and team name. This PR refactors these statistics to be keyed by userId and teamId instead.

To support this, SessionResultsData is updated to expose the teamId and userId of giver and recipient.