### PR TITLE
[#14169] Allow users to access their own account requests

### DIFF
--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -10,6 +10,7 @@ import teammates.logic.core.UsersLogic;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
+import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -125,6 +126,26 @@ final class GateKeeper {
         verifyNotNull(student, "student");
         verifyInstructorHasPrivilegeForSection(requestContext, student.getCourseId(), student.getSectionId(),
                 Const.InstructorPermissions.CAN_VIEW_STUDENT);
+    }
+
+    /**
+     * Verifies that the user can view the specified account request.
+     *
+     * Admins can view all account requests. Non-admins can only view account requests that they own.
+     */
+    void verifyCanViewAccountRequest(RequestContext requestContext, UUID accountRequestId)
+            throws UnauthorizedAccessException {
+        if (requestContext.isAdmin()) {
+            return;
+        }
+
+        AccountRequest accountRequest = logic.getAccountRequest(accountRequestId);
+        verifyNotNull(accountRequest, "account request");
+
+        if (requestContext.getAccount() == null
+                || !requestContext.getAccount().getId().equals(accountRequest.getAccountId())) {
+            throw new UnauthorizedAccessException("Account request [" + accountRequestId + "] is not accessible to user");
+        }
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/GateKeeper.java
+++ b/src/main/java/teammates/ui/webapi/GateKeeper.java
@@ -7,10 +7,10 @@ import teammates.common.util.Const;
 import teammates.logic.api.Logic;
 import teammates.logic.core.AuthLogic;
 import teammates.logic.core.UsersLogic;
+import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
-import teammates.storage.entity.AccountRequest;
 import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
 
@@ -131,7 +131,7 @@ final class GateKeeper {
     /**
      * Verifies that the user can view the specified account request.
      *
-     * Admins can view all account requests. Non-admins can only view account requests that they own.
+     * <p>Admins can view all account requests. Non-admins can only view account requests that they own.
      */
     void verifyCanViewAccountRequest(RequestContext requestContext, UUID accountRequestId)
             throws UnauthorizedAccessException {

--- a/src/main/java/teammates/ui/webapi/GetAccountRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/GetAccountRequestAction.java
@@ -5,12 +5,19 @@ import java.util.UUID;
 import teammates.common.util.Const;
 import teammates.storage.entity.AccountRequest;
 import teammates.ui.exception.EntityNotFoundException;
+import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.output.AccountRequestData;
 
 /**
  * Gets account request information.
  */
-public class GetAccountRequestAction extends AdminOnlyAction {
+public class GetAccountRequestAction extends LoggedInAction {
+
+    @Override
+    void checkSpecificAccessControl() throws UnauthorizedAccessException {
+        UUID id = getUuidRequestParamValue(Const.ParamsNames.ACCOUNT_REQUEST_ID);
+        gateKeeper.verifyCanViewAccountRequest(requestContext, id);
+    }
 
     @Override
     public JsonResult execute() {

--- a/src/test/java/teammates/ui/webapi/GetAccountRequestActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetAccountRequestActionTest.java
@@ -1,0 +1,68 @@
+package teammates.ui.webapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.testng.annotations.Test;
+
+import teammates.common.util.Const;
+import teammates.test.GroupNames;
+import teammates.ui.exception.UnauthorizedAccessException;
+import teammates.ui.output.AccountRequestData;
+
+/**
+ * Tests for {@link GetAccountRequestAction}.
+ */
+public class GetAccountRequestActionTest extends BaseActionTest<GetAccountRequestAction, AccountRequestData> {
+
+    @Test(groups = GroupNames.ACTION)
+    public void getAccountRequestAction_owner_returnsAccountRequestData() {
+        var account = given.account("account");
+        var institute = given.institute("institute", i -> i.name("Test Institute").country("SG"));
+        var accountRequest = given.accountRequest("account-request", ar -> ar.account(account.alias())
+                .institute(institute.alias())
+                .name("Request Owner")
+                .email("owner@test.tmt"));
+        persistGivenData(given);
+
+        RequestContext request = new RequestContext()
+                .withParam(Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.id().toString())
+                .withCookie(getAuthCookie(account.id()));
+
+        AccountRequestData result = execute(request);
+
+        assertEquals(accountRequest.id(), result.getAccountRequestId());
+        assertEquals("Request Owner", result.getName());
+        assertEquals("owner@test.tmt", result.getEmail());
+        assertEquals("Test Institute", result.getInstitute());
+    }
+
+    @Test(groups = GroupNames.ACTION)
+    public void getAccountRequestAction_adminBypass_returnsAccountRequestData() {
+        var adminAccount = given.account("admin-account", a -> a.admin());
+        var ownerAccount = given.account("owner-account");
+        var accountRequest = given.accountRequest("account-request", ar -> ar.account(ownerAccount.alias()));
+        persistGivenData(given);
+
+        RequestContext request = new RequestContext()
+                .withParam(Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.id().toString())
+                .withCookie(getAuthCookie(adminAccount.id()));
+
+        AccountRequestData result = execute(request);
+
+        assertEquals(accountRequest.id(), result.getAccountRequestId());
+    }
+
+    @Test(groups = GroupNames.ACTION)
+    public void getAccountRequestAction_differentLoggedInUser_throwsUnauthorizedAccessException() {
+        var ownerAccount = given.account("owner-account");
+        var otherAccount = given.account("other-account");
+        var accountRequest = given.accountRequest("account-request", ar -> ar.account(ownerAccount.alias()));
+        persistGivenData(given);
+
+        RequestContext request = new RequestContext()
+                .withParam(Const.ParamsNames.ACCOUNT_REQUEST_ID, accountRequest.id().toString())
+                .withCookie(getAuthCookie(otherAccount.id()));
+
+        assertActionThrows(UnauthorizedAccessException.class, request);
+    }
+}


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14169

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Now that account requests are associated with particular accounts, we can extend GetAccountRequestAction to allow users to fetch their own account requests.
