### PR TITLE
[#13477] Fix environment-dependent CAPTCHA test failures

### DIFF
--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -5,6 +5,7 @@ import { SessionLinksRecoveryPageComponent } from './session-links-recovery-page
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { Mocked } from 'vitest';
+import { environment } from '../../../environments/environment';
 
 const mockStatusMessageService: Mocked<Partial<StatusMessageService>> = {
   showErrorToast: vi.fn(),

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -35,11 +35,6 @@ function setCaptchaState(
   component.captchaSiteKey = 'fake-key';
 }
 
-/**
- * Test suite for SessionLinksRecoveryPageComponent.
- * Note: To prevent environment-dependent test failures when a recaptcha site key is configured
- * in the environment, the captchaSiteKey must be bypassed/reset during component setup.
- */
 describe('SessionLinksRecoveryPageComponent', () => {
   let component: SessionLinksRecoveryPageComponent;
   let fixture: ComponentFixture<SessionLinksRecoveryPageComponent>;

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -34,6 +34,11 @@ function setCaptchaState(
   component.captchaSiteKey = 'fake-key';
 }
 
+/**
+ * Test suite for SessionLinksRecoveryPageComponent.
+ * Note: To prevent environment-dependent test failures when a recaptcha site key is configured
+ * in the environment, the captchaSiteKey must be bypassed/reset during component setup.
+ */
 describe('SessionLinksRecoveryPageComponent', () => {
   let component: SessionLinksRecoveryPageComponent;
   let fixture: ComponentFixture<SessionLinksRecoveryPageComponent>;

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -45,6 +45,8 @@ describe('SessionLinksRecoveryPageComponent', () => {
   let fixture: ComponentFixture<SessionLinksRecoveryPageComponent>;
 
   beforeEach(async () => {
+    environment.captchaSiteKey = '';
+
     await TestBed.configureTestingModule({
       imports: [SessionLinksRecoveryPageComponent],
       providers: [


### PR DESCRIPTION
Fixes #13477

This PR fixes environment-dependent test failures in the frontend spec suite for session links recovery (`session-links-recovery-page.component.spec.ts`).

When a local developer configures a real captchaSiteKey in their config.ts, the recovery component attempts to render the <ngx-recaptcha2> element (since @if (captchaSiteKey !== '') evaluates to true). However, because testing modules mock or override component imports and exclude NgxCaptchaModule to speed up the test environment, this results in an Angular compilation error: NG0303: Can't bind to 'siteKey' since it isn't a known property of 'ngx-recaptcha2'.

This fix consistently resets the CAPTCHA site key to an empty string at the beginning of the setup (beforeEach) in the spec, ensuring the tests can run successfully in any configuration.