### PR TITLE
[#13918] Migrate GetUserCookieAction to use email instead of Google ID

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseE2ETestCase.java
@@ -153,12 +153,12 @@ public abstract class BaseE2ETestCase extends BaseTestCase {
     /**
      * Logs in to a page using the given credentials.
      */
-    protected <T extends AppPage> T loginToPage(AppUrl url, Class<T> typeOfPage, String userId) {
+    protected <T extends AppPage> T loginToPage(AppUrl url, Class<T> typeOfPage, String userEmail) {
         // In order for the cookie injection to work, we need to be in the domain.
         // Use the home page to minimize the page load time.
         browser.goToUrl(TestProperties.TEAMMATES_FRONTEND_URL);
 
-        String cookieValue = BACKDOOR.getUserCookie(userId);
+        String cookieValue = BACKDOOR.getUserCookie(userEmail);
         browser.addCookie(Const.SecurityConfig.AUTH_COOKIE_NAME, cookieValue, true, true);
 
         return getNewPageInstance(url, typeOfPage);

--- a/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/BaseFeedbackQuestionE2ETest.java
@@ -36,14 +36,14 @@ public abstract class BaseFeedbackQuestionE2ETest extends BaseE2ETestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
                 .withFeedbackSessionId(feedbackSession.getId());
 
-        return loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
+        return loginToPage(url, InstructorFeedbackEditPage.class, instructor.getEmail());
     }
 
     FeedbackSubmitPage loginToFeedbackSubmitPage() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withFeedbackSessionId(feedbackSession.getId());
 
-        return loginToPage(url, FeedbackSubmitPage.class, student.getGoogleId());
+        return loginToPage(url, FeedbackSubmitPage.class, student.getEmail());
     }
 
     FeedbackSubmitPage getFeedbackSubmitPage() {

--- a/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackResultsPageE2ETest.java
@@ -65,7 +65,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         Student student = testData.students.get("Alice");
         url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
                 .withFeedbackSessionId(openSession.getId());
-        resultsPage = loginToPage(url, FeedbackResultsPage.class, student.getGoogleId());
+        resultsPage = loginToPage(url, FeedbackResultsPage.class, student.getEmail());
 
         resultsPage.verifyFeedbackSessionDetails(openSession, course);
 
@@ -104,7 +104,7 @@ public class FeedbackResultsPageE2ETest extends BaseE2ETestCase {
         Instructor instructor = testData.instructors.get("FRes.instr");
         url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
                 .withFeedbackSessionId(openSession.getId());
-        resultsPage = loginToPage(url, FeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(url, FeedbackResultsPage.class, instructor.getEmail());
 
         resultsPage.verifyFeedbackSessionDetails(openSession, course);
 

--- a/src/e2e/java/teammates/e2e/cases/FeedbackSubmitPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/FeedbackSubmitPageE2ETest.java
@@ -58,7 +58,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
                 .withFeedbackSessionId(openSession.getId());
-        FeedbackSubmitPage submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getGoogleId());
+        FeedbackSubmitPage submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getEmail());
 
         ______TS("verify loaded session data");
         submitPage.verifyFeedbackSessionDetails(openSession, course);
@@ -70,7 +70,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         ______TS("questions with giver type students");
         logout();
         submitPage = loginToPage(getStudentSubmitPageUrl(openSession), FeedbackSubmitPage.class,
-                student.getGoogleId());
+                student.getEmail());
 
         submitPage.verifyNumQuestions(4);
         submitPage.verifyQuestionDetails(1, testData.feedbackQuestions.get("qn1InSession1"));
@@ -157,7 +157,7 @@ public class FeedbackSubmitPageE2ETest extends BaseE2ETestCase {
         url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
                 .withFeedbackSessionId(openSession.getId())
                 .withPreviewAs(instructor.getId().toString());
-        submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getGoogleId());
+        submitPage = loginToPage(url, FeedbackSubmitPage.class, instructor.getEmail());
 
         submitPage.verifyFeedbackSessionDetails(openSession, course);
         submitPage.verifyNumQuestions(1);

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
@@ -42,7 +42,7 @@ public class InstructorCourseDetailsPageE2ETest extends BaseE2ETestCase {
         AppUrl detailsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_DETAILS_PAGE)
                 .withCourseId(course.getId());
         InstructorCourseDetailsPage detailsPage =
-                loginToPage(detailsPageUrl, InstructorCourseDetailsPage.class, instructor1.getGoogleId());
+                loginToPage(detailsPageUrl, InstructorCourseDetailsPage.class, instructor1.getEmail());
 
         ______TS("verify loaded details");
         List<Instructor> instructors = Arrays.asList(instructor1, testData.instructors.get("ICDet.instr2"));

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEditPageE2ETest.java
@@ -43,7 +43,7 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
                 .withCourseId(course.getId());
         InstructorCourseEditPage editPage =
-                loginToPage(url, InstructorCourseEditPage.class, instructors[2].getGoogleId());
+                loginToPage(url, InstructorCourseEditPage.class, instructors[2].getEmail());
 
         editPage.verifyCourseNotEditable();
         editPage.verifyInstructorsNotEditable();
@@ -55,7 +55,7 @@ public class InstructorCourseEditPageE2ETest extends BaseE2ETestCase {
         logout();
         url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
                 .withCourseId(course.getId());
-        editPage = loginToPage(url, InstructorCourseEditPage.class, instructors[3].getGoogleId());
+        editPage = loginToPage(url, InstructorCourseEditPage.class, instructors[3].getEmail());
 
         // The helper (instructors[0]) has a custom role; track its name-keyed privileges for verification.
         InstructorPermissionSet helperCourseLevel = new InstructorPermissionSet();

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseEnrollPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseEnrollPageE2ETest.java
@@ -29,7 +29,7 @@ public class InstructorCourseEnrollPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_ENROLL_PAGE)
                 .withCourseId(testData.courses.get("ICEnroll.CS2104").getId());
         InstructorCourseEnrollPage enrollPage = loginToPage(url, InstructorCourseEnrollPage.class,
-                testData.instructors.get("ICEnroll.teammates.test").getGoogleId());
+                testData.instructors.get("ICEnroll.teammates.test").getEmail());
         Course course = testData.courses.get("ICEnroll.CS2104");
         Team team1 = testData.teams.get("tm.e2e.ICEnroll.courseICEnroll.CS2104-SectionA-Team1");
         Team team2 = testData.teams.get("tm.e2e.ICEnroll.courseICEnroll.CS2104-SectionB-Team2");

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseJoinConfirmationPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseJoinConfirmationPageE2ETest.java
@@ -13,6 +13,7 @@ import teammates.storage.entity.Instructor;
  */
 public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
     private Instructor newInstructor;
+    private String newInstructorDisplayedUserId;
 
     @Override
     protected void prepareTestData() {
@@ -20,6 +21,7 @@ public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase
                 loadDataBundle("/InstructorCourseJoinConfirmationPageE2ETest.json"));
 
         newInstructor = testData.instructors.get("ICJoinConf.instr.CS1101");
+        newInstructorDisplayedUserId = testData.accounts.get("ICJoinConf.instr.CS1101").getGoogleId();
     }
 
     @Test
@@ -27,12 +29,12 @@ public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase
     public void testAll() {
         ______TS("Click join link: invalid key");
         String invalidKey = "invalidKey";
+        String newInstructorEmail = newInstructor.getEmail();
         AppUrl joinLink = createFrontendUrl(Const.WebPageURIs.JOIN_PAGE)
                 .withRegistrationKey(invalidKey)
                 .withEntityType(Const.EntityType.INSTRUCTOR);
-        String newInstructorId = "tm.e2e.ICJoinConf.instr2";
         CourseJoinConfirmationPage confirmationPage = loginToPage(
-                joinLink, CourseJoinConfirmationPage.class, newInstructorId);
+                joinLink, CourseJoinConfirmationPage.class, newInstructorEmail);
 
         confirmationPage.verifyDisplayedMessage("The course join link is invalid. You may have "
                 + "entered the URL incorrectly or the URL may correspond to a/an instructor that does not exist.");
@@ -43,7 +45,7 @@ public class InstructorCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase
                 .withEntityType(Const.EntityType.INSTRUCTOR);
         confirmationPage = getNewPageInstance(joinLink, CourseJoinConfirmationPage.class);
 
-        confirmationPage.verifyJoiningUser(newInstructorId);
+        confirmationPage.verifyJoiningUser(newInstructorDisplayedUserId);
         confirmationPage.confirmJoinCourse(InstructorHomePage.class);
 
         ______TS("Already joined, no confirmation page");

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsEditPageE2ETest.java
@@ -35,7 +35,7 @@ public class InstructorCourseStudentDetailsEditPageE2ETest extends BaseE2ETestCa
                 .withUserId(student.getId());
         InstructorCourseStudentDetailsEditPage editPage =
                 loginToPage(editPageUrl, InstructorCourseStudentDetailsEditPage.class,
-                        testData.instructors.get("ICSDetEdit.instr").getGoogleId());
+                        testData.instructors.get("ICSDetEdit.instr").getEmail());
 
         ______TS("verify loaded data");
         editPage.verifyStudentDetails(student);

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsPageE2ETest.java
@@ -30,7 +30,7 @@ public class InstructorCourseStudentDetailsPageE2ETest extends BaseE2ETestCase {
         AppUrl viewPageUrl = getStudentDetailsViewPageUrl(student.getId());
         InstructorCourseStudentDetailsViewPage viewPage =
                 loginToPage(viewPageUrl, InstructorCourseStudentDetailsViewPage.class,
-                        testData.instructors.get("ICSDet.instr").getGoogleId());
+                        testData.instructors.get("ICSDet.instr").getEmail());
 
         viewPage.verifyStudentDetails(student);
     }

--- a/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
@@ -115,9 +115,9 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        String instructorId = testData.accounts.get("ICs.instructor").getGoogleId();
+        String instructorEmail = testData.accounts.get("ICs.instructor").getEmail();
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSES_PAGE);
-        InstructorCoursesPage coursesPage = loginToPage(url, InstructorCoursesPage.class, instructorId);
+        InstructorCoursesPage coursesPage = loginToPage(url, InstructorCoursesPage.class, instructorEmail);
 
         ______TS("verify loaded data");
         Course[] activeCourses = { courses[0], courses[1], courses[2] };

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
@@ -48,7 +48,7 @@ public class InstructorFeedbackEditPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_EDIT_PAGE)
                 .withFeedbackSessionId(feedbackSession.getId());
         InstructorFeedbackEditPage feedbackEditPage =
-                loginToPage(url, InstructorFeedbackEditPage.class, instructor.getGoogleId());
+                loginToPage(url, InstructorFeedbackEditPage.class, instructor.getEmail());
 
         ______TS("verify loaded data");
         feedbackEditPage.verifySessionDetails(course, feedbackSession);

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackReportPageE2ETest.java
@@ -145,7 +145,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
     }
 
     private void testQuestionView() {
-        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getEmail());
 
         ______TS("Question view: no missing responses");
         resultsPage.includeMissingResponses(false);
@@ -182,7 +182,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
     }
 
     private void testGrqView() {
-        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getEmail());
 
         ______TS("GRQ view: no missing responses");
         boolean isGroupedByTeam = true;
@@ -215,7 +215,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
     }
 
     private void testRgqView() {
-        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getEmail());
 
         ______TS("RGQ view: no missing responses");
         boolean isGroupedByTeam = true;
@@ -249,7 +249,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
     }
 
     private void testGqrView() {
-        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getEmail());
 
         ______TS("GQR view: no missing responses");
         boolean isGroupedByTeam = true;
@@ -291,7 +291,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
     }
 
     private void testRqgView() {
-        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class, instructor.getEmail());
 
         ______TS("RQG view: no missing responses");
         boolean isGroupedByTeam = true;
@@ -339,7 +339,7 @@ public class InstructorFeedbackReportPageE2ETest extends BaseE2ETestCase {
 
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
                 .withFeedbackSessionId(feedbackSession.getId());
-        resultsPage = loginToPage(url, InstructorFeedbackResultsPage.class, instructor.getGoogleId());
+        resultsPage = loginToPage(url, InstructorFeedbackResultsPage.class, instructor.getEmail());
 
         ______TS("verify loaded session details");
         // Sync resultsVisibleFromTime from database as it may differ from JSON test data

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
@@ -84,7 +84,7 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSIONS_PAGE);
         InstructorFeedbackSessionsPage feedbackSessionsPage =
-                loginToPage(url, InstructorFeedbackSessionsPage.class, instructor.getGoogleId());
+                loginToPage(url, InstructorFeedbackSessionsPage.class, instructor.getEmail());
 
         ______TS("verify loaded data");
         FeedbackSession[] loadedSessions = { closedSession, openSession };

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -75,7 +75,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
     @Override
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE);
-        InstructorHomePage homePage = loginToPage(url, InstructorHomePage.class, instructor.getGoogleId());
+        InstructorHomePage homePage = loginToPage(url, InstructorHomePage.class, instructor.getEmail());
 
         ______TS("verify loaded data");
         homePage.sortCoursesById();

--- a/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
@@ -28,10 +28,10 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
     @Test
     @Override
     public void testAll() {
-        String instructorId = testData.accounts.get("instructor1OfCourse1").getGoogleId();
+        String instructorEmail = testData.accounts.get("instructor1OfCourse1").getEmail();
         AppUrl searchPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SEARCH_PAGE);
 
-        InstructorSearchPage searchPage = loginToPage(searchPageUrl, InstructorSearchPage.class, instructorId);
+        InstructorSearchPage searchPage = loginToPage(searchPageUrl, InstructorSearchPage.class, instructorEmail);
 
         ______TS("cannot click search button if no search term is entered");
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
@@ -26,6 +26,9 @@ import teammates.ui.output.DeadlineExtensionsData;
  */
 public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETestCase {
     private Instructor instructor;
+    private Instructor instructorWithExtension;
+    private Student alice;
+    private Student charlie;
     private FeedbackSession feedbackSession;
     private Map<String, User> users;
     private Collection<Student> students;
@@ -37,6 +40,9 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
                 loadDataBundle("/InstructorSessionIndividualExtensionPageE2ETest.json"));
 
         instructor = testData.instructors.get("ISesIe.instructor1");
+        instructorWithExtension = testData.instructors.get("ISesIe.instructor1");
+        alice = testData.students.get("alice.tmms@ISesIe.CS2104");
+        charlie = testData.students.get("charlie.tmms@ISesIe.CS2104");
         feedbackSession = testData.feedbackSessions.get("firstSession");
         students = testData.students.values();
         instructors = testData.instructors.values();
@@ -74,8 +80,8 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         Map<UUID, Long> updatedDeadlines = updatedExtensionsData.getUserDeadlines();
         Instant expectedDeadline = feedbackSession.getEndTime().plus(Duration.ofHours(12));
 
-        verifyUpdatedDeadlinesMap(updatedDeadlines, "alice.tmms@gmail.tmt",
-                "charlie.tmms@gmail.tmt", "instructor1.tmms@gmail.tmt");
+        verifyUpdatedDeadlinesMap(updatedDeadlines, alice.getEmail(),
+                charlie.getEmail(), instructorWithExtension.getEmail());
         verifyDeadlineExtensionsUpdated(updatedDeadlines, expectedDeadline);
 
         ______TS("verify updated some deadlines, notifyUsers enabled");
@@ -92,8 +98,8 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
                 getDeadlineExtensions(feedbackSession.getId());
         updatedDeadlines = updatedExtensionsData.getUserDeadlines();
 
-        verifyUpdatedDeadlinesMap(updatedDeadlines, "alice.tmms@gmail.tmt",
-                "charlie.tmms@gmail.tmt", "instructor1.tmms@gmail.tmt");
+        verifyUpdatedDeadlinesMap(updatedDeadlines, alice.getEmail(),
+                charlie.getEmail(), instructorWithExtension.getEmail());
         verifyDeadlineExtensionsUpdated(updatedDeadlines, expectedDeadline);
 
         ______TS("verify delete some deadlines, notifyUsers enabled");

--- a/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSessionIndividualExtensionPageE2ETest.java
@@ -156,6 +156,6 @@ public class InstructorSessionIndividualExtensionPageE2ETest extends BaseE2ETest
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_INDIVIDUAL_EXTENSION_PAGE)
                 .withFeedbackSessionId(feedbackSession.getId());
 
-        return loginToPage(url, InstructorSessionIndividualExtensionPage.class, instructor.getGoogleId());
+        return loginToPage(url, InstructorSessionIndividualExtensionPage.class, instructor.getEmail());
     }
 }

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentActivityLogsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentActivityLogsPageE2ETest.java
@@ -48,7 +48,7 @@ public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_ACTIVITY_LOGS_PAGE)
                 .withCourseId("tm.e2e.ISActLogs.CS2104");
         InstructorStudentActivityLogsPage studentActivityLogsPage =
-                loginToPage(url, InstructorStudentActivityLogsPage.class, instructor.getGoogleId());
+                loginToPage(url, InstructorStudentActivityLogsPage.class, instructor.getEmail());
 
         ______TS("verify default datetime");
         String currentLogsFromDate = studentActivityLogsPage.getLogsFromDate();
@@ -71,7 +71,7 @@ public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
         AppUrl studentSubmissionPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_SUBMISSION_PAGE)
                 .withFeedbackSessionId(feedbackSession.getId());
         FeedbackSubmitPage studentSubmissionPage = loginToPage(studentSubmissionPageUrl,
-                FeedbackSubmitPage.class, student.getGoogleId());
+                FeedbackSubmitPage.class, student.getEmail());
 
         Student receiver = testData.students.get("benny.tmms@ISActLogs.CS2104");
 
@@ -86,7 +86,7 @@ public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
 
         logout();
         studentActivityLogsPage = loginToPage(url, InstructorStudentActivityLogsPage.class,
-                instructor.getGoogleId());
+                instructor.getEmail());
         studentActivityLogsPage.setActivityType("session access and submission");
         studentActivityLogsPage.setSessionDropdown(feedbackSession.getName());
         studentActivityLogsPage.waitForPageToLoad();

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
@@ -34,10 +34,10 @@ public class InstructorStudentListPageE2ETest extends BaseE2ETestCase {
         ______TS("verify loaded data");
 
         Instructor instructor = testData.instructors.get("instructorOfCourse1");
-        String instructorId = instructor.getGoogleId();
+        String instructorEmail = instructor.getEmail();
 
         AppUrl listPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_LIST_PAGE);
-        InstructorStudentListPage listPage = loginToPage(listPageUrl, InstructorStudentListPage.class, instructorId);
+        InstructorStudentListPage listPage = loginToPage(listPageUrl, InstructorStudentListPage.class, instructorEmail);
 
         listPage.verifyAllCoursesHaveTabs(testData.courses.values());
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentRecordsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentRecordsPageE2ETest.java
@@ -28,7 +28,7 @@ public class InstructorStudentRecordsPageE2ETest extends BaseE2ETestCase {
         Instructor instructor = testData.instructors.get("teammates.test.CS2104");
         Student student = testData.students.get("benny.c.tmms@ISR.CS2104");
 
-        String instructorId = instructor.getGoogleId();
+        String instructorEmail = instructor.getEmail();
         String courseId = instructor.getCourseId();
 
         AppUrl recordsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_RECORDS_PAGE)
@@ -36,7 +36,7 @@ public class InstructorStudentRecordsPageE2ETest extends BaseE2ETestCase {
                 .withUserId(student.getId());
 
         InstructorStudentRecordsPage recordsPage =
-                loginToPage(recordsPageUrl, InstructorStudentRecordsPage.class, instructorId);
+                loginToPage(recordsPageUrl, InstructorStudentRecordsPage.class, instructorEmail);
 
         recordsPage.verifyStudentDetails(student);
     }

--- a/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/NotificationsE2ETest.java
@@ -43,7 +43,7 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         Account instructorAccount = testData.accounts.get("notif.instructor");
         AppUrl instructorNotificationsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_NOTIFICATIONS_PAGE);
         InstructorNotificationsPage notificationsPage = loginToPage(instructorNotificationsPageUrl,
-                InstructorNotificationsPage.class, instructorAccount.getGoogleId());
+                InstructorNotificationsPage.class, instructorAccount.getEmail());
 
         ______TS("verify that only active notifications for instructors are shown");
         Notification[] notShownNotifications = {
@@ -72,7 +72,7 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         Account studentAccount = testData.accounts.get("notif.student");
         AppUrl studentNotificationsPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_NOTIFICATIONS_PAGE);
         StudentNotificationsPage notificationsPage = loginToPage(studentNotificationsPageUrl, StudentNotificationsPage.class,
-                studentAccount.getGoogleId());
+                studentAccount.getEmail());
 
         ______TS("verify that only active notifications for students are shown");
         Notification[] notShownNotifications = {
@@ -102,7 +102,7 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         Account studentAccount = testData.accounts.get("notif.student");
         AppUrl studentHomePageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
         StudentHomePage homePage = loginToPage(studentHomePageUrl, StudentHomePage.class,
-                studentAccount.getGoogleId());
+                studentAccount.getEmail());
 
         ______TS("verify active notification with correct information is shown");
         assertTrue(homePage.isBannerVisible(true));
@@ -134,7 +134,7 @@ public class NotificationsE2ETest extends BaseE2ETestCase {
         ______TS("verify that the notifications marked as read are reflected in the notifications page");
         AppUrl studentNotificationsPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_NOTIFICATIONS_PAGE);
         StudentNotificationsPage notificationsPage = loginToPage(studentNotificationsPageUrl, StudentNotificationsPage.class,
-                studentAccount.getGoogleId());
+                studentAccount.getEmail());
 
         Notification[] shownNotifications = {
                 testData.notifications.get("notification1"),

--- a/src/e2e/java/teammates/e2e/cases/StudentCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentCourseDetailsPageE2ETest.java
@@ -26,7 +26,7 @@ public class StudentCourseDetailsPageE2ETest extends BaseE2ETestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_COURSE_DETAILS_PAGE)
                 .withCourseId("tm.e2e.SCDet.CS2104");
         StudentCourseDetailsPage detailsPage = loginToPage(url, StudentCourseDetailsPage.class,
-                testData.accounts.get("SCDet.alice").getGoogleId());
+                testData.accounts.get("SCDet.alice").getEmail());
 
         ______TS("verify loaded data");
         Instructor[] instructors = { testData.instructors.get("SCDet.instr"),

--- a/src/e2e/java/teammates/e2e/cases/StudentCourseJoinConfirmationPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentCourseJoinConfirmationPageE2ETest.java
@@ -13,14 +13,16 @@ import teammates.storage.entity.Student;
  */
 public class StudentCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
     private Student newStudent;
-    private String newStudentGoogleId;
+    private String newStudentEmail;
+    private String newStudentDisplayedUserId;
 
     @Override
     protected void prepareTestData() {
         testData = removeAndRestoreDataBundle(loadDataBundle("/StudentCourseJoinConfirmationPageE2ETest.json"));
 
         newStudent = testData.students.get("alice.tmms@SCJoinConf.CS2104");
-        newStudentGoogleId = testData.accounts.get("alice.tmms").getGoogleId();
+        newStudentEmail = testData.accounts.get("alice.tmms").getEmail();
+        newStudentDisplayedUserId = testData.accounts.get("alice.tmms").getGoogleId();
     }
 
     @Test
@@ -34,7 +36,7 @@ public class StudentCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
                 .withCourseId(courseId)
                 .withEntityType(Const.EntityType.STUDENT);
         CourseJoinConfirmationPage confirmationPage = loginToPage(
-                joinLink, CourseJoinConfirmationPage.class, newStudentGoogleId);
+                joinLink, CourseJoinConfirmationPage.class, newStudentEmail);
 
         confirmationPage.verifyDisplayedMessage("The course join link is invalid. You may have "
                 + "entered the URL incorrectly or the URL may correspond to a/an student that does not exist.");
@@ -46,7 +48,7 @@ public class StudentCourseJoinConfirmationPageE2ETest extends BaseE2ETestCase {
                 .withEntityType(Const.EntityType.STUDENT);
         confirmationPage = getNewPageInstance(joinLink, CourseJoinConfirmationPage.class);
 
-        confirmationPage.verifyJoiningUser(newStudentGoogleId);
+        confirmationPage.verifyJoiningUser(newStudentDisplayedUserId);
         confirmationPage.confirmJoinCourse(StudentHomePage.class);
 
         ______TS("Already joined, no confirmation page");

--- a/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
@@ -27,7 +27,8 @@ public class StudentHomePageE2ETest extends BaseE2ETestCase {
     public void testAll() {
 
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
-        StudentHomePage homePage = loginToPage(url, StudentHomePage.class, "tm.e2e.SHome.student");
+        String studentEmail = testData.accounts.get("SHome.student").getEmail();
+        StudentHomePage homePage = loginToPage(url, StudentHomePage.class, studentEmail);
 
         ______TS("courses visible to student are shown");
         List<String> courseIds = getAllVisibleCourseIds();

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackResultsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackResultsPageAxeTest.java
@@ -24,7 +24,7 @@ public class FeedbackResultsPageAxeTest extends BaseAxeTestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_SESSION_RESULTS_PAGE)
                 .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId());
         FeedbackResultsPage resultsPage = loginToPage(url, FeedbackResultsPage.class,
-                testData.students.get("Alice").getGoogleId());
+                testData.students.get("Alice").getEmail());
 
         Results results = getAxeBuilder().analyze(resultsPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/FeedbackSubmitPageAxeTest.java
@@ -25,7 +25,7 @@ public class FeedbackSubmitPageAxeTest extends BaseAxeTestCase {
                 .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId());
 
         FeedbackSubmitPage feedbackSubmitPage = loginToPage(url, FeedbackSubmitPage.class,
-                testData.students.get("alice.tmms@FSubmit.CS2104").getGoogleId());
+                testData.students.get("alice.tmms@FSubmit.CS2104").getEmail());
 
         Results results = getAxeBuilder("aria-valuenow").analyze(feedbackSubmitPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseDetailsPageAxeTest.java
@@ -25,7 +25,7 @@ public class InstructorCourseDetailsPageAxeTest extends BaseAxeTestCase {
         AppUrl detailsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_DETAILS_PAGE)
                 .withCourseId(testData.courses.get("ICDet.CS2104").getId());
         InstructorCourseDetailsPage detailsPage = loginToPage(detailsPageUrl, InstructorCourseDetailsPage.class,
-                testData.instructors.get("ICDet.instr").getGoogleId());
+                testData.instructors.get("ICDet.instr").getEmail());
 
         Results results = getAxeBuilder().analyze(detailsPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEditPageAxeTest.java
@@ -24,7 +24,7 @@ public class InstructorCourseEditPageAxeTest extends BaseAxeTestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_EDIT_PAGE)
                 .withCourseId(testData.courses.get("ICEdit.CS2104").getId());
         InstructorCourseEditPage editPage = loginToPage(url, InstructorCourseEditPage.class,
-                testData.instructors.get("ICEdit.coowner.CS2104").getGoogleId());
+                testData.instructors.get("ICEdit.coowner.CS2104").getEmail());
 
         Results results = getAxeBuilder().analyze(editPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEnrollPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseEnrollPageAxeTest.java
@@ -24,7 +24,7 @@ public class InstructorCourseEnrollPageAxeTest extends BaseAxeTestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSE_ENROLL_PAGE)
                 .withCourseId(testData.courses.get("ICEnroll.CS2104").getId());
         InstructorCourseEnrollPage enrollPage = loginToPage(url, InstructorCourseEnrollPage.class,
-                testData.instructors.get("ICEnroll.teammates.test").getGoogleId());
+                testData.instructors.get("ICEnroll.teammates.test").getEmail());
 
         // These rules are disabled due to Handsontable, which is yet to support accessibility.
         Results results = getAxeBuilder(

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseJoinConfirmationPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseJoinConfirmationPageAxeTest.java
@@ -13,9 +13,6 @@ import teammates.storage.entity.Instructor;
  * SUT: {@link Const.WebPageURIs#JOIN_PAGE}.
  */
 public class InstructorCourseJoinConfirmationPageAxeTest extends BaseAxeTestCase {
-
-    private static final String NEW_INSTRUCTOR_GOOGLE_ID = "tm.e2e.ICJoinConf.instr2";
-
     private Instructor newInstructor;
 
     @Override
@@ -33,7 +30,7 @@ public class InstructorCourseJoinConfirmationPageAxeTest extends BaseAxeTestCase
                 .withRegistrationKey(newInstructor.getRegKey())
                 .withEntityType(Const.EntityType.INSTRUCTOR);
         CourseJoinConfirmationPage confirmationPage = loginToPage(
-                joinLink, CourseJoinConfirmationPage.class, NEW_INSTRUCTOR_GOOGLE_ID);
+                joinLink, CourseJoinConfirmationPage.class, newInstructor.getEmail());
 
         Results results = getAxeBuilder().analyze(confirmationPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsEditPageAxeTest.java
@@ -27,7 +27,7 @@ public class InstructorCourseStudentDetailsEditPageAxeTest extends BaseAxeTestCa
                 .withUserId(testData.students.get("ICSDetEdit.jose.tmms").getId());
         InstructorCourseStudentDetailsEditPage editPage =
                 loginToPage(editPageUrl, InstructorCourseStudentDetailsEditPage.class,
-                        testData.instructors.get("ICSDetEdit.instr").getGoogleId());
+                        testData.instructors.get("ICSDetEdit.instr").getEmail());
 
         Results results = getAxeBuilder().analyze(editPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCourseStudentDetailsPageAxeTest.java
@@ -27,7 +27,7 @@ public class InstructorCourseStudentDetailsPageAxeTest extends BaseAxeTestCase {
                 .withUserId(testData.students.get("ICSDet.jose.tmms").getId());
         InstructorCourseStudentDetailsViewPage viewPage =
                 loginToPage(viewPageUrl, InstructorCourseStudentDetailsViewPage.class,
-                testData.instructors.get("ICSDet.instr").getGoogleId());
+                testData.instructors.get("ICSDet.instr").getEmail());
 
         Results results = getAxeBuilder().analyze(viewPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorCoursesPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorCoursesPageAxeTest.java
@@ -24,7 +24,7 @@ public class InstructorCoursesPageAxeTest extends BaseAxeTestCase {
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_COURSES_PAGE);
         InstructorCoursesPage coursesPage = loginToPage(url, InstructorCoursesPage.class,
-                testData.accounts.get("ICs.instructor").getGoogleId());
+                testData.accounts.get("ICs.instructor").getEmail());
 
         Results results = getAxeBuilder().analyze(coursesPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackEditPageAxeTest.java
@@ -26,7 +26,7 @@ public class InstructorFeedbackEditPageAxeTest extends BaseAxeTestCase {
                 .withFeedbackSessionId(testData.feedbackSessions.get("openSession").getId());
 
         InstructorFeedbackEditPage feedbackEditPage = loginToPage(url, InstructorFeedbackEditPage.class,
-                testData.instructors.get("InstFEP.instr").getGoogleId());
+                testData.instructors.get("InstFEP.instr").getEmail());
 
         // landmark-unique, aria-valuenow might be caused by tinymce
         // aria-prohibited-attr is caused by https://github.com/tinymce/tinymce/issues/7346

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackReportPageAxeTest.java
@@ -25,7 +25,7 @@ public class InstructorFeedbackReportPageAxeTest extends BaseAxeTestCase {
         AppUrl resultsUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_REPORT_PAGE)
                 .withFeedbackSessionId(testData.feedbackSessions.get("Open Session").getId());
         InstructorFeedbackResultsPage resultsPage = loginToPage(resultsUrl, InstructorFeedbackResultsPage.class,
-                testData.instructors.get("IFRep.instr.CS2104").getGoogleId());
+                testData.instructors.get("IFRep.instr.CS2104").getEmail());
 
         Results results = getAxeBuilder().analyze(resultsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackSessionsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorFeedbackSessionsPageAxeTest.java
@@ -25,7 +25,7 @@ public class InstructorFeedbackSessionsPageAxeTest extends BaseAxeTestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SESSIONS_PAGE);
         InstructorFeedbackSessionsPage feedbackSessionsPage =
                 loginToPage(url, InstructorFeedbackSessionsPage.class,
-                testData.instructors.get("IFSessionPage.instr1").getGoogleId());
+                testData.instructors.get("IFSessionPage.instr1").getEmail());
 
         Results results = getAxeBuilder().analyze(feedbackSessionsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorHomePageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorHomePageAxeTest.java
@@ -24,7 +24,7 @@ public class InstructorHomePageAxeTest extends BaseAxeTestCase {
     public void testAll() {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_HOME_PAGE);
         InstructorHomePage homePage = loginToPage(url, InstructorHomePage.class,
-                testData.instructors.get("IHome.instr.CS2104").getGoogleId());
+                testData.instructors.get("IHome.instr.CS2104").getEmail());
 
         Results results = getAxeBuilder().analyze(homePage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorNotificationsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorNotificationsPageAxeTest.java
@@ -26,7 +26,7 @@ public class InstructorNotificationsPageAxeTest extends BaseAxeTestCase {
     public void testAll() {
         AppUrl notificationsPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_NOTIFICATIONS_PAGE);
         InstructorNotificationsPage notificationsPage = loginToPage(notificationsPageUrl, InstructorNotificationsPage.class,
-                testData.accounts.get("INotifs.instr").getGoogleId());
+                testData.accounts.get("INotifs.instr").getEmail());
 
         Results results = getAxeBuilder().analyze(notificationsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorSearchPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorSearchPageAxeTest.java
@@ -25,7 +25,7 @@ public class InstructorSearchPageAxeTest extends BaseAxeTestCase {
         AppUrl searchPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_SEARCH_PAGE);
 
         InstructorSearchPage searchPage = loginToPage(searchPageUrl, InstructorSearchPage.class,
-                testData.accounts.get("instructor1OfCourse1").getGoogleId());
+                testData.accounts.get("instructor1OfCourse1").getEmail());
 
         searchPage.search("student2");
 

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorSessionIndividualExtensionPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorSessionIndividualExtensionPageAxeTest.java
@@ -27,7 +27,7 @@ public class InstructorSessionIndividualExtensionPageAxeTest extends BaseAxeTest
 
         InstructorSessionIndividualExtensionPage individualExtensionPage =
                 loginToPage(url, InstructorSessionIndividualExtensionPage.class,
-                testData.instructors.get("ISesIe.instructor1").getGoogleId());
+                testData.instructors.get("ISesIe.instructor1").getEmail());
 
         Results results = getAxeBuilder().analyze(individualExtensionPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentActivityLogsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentActivityLogsPageAxeTest.java
@@ -26,7 +26,7 @@ public class InstructorStudentActivityLogsPageAxeTest extends BaseAxeTestCase {
                 .withCourseId("tm.e2e.ISActLogs.CS2104");
         InstructorStudentActivityLogsPage studentActivityLogsPage =
                 loginToPage(url, InstructorStudentActivityLogsPage.class,
-                testData.instructors.get("instructor").getGoogleId());
+                testData.instructors.get("instructor").getEmail());
 
         Results results = getAxeBuilder().analyze(studentActivityLogsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentListPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentListPageAxeTest.java
@@ -24,7 +24,7 @@ public class InstructorStudentListPageAxeTest extends BaseAxeTestCase {
     public void testAll() {
         AppUrl listPageUrl = createFrontendUrl(Const.WebPageURIs.INSTRUCTOR_STUDENT_LIST_PAGE);
         InstructorStudentListPage listPage = loginToPage(listPageUrl, InstructorStudentListPage.class,
-                testData.instructors.get("instructorOfCourse1").getGoogleId());
+                testData.instructors.get("instructorOfCourse1").getEmail());
 
         Results results = getAxeBuilder().analyze(listPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentRecordsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/InstructorStudentRecordsPageAxeTest.java
@@ -28,7 +28,7 @@ public class InstructorStudentRecordsPageAxeTest extends BaseAxeTestCase {
 
         InstructorStudentRecordsPage recordsPage =
                 loginToPage(recordsPageUrl, InstructorStudentRecordsPage.class,
-                testData.instructors.get("teammates.test.CS2104").getGoogleId());
+                testData.instructors.get("teammates.test.CS2104").getEmail());
 
         Results results = getAxeBuilder().analyze(recordsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentCourseDetailsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentCourseDetailsPageAxeTest.java
@@ -26,7 +26,7 @@ public class StudentCourseDetailsPageAxeTest extends BaseAxeTestCase {
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_COURSE_DETAILS_PAGE)
                 .withCourseId("tm.e2e.SCDet.CS2104");
         StudentCourseDetailsPage detailsPage = loginToPage(url, StudentCourseDetailsPage.class,
-                testData.students.get("SCDet.alice").getGoogleId());
+                testData.students.get("SCDet.alice").getEmail());
 
         Results results = getAxeBuilder().analyze(detailsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentCourseJoinConfirmationPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentCourseJoinConfirmationPageAxeTest.java
@@ -15,7 +15,7 @@ import teammates.storage.entity.Student;
 public class StudentCourseJoinConfirmationPageAxeTest extends BaseAxeTestCase {
 
     private Student newStudent;
-    private String newStudentGoogleId;
+    private String newStudentEmail;
 
     @Override
     protected void prepareTestData() {
@@ -23,7 +23,7 @@ public class StudentCourseJoinConfirmationPageAxeTest extends BaseAxeTestCase {
                 loadDataBundle("/StudentCourseJoinConfirmationPageE2ETest.json"));
 
         newStudent = testData.students.get("alice.tmms@SCJoinConf.CS2104");
-        newStudentGoogleId = testData.accounts.get("alice.tmms").getGoogleId();
+        newStudentEmail = testData.accounts.get("alice.tmms").getEmail();
     }
 
     @Test
@@ -34,7 +34,7 @@ public class StudentCourseJoinConfirmationPageAxeTest extends BaseAxeTestCase {
                 .withCourseId(testData.courses.get("SCJoinConf.CS2104").getId())
                 .withEntityType(Const.EntityType.STUDENT);
         CourseJoinConfirmationPage confirmationPage = loginToPage(
-                joinLink, CourseJoinConfirmationPage.class, newStudentGoogleId);
+                joinLink, CourseJoinConfirmationPage.class, newStudentEmail);
 
         Results results = getAxeBuilder().analyze(confirmationPage.getBrowser().getDriver());
         assertViolationFree(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentHomePageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentHomePageAxeTest.java
@@ -24,7 +24,8 @@ public class StudentHomePageAxeTest extends BaseAxeTestCase {
     public void testAll() {
 
         AppUrl url = createFrontendUrl(Const.WebPageURIs.STUDENT_HOME_PAGE);
-        StudentHomePage homePage = loginToPage(url, StudentHomePage.class, "tm.e2e.SHome.student");
+        String studentEmail = testData.accounts.get("SHome.student").getEmail();
+        StudentHomePage homePage = loginToPage(url, StudentHomePage.class, studentEmail);
 
         Results results = getAxeBuilder().analyze(homePage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/cases/axe/StudentNotificationsPageAxeTest.java
+++ b/src/e2e/java/teammates/e2e/cases/axe/StudentNotificationsPageAxeTest.java
@@ -26,7 +26,7 @@ public class StudentNotificationsPageAxeTest extends BaseAxeTestCase {
     public void testAll() {
         AppUrl notificationsPageUrl = createFrontendUrl(Const.WebPageURIs.STUDENT_NOTIFICATIONS_PAGE);
         StudentNotificationsPage notificationsPage = loginToPage(notificationsPageUrl, StudentNotificationsPage.class,
-                testData.accounts.get("SNotifs.student").getGoogleId());
+                testData.accounts.get("SNotifs.student").getEmail());
 
         Results results = getAxeBuilder().analyze(notificationsPage.getBrowser().getDriver());
         formatViolations(results);

--- a/src/e2e/java/teammates/e2e/pageobjects/CourseJoinConfirmationPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/CourseJoinConfirmationPage.java
@@ -23,8 +23,8 @@ public class CourseJoinConfirmationPage extends AppPage {
         return true;
     }
 
-    public void verifyJoiningUser(String googleId) {
-        assertEquals(browser.driver.findElement(By.id("user-id")).getText(), googleId);
+    public void verifyJoiningUser(String displayedUserId) {
+        assertEquals(browser.driver.findElement(By.id("user-id")).getText(), displayedUserId);
     }
 
     public <T extends AppPage> T confirmJoinCourse(Class<T> typeOfPage) {

--- a/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.Provider;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.test.BaseTestCase;
@@ -83,6 +84,16 @@ public class TestDataValidityTest extends BaseTestCase {
                     if (!isValidTestEmail(account.getEmail())) {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid account email: " + account.getEmail());
+                    }
+
+                    if (account.getProvider() != Provider.TEAMMATES_DEV) {
+                        errors.computeIfAbsent(pathString, k -> new ArrayList<>())
+                                .add("account provider must be TEAMMATES_DEV: " + account.getProvider());
+                    }
+
+                    if (!account.getEmail().equals(account.getSubject())) {
+                        errors.computeIfAbsent(pathString, k -> new ArrayList<>())
+                                .add("TEAMMATES_DEV account subject must match email: " + account.getEmail());
                     }
                 });
 

--- a/src/e2e/resources/data/AdminAccountsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminAccountsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Instr2",
       "email": "aaccounts.instr2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.AAccounts.instr2"
+      "subject": "aaccounts.instr2@gmail.tmt"
     },
     "AAccounts.instr3": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Teammates Instr3",
       "email": "aaccounts.instr3@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.AAccounts.instr3"
+      "subject": "aaccounts.instr3@gmail.tmt"
     }
   },
   "courses": {

--- a/src/e2e/resources/data/AdminSearchPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSearchPageE2ETest.json
@@ -38,7 +38,7 @@
       "name": "Instructor1 of Course1",
       "email": "asearch.instructor1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ASearch.instr1"
+      "subject": "asearch.instructor1@gmail.tmt"
     },
     "instructor2OfCourse1": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -46,7 +46,7 @@
       "name": "Instructor2 of Course1",
       "email": "asearch.instructor2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ASearch.instr2"
+      "subject": "asearch.instructor2@gmail.tmt"
     },
     "student1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -54,7 +54,7 @@
       "name": "Student1 in course1",
       "email": "asearch.student@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ASearch.student1"
+      "subject": "asearch.student@gmail.tmt"
     },
     "unregisteredInstructor1": {
       "id": "00000000-0000-4000-8000-000000000103",
@@ -62,7 +62,7 @@
       "name": "Typical Instructor Name",
       "email": "asearch.unregisteredinstructor1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "asearch.unregisteredinstructor1"
+      "subject": "asearch.unregisteredinstructor1@gmail.tmt"
     },
     "unregisteredInstructor2": {
       "id": "00000000-0000-4000-8000-000000000104",
@@ -70,7 +70,7 @@
       "name": "Typical Instructor Name",
       "email": "asearch.unregisteredinstructor2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "asearch.unregisteredinstructor2"
+      "subject": "asearch.unregisteredinstructor2@gmail.tmt"
     },
     "unregisteredInstructor3": {
       "id": "00000000-0000-4000-8000-000000000105",
@@ -78,7 +78,7 @@
       "name": "Typical Instructor Name",
       "email": "asearch.unregisteredinstructor3@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "asearch.unregisteredinstructor3"
+      "subject": "asearch.unregisteredinstructor3@gmail.tmt"
     },
     "unregisteredInstructor4": {
       "id": "00000000-0000-4000-8000-000000000106",
@@ -86,7 +86,7 @@
       "name": "Typical Instructor Name",
       "email": "asearch.unregisteredinstructor4@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "asearch.unregisteredinstructor4"
+      "subject": "asearch.unregisteredinstructor4@gmail.tmt"
     },
     "unregisteredInstructor5": {
       "id": "00000000-0000-4000-8000-000000000107",
@@ -94,7 +94,7 @@
       "name": "Typical Instructor Name",
       "email": "asearch.unregisteredinstructor5@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "asearch.unregisteredinstructor5"
+      "subject": "asearch.unregisteredinstructor5@gmail.tmt"
     }
   },
   "accountVerificationRequests": {

--- a/src/e2e/resources/data/AdminSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/AdminSessionsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Instructor1 of Course1",
       "email": "asess.instructor1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ASess.instr1",
+      "subject": "asess.instructor1@gmail.tmt",
       "readNotifications": {}
     }
   },

--- a/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
+++ b/src/e2e/resources/data/AutomatedSessionRemindersE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Test Ins for Aut Sessions Reminder",
       "email": "autsesrem.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.AutSesRem.instructor"
+      "subject": "autsesrem.instructor@gmail.tmt"
     }
   },
   "courses": {

--- a/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumOptionQuestionE2ETest.json
@@ -11,25 +11,25 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FCSumOptQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcsumoptqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumOptQn.instructor"
+      "subject": "fcsumoptqn.instructor@gmail.tmt"
     },
     "tm.e2e.FCSumOptQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FCSumOptQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fcsumoptqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumOptQn.alice.tmms"
+      "subject": "fcsumoptqn.alice.tmms@gmail.tmt"
     },
     "tm.e2e.FCSumOptQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FCSumOptQn.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "fcsumoptqn.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumOptQn.benny.tmms"
+      "subject": "fcsumoptqn.benny.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -49,7 +49,7 @@
   "instructors": {
     "instructor": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcsumoptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000501",
@@ -59,7 +59,7 @@
     },
     "instructor2": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcsumoptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000502",
@@ -72,7 +72,7 @@
     "alice.tmms@FCSumOptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FCSumOptQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fcsumoptqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",
@@ -81,7 +81,7 @@
     "benny.tmms@FCSumOptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FCSumOptQn.CS2104",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "fcsumoptqn.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000003",

--- a/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackConstSumRecipientQuestionE2ETest.json
@@ -11,25 +11,25 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FCSumRcptQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcsumrcptqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumRcptQn.instructor"
+      "subject": "fcsumrcptqn.instructor@gmail.tmt"
     },
     "tm.e2e.FCSumRcptQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FCSumRcptQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fcsumrcptqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumRcptQn.alice.tmms"
+      "subject": "fcsumrcptqn.alice.tmms@gmail.tmt"
     },
     "tm.e2e.FCSumRcptQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FCSumRcptQn.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "fcsumrcptqn.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumRcptQn.benny.tmms"
+      "subject": "fcsumrcptqn.benny.tmms@gmail.tmt"
     },
     "tm.e2e.FCSumRcptQn.charlie.tmms": {
       "id": "00000000-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "Charlie Davis",
       "email": "fcsumrcptqn.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumRcptQn.charlie.tmms"
+      "subject": "fcsumrcptqn.charlie.tmms@gmail.tmt"
     },
     "tm.e2e.FCSumRcptQn.danny.tmms": {
       "id": "00000000-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "Danny Engrid",
       "email": "fcsumrcptqn.danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCSumRcptQn.danny.tmms"
+      "subject": "fcsumrcptqn.danny.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -67,7 +67,7 @@
       "id": "00000000-0000-4000-8000-000000000501",
       "courseId": "tm.e2e.FCSumRcptQn.CS2104",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcsumrcptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -77,7 +77,7 @@
       "id": "00000000-0000-4000-8000-000000000502",
       "courseId": "tm.e2e.FCSumRcptQn.CS1101",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcsumrcptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -88,7 +88,7 @@
     "alice.tmms@FCSumRcptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FCSumRcptQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fcsumrcptqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",
@@ -97,7 +97,7 @@
     "benny.tmms@FCSumRcptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FCSumRcptQn.CS2104",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "fcsumrcptqn.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000003",

--- a/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackContributionQuestionE2ETest.json
@@ -11,41 +11,41 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FContrQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcontrqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FContrQn.instructor"
+      "subject": "fcontrqn.instructor@gmail.tmt"
     },
     "tm.e2e.FContrQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FCContrQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fccontrqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCContrQn.alice.tmms"
+      "subject": "fccontrqn.alice.tmms@gmail.tmt"
     },
     "tm.e2e.FContrQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FCContrQn.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "fccontrqn.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCContrQn.benny.tmms"
+      "subject": "fccontrqn.benny.tmms@gmail.tmt"
     },
     "tm.e2e.FContrQn.charlie.tmms": {
       "id": "00000000-0000-4000-8000-000000000004",
       "googleId": "tm.e2e.FCContrQn.charlie.tmms",
       "name": "Charlie Davis",
-      "email": "charlie.d.tmms@gmail.tmt",
+      "email": "fccontrqn.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCContrQn.charlie.tmms"
+      "subject": "fccontrqn.charlie.tmms@gmail.tmt"
     },
     "tm.e2e.FContrQn.danny.tmms": {
       "id": "00000000-0000-4000-8000-000000000005",
       "googleId": "tm.e2e.FCContrQn.danny.tmms",
       "name": "Danny Engrid",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "fccontrqn.danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FCContrQn.danny.tmms"
+      "subject": "fccontrqn.danny.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -66,7 +66,7 @@
     "instructor": {
       "courseId": "tm.e2e.FContrQn.CS2104",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcontrqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -76,7 +76,7 @@
     "instructor2": {
       "courseId": "tm.e2e.FContrQn.CS1101",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fcontrqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -88,7 +88,7 @@
     "alice.tmms@FContrQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FContrQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fccontrqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",
@@ -97,7 +97,7 @@
     "benny.tmms@FContrQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FContrQn.CS2104",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "fccontrqn.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000003",
@@ -106,7 +106,7 @@
     "charlie.tmms@FContrQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000603",
       "courseId": "tm.e2e.FContrQn.CS2104",
-      "email": "fcontrqn.charlie.tmms@gmail.tmt",
+      "email": "fccontrqn.charlie.tmms@gmail.tmt",
       "name": "Charlie Davis",
       "comments": "This student's name is Charlie Davis",
       "accountId": "00000000-0000-4000-8000-000000000004",
@@ -115,7 +115,7 @@
     "danny.tmms@FContrQn.CS1101": {
       "id": "00000000-0000-4000-8000-000000000604",
       "courseId": "tm.e2e.FContrQn.CS1101",
-      "email": "fcontrqn.danny.tmms@gmail.tmt",
+      "email": "fccontrqn.danny.tmms@gmail.tmt",
       "name": "Danny Engrid",
       "comments": "This student's name is Danny Engrid",
       "accountId": "00000000-0000-4000-8000-000000000005",

--- a/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMcqQuestionE2ETest.json
@@ -11,25 +11,25 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FMcqQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fmcqqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FMcqQn.instructor"
+      "subject": "fmcqqn.instructor@gmail.tmt"
     },
     "tm.e2e.FMcqQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FMcqQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fmcqqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FMcqQn.alice.tmms"
+      "subject": "fmcqqn.alice.tmms@gmail.tmt"
     },
     "tm.e2e.FMcqQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FMcqQn.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "fmcqqn.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FMcqQn.benny.tmms"
+      "subject": "fmcqqn.benny.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -51,7 +51,7 @@
     "instructor": {
       "id": "00000000-0000-4000-8000-000000000501",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fmcqqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -62,7 +62,7 @@
       "id": "00000000-0000-4000-8000-000000000502",
       "courseId": "tm.e2e.FMcqQn.CS1101",
       "displayName": "Co-owner",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fmcqqn.instructor@gmail.tmt",
       "isDisplayedToStudents": true,
       "name": "Teammates Test",
       "role": "COOWNER",
@@ -87,7 +87,7 @@
     "alice.tmms@FMcqQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FMcqQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fmcqqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",
@@ -96,7 +96,7 @@
     "benny.tmms@FMcqQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FMcqQn.CS2104",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "fmcqqn.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000003",

--- a/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackMsqQuestionE2ETest.json
@@ -11,17 +11,17 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FMsqQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fmsqqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FMsqQn.instructor"
+      "subject": "fmsqqn.instructor@gmail.tmt"
     },
     "tm.e2e.FMsqQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FMsqQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fmsqqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FMsqQn.alice.tmms"
+      "subject": "fmsqqn.alice.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -43,7 +43,7 @@
     "instructor": {
       "id": "00000000-0000-4000-8000-000000000501",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fmsqqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "courseId": "tm.e2e.FMsqQn.CS2104",
@@ -61,7 +61,7 @@
     },
     "instructor3": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fmsqqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000503",
@@ -190,7 +190,7 @@
     "alice.tmms@FMsqQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FMsqQn.CS2104",
-      "email": "alice.b.tmm1s@gmail.tmt",
+      "email": "fmsqqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",

--- a/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackNumScaleQuestionE2ETest.json
@@ -10,18 +10,18 @@
     "instructorWithSessions": {
       "googleId": "tm.e2e.FNumScaleQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fnumscaleqn.instructor@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FNumScaleQn.instructor"
+      "subject": "fnumscaleqn.instructor@gmail.tmt"
     },
     "tm.e2e.FNumScaleQn.alice.tmms": {
       "googleId": "tm.e2e.FNumScaleQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fnumscaleqn.alice.tmms@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FNumScaleQn.alice.tmms"
+      "subject": "fnumscaleqn.alice.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -42,7 +42,7 @@
   "instructors": {
     "instructor": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fnumscaleqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000501",
@@ -52,7 +52,7 @@
     },
     "instructor2": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "fnumscaleqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000502",
@@ -177,7 +177,7 @@
     "alice.tmms@FNumScaleQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FNumScaleQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "fnumscaleqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",

--- a/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankOptionQuestionE2ETest.json
@@ -11,41 +11,41 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FRankOptQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frankoptqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankOptQn.instructor"
+      "subject": "frankoptqn.instructor@gmail.tmt"
     },
     "tm.e2e.FRankOptQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.FRankOptQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "frankoptqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankOptQn.alice.tmms"
+      "subject": "frankoptqn.alice.tmms@gmail.tmt"
     },
     "tm.e2e.FRankOptQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FRankOptQn.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "frankoptqn.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankOptQn.benny.tmms"
+      "subject": "frankoptqn.benny.tmms@gmail.tmt"
     },
     "tm.e2e.FRankOptQn.charlie.tmms": {
       "id": "00000000-0000-4000-8000-000000000004",
       "googleId": "tm.e2e.FRankOptQn.charlie.tmms",
       "name": "Charlie Davis",
-      "email": "charlie.d.tmms@gmail.tmt",
+      "email": "frankoptqn.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankOptQn.charlie.tmms"
+      "subject": "frankoptqn.charlie.tmms@gmail.tmt"
     },
     "tm.e2e.FRankOptQn.danny.tmms": {
       "id": "00000000-0000-4000-8000-000000000005",
       "googleId": "tm.e2e.FRankOptQn.danny.tmms",
       "name": "Danny Engrid",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "frankoptqn.danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankOptQn.danny.tmms"
+      "subject": "frankoptqn.danny.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -67,7 +67,7 @@
     "instructor": {
       "id": "00000000-0000-4000-8000-000000000501",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frankoptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -78,7 +78,7 @@
       "id": "00000000-0000-4000-8000-000000000502",
       "courseId": "tm.e2e.FRankOptQn.CS1101",
       "displayName": "Co-owner",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frankoptqn.instructor@gmail.tmt",
       "isDisplayedToStudents": true,
       "name": "Teammates Test",
       "role": "COOWNER",
@@ -108,7 +108,7 @@
     "alice.tmms@FRankOptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FRankOptQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "frankoptqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",
@@ -117,7 +117,7 @@
     "benny.tmms@FRankOptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FRankOptQn.CS2104",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "frankoptqn.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000003",
@@ -126,7 +126,7 @@
     "charlie.tmms@FRankOptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000603",
       "courseId": "tm.e2e.FRankOptQn.CS2104",
-      "email": "charlie.d.tmms@gmail.tmt",
+      "email": "frankoptqn.charlie.tmms@gmail.tmt",
       "name": "Charlie Davis",
       "comments": "This student's name is Charlie Davis",
       "accountId": "00000000-0000-4000-8000-000000000004",
@@ -135,7 +135,7 @@
     "danny.tmms@FRankOptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000604",
       "courseId": "tm.e2e.FRankOptQn.CS2104",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "frankoptqn.danny.tmms@gmail.tmt",
       "name": "Danny Engrid",
       "comments": "This student's name is Danny Engrid",
       "accountId": "00000000-0000-4000-8000-000000000005",

--- a/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRankRecipientQuestionE2ETest.json
@@ -11,9 +11,9 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FRankRcptQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frankrcptqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankRcptQn.instructor"
+      "subject": "frankrcptqn.instructor@gmail.tmt"
     },
     "instructor2": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,39 +21,39 @@
       "name": "Teammates Test 2",
       "email": "tmms.test2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankRcptQn.instructor2"
+      "subject": "tmms.test2@gmail.tmt"
     },
     "tm.e2e.FRankRcptQn.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.FRankRcptQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "frankrcptqn.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankRcptQn.alice.tmms"
+      "subject": "frankrcptqn.alice.tmms@gmail.tmt"
     },
     "tm.e2e.FRankRcptQn.benny.tmms": {
       "id": "00000000-0000-4000-8000-000000000004",
       "googleId": "tm.e2e.FRankRcptQn.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "frankrcptqn.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankRcptQn.benny.tmms"
+      "subject": "frankrcptqn.benny.tmms@gmail.tmt"
     },
     "tm.e2e.FRankRcptQn.charlie.tmms": {
       "id": "00000000-0000-4000-8000-000000000005",
       "googleId": "tm.e2e.FRankRcptQn.charlie.tmms",
       "name": "Charlie Davis",
-      "email": "charlie.d.tmms@gmail.tmt",
+      "email": "frankrcptqn.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankRcptQn.charlie.tmms"
+      "subject": "frankrcptqn.charlie.tmms@gmail.tmt"
     },
     "tm.e2e.FRankRcptQn.danny.tmms": {
       "id": "00000000-0000-4000-8000-000000000006",
       "googleId": "tm.e2e.FRankRcptQn.danny.tmms",
       "name": "Danny Engrid",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "frankrcptqn.danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRankRcptQn.danny.tmms"
+      "subject": "frankrcptqn.danny.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -74,7 +74,7 @@
     "instructor": {
       "courseId": "tm.e2e.FRankRcptQn.CS2104",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frankrcptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -94,7 +94,7 @@
     "instructor3": {
       "courseId": "tm.e2e.FRankRcptQn.CS1101",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frankrcptqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -106,7 +106,7 @@
     "alice.tmms@FRankRcptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FRankRcptQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "frankrcptqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000003",
@@ -115,7 +115,7 @@
     "benny.tmms@FRankRcptQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FRankRcptQn.CS2104",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "frankrcptqn.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000004",

--- a/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackResultsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "fres.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.instr"
+      "subject": "fres.instr@gmail.tmt"
     },
     "FRes.instr2": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Teammates Test",
       "email": "fres.instr2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.instr2"
+      "subject": "fres.instr2@gmail.tmt"
     },
     "FRes.alice.b": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,7 +29,7 @@
       "name": "Alice B.",
       "email": "fres.alice.b@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.alice.b"
+      "subject": "fres.alice.b@gmail.tmt"
     },
     "FRes.benny.c": {
       "id": "00000000-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "Benny C.",
       "email": "fres.benny.c@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.benny.c"
+      "subject": "fres.benny.c@gmail.tmt"
     },
     "FRes.charlie.d": {
       "id": "00000000-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "Charlie D.",
       "email": "fres.charlie.d@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.charlie.d"
+      "subject": "fres.charlie.d@gmail.tmt"
     },
     "FRes.danny.e": {
       "id": "00000000-0000-4000-8000-000000000006",
@@ -53,7 +53,7 @@
       "name": "Danny E.",
       "email": "fres.danny.e@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.danny.e"
+      "subject": "fres.danny.e@gmail.tmt"
     },
     "FRes.emily.f": {
       "id": "00000000-0000-4000-8000-000000000007",
@@ -61,7 +61,7 @@
       "name": "Emily F.",
       "email": "fres.emily.f@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRes.emily.f"
+      "subject": "fres.emily.f@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackRubricQuestionE2ETest.json
@@ -11,9 +11,33 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.FRubricQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frubricqn.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FRubricQn.instructor"
+      "subject": "frubricqn.instructor@gmail.tmt"
+    },
+    "tm.e2e.FRubricQn.alice.tmms": {
+      "id": "00000000-0000-4000-8000-000000000002",
+      "googleId": "tm.e2e.FRubricQn.alice.tmms",
+      "name": "Alice Betsy",
+      "email": "frubricqn.alice.tmms@gmail.tmt",
+      "provider": "TEAMMATES_DEV",
+      "subject": "frubricqn.alice.tmms@gmail.tmt"
+    },
+    "tm.e2e.FRubricQn.benny.tmms": {
+      "id": "00000000-0000-4000-8000-000000000003",
+      "googleId": "tm.e2e.FRubricQn.benny.tmms",
+      "name": "Benny Charles",
+      "email": "frubricqn.benny.tmms@gmail.tmt",
+      "provider": "TEAMMATES_DEV",
+      "subject": "frubricqn.benny.tmms@gmail.tmt"
+    },
+    "tm.e2e.FRubricQn.charlie.tmms": {
+      "id": "00000000-0000-4000-8000-000000000004",
+      "googleId": "tm.e2e.FRubricQn.charlie.tmms",
+      "name": "Charlie Davis",
+      "email": "frubricqn.charlie.tmms@gmail.tmt",
+      "provider": "TEAMMATES_DEV",
+      "subject": "frubricqn.charlie.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -64,7 +88,7 @@
       "id": "00000000-0000-4000-8000-000000000501",
       "courseId": "tm.e2e.FRubricQn.CS2104",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frubricqn.instructor@gmail.tmt",
       "regKey": "4F647E6C589F4A653FE2E00ACBF60E97098AEE5B9B2B344F1433AC3336D567FE498879D5EDC75B130B1D4316641CEEE7AA53CA47CAAE91920644B3AC4DC6D66F",
       "accountId": "00000000-0000-4000-8000-000000000001"
     },
@@ -75,7 +99,7 @@
       "id": "00000000-0000-4000-8000-000000000502",
       "courseId": "tm.e2e.FRubricQn.CS1101",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "frubricqn.instructor@gmail.tmt",
       "regKey": "4F647E6C589F4A653FE2E00ACBF60E97098AEE5B9B2B344F1433AC3336D567FEA097E915F0B418903EA5756DB26891F20E0D47726D1FAA6CE0C29EAF17D950CD",
       "accountId": "00000000-0000-4000-8000-000000000001"
     }
@@ -86,9 +110,9 @@
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.FRubricQn.CS2104",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "frubricqn.alice.tmms@gmail.tmt",
       "regKey": "EBE50B16D49CF8511F63AC64F55EEE9A9BBF979EDD08808B815CB748176E61CBBD7364C6F112325851C21A8237FE3F2B9D157BBE8E0A82BFC8695990DDDB8DDB",
-      "accountId": "00000000-0000-4000-8000-000000000001",
+      "accountId": "00000000-0000-4000-8000-000000000002",
       "teamId": "00000000-0000-4000-8000-000000000301"
     },
     "benny.tmms@FRubricQn.CS2104": {
@@ -96,9 +120,9 @@
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.FRubricQn.CS2104",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "frubricqn.benny.tmms@gmail.tmt",
       "regKey": "4E89CF58E1263D114A5A352555BDEF24FE9EBA55575B73F1FCDE2A30FF8DF1C8A04289CB0E187D938973732E18082EBF82A64E5B2EC66152A7A50EBB4790F91F",
-      "accountId": "00000000-0000-4000-8000-000000000001",
+      "accountId": "00000000-0000-4000-8000-000000000003",
       "teamId": "00000000-0000-4000-8000-000000000301"
     },
     "charlie.tmms@FRubricQn.CS2104": {
@@ -108,7 +132,7 @@
       "name": "Charlie Davis",
       "email": "frubricqn.charlie.tmms@gmail.tmt",
       "regKey": "067D131524890778C6BBB57B778D4F2FBCF1FA17123302BA4FBBC6705321C17311B2393495AFC68170567B84EB749F9C59DB034E6B00DC113C1D97A09171A55F438B4CED8016561F1425C109373DEA8C",
-      "accountId": "00000000-0000-4000-8000-000000000001",
+      "accountId": "00000000-0000-4000-8000-000000000004",
       "teamId": "00000000-0000-4000-8000-000000000301"
     },
     "danny.tmms@FRubricQn.CS1101": {

--- a/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
+++ b/src/e2e/resources/data/FeedbackSubmitPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "fsubmit.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.instr"
+      "subject": "fsubmit.instr@gmail.tmt"
     },
     "FSubmit.instr2": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Teammates Test2",
       "email": "fsubmit.instr2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.instr2"
+      "subject": "fsubmit.instr2@gmail.tmt"
     },
     "FSubmit.alice.b": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,7 +29,7 @@
       "name": "Alice Betsy",
       "email": "fsubmit.alice.b@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.alice.b"
+      "subject": "fsubmit.alice.b@gmail.tmt"
     },
     "FSubmit.benny.c": {
       "id": "00000000-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "Benny Charles",
       "email": "fsubmit.benny.c@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.benny.c"
+      "subject": "fsubmit.benny.c@gmail.tmt"
     },
     "FSubmit.charlie.d": {
       "id": "00000000-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "Charlie Davis",
       "email": "fsubmit.charlie.d@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.charlie.d"
+      "subject": "fsubmit.charlie.d@gmail.tmt"
     },
     "FSubmit.danny.e": {
       "id": "00000000-0000-4000-8000-000000000006",
@@ -53,7 +53,7 @@
       "name": "Danny Engrid",
       "email": "fsubmit.danny.e@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.danny.e"
+      "subject": "fsubmit.danny.e@gmail.tmt"
     },
     "FSubmit.emily.f": {
       "id": "00000000-0000-4000-8000-000000000007",
@@ -61,7 +61,7 @@
       "name": "Emily",
       "email": "fsubmit.emily.f@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FSubmit.emily.f"
+      "subject": "fsubmit.emily.f@gmail.tmt"
     }
   },
   "courses": {

--- a/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
+++ b/src/e2e/resources/data/FeedbackTextQuestionE2ETest.json
@@ -10,18 +10,18 @@
     "instructorWithSessions": {
       "googleId": "tm.e2e.FTextQn.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "ftextqn.instructor@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FTextQn.instructor"
+      "subject": "ftextqn.instructor@gmail.tmt"
     },
     "tm.e2e.FTextQn.alice.tmms": {
       "googleId": "tm.e2e.FTextQn.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "ftextqn.alice.tmms@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.FTextQn.alice.tmms"
+      "subject": "ftextqn.alice.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -42,7 +42,7 @@
   "instructors": {
     "instructor": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "ftextqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000501",
@@ -61,7 +61,7 @@
     },
     "instructor3": {
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "ftextqn.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "id": "00000000-0000-4000-8000-000000000503",
@@ -167,7 +167,7 @@
     "alice.tmms@FTextQn.CS2104": {
       "id": "00000000-0000-4000-8000-000000000604",
       "courseId": "tm.e2e.FTextQn.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "ftextqn.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",

--- a/src/e2e/resources/data/InstructorCourseDetailsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseDetailsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "icdet.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICDet.instr"
+      "subject": "icdet.instr@gmail.tmt"
     },
     "ICDet.instr2": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,23 +21,23 @@
       "name": "Teammates Test 2",
       "email": "icdet.instr2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICDet.instr2"
+      "subject": "icdet.instr2@gmail.tmt"
     },
     "Alice": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.ICDet.alice.b",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "icdet.alice.b@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICDet.alice.b"
+      "subject": "icdet.alice.b@gmail.tmt"
     },
     "Danny": {
       "id": "00000000-0000-4000-8000-000000000004",
       "googleId": "tm.e2e.ICDet.danny.e",
       "name": "Charlie Davis",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "icdet.danny.e@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICDet.danny.e"
+      "subject": "icdet.danny.e@gmail.tmt"
     }
   },
   "courses": {
@@ -74,7 +74,7 @@
     "alice.tmms@ICDet.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.ICDet.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "icdet.alice.b@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000003",
@@ -99,7 +99,7 @@
     "danny.tmms@ICDet.CS2104": {
       "id": "00000000-0000-4000-8000-000000000604",
       "courseId": "tm.e2e.ICDet.CS2104",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "icdet.danny.e@gmail.tmt",
       "name": "Danny Engrid",
       "comments": "This student's name is Danny Engrid",
       "accountId": "00000000-0000-4000-8000-000000000004",

--- a/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseEditPageE2ETest.json
@@ -11,17 +11,17 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.ICEdit.coowner",
       "name": "Teammates Test",
-      "email": "icedit.coowner@gmail.tmt",
+      "email": "icedit.coowner.cs2104@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.coowner"
+      "subject": "icedit.coowner.cs2104@gmail.tmt"
     },
     "ICEdit.observer": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.ICEdit.observer",
       "name": "Teammates Instructor",
-      "email": "icedit.observer@gmail.tmt",
+      "email": "icedit.observer.cs2104@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.observer"
+      "subject": "icedit.observer.cs2104@gmail.tmt"
     },
     "ICEdit.manager.CS2104": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,7 +29,7 @@
       "name": "CS2104 Manager",
       "email": "icedit.manager.cs2104@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.manager.CS2104"
+      "subject": "icedit.manager.cs2104@gmail.tmt"
     },
     "ICEdit.tutor.CS2104": {
       "id": "00000000-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "CS2104 Tutor",
       "email": "icedit.tutor.cs2104@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.tutor.CS2104"
+      "subject": "icedit.tutor.cs2104@gmail.tmt"
     },
     "ICEdit.helper.CS2104": {
       "id": "00000000-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "CS2104 Helper",
       "email": "icedit.helper.cs2104@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.helper.CS2104"
+      "subject": "icedit.helper.cs2104@gmail.tmt"
     },
     "ICEdit.helper.CS2103T": {
       "id": "00000000-0000-4000-8000-000000000006",
@@ -53,7 +53,7 @@
       "name": "CS2103T Helper",
       "email": "icedit.helper.cs2103t@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.helper.CS2103T"
+      "subject": "icedit.helper.cs2103t@gmail.tmt"
     },
     "ICEdit.manager.CS2105": {
       "id": "00000000-0000-4000-8000-000000000007",
@@ -61,7 +61,7 @@
       "name": "CS2105 Manager",
       "email": "icedit.manager.cs2105@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.manager.CS2105"
+      "subject": "icedit.manager.cs2105@gmail.tmt"
     },
     "ICEdit.tutor.CS2106": {
       "id": "00000000-0000-4000-8000-000000000008",
@@ -69,31 +69,31 @@
       "name": "CS2106 Tutor",
       "email": "icedit.tutor.cs2106@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.tutor.CS2106"
+      "subject": "icedit.tutor.cs2106@gmail.tmt"
     },
     "tm.e2e.ICEdit.alice.tmms": {
       "id": "00000000-0000-4000-8000-000000000009",
       "googleId": "tm.e2e.ICEdit.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "icedit.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.alice.tmms"
+      "subject": "icedit.alice.tmms@gmail.tmt"
     },
     "tm.e2e.ICEdit.charlie.tmms": {
       "id": "00000000-0000-4000-8000-000000000010",
       "googleId": "tm.e2e.ICEdit.charlie.tmms",
       "name": "Charlie Davis",
-      "email": "charlie.d.tmms@gmail.tmt",
+      "email": "icedit.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.charlie.tmms"
+      "subject": "icedit.charlie.tmms@gmail.tmt"
     },
     "tm.e2e.ICEdit.danny.tmms": {
       "id": "00000000-0000-4000-8000-000000000011",
       "googleId": "tm.e2e.ICEdit.danny.tmms",
       "name": "Danny Engrid",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "icedit.danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEdit.danny.tmms"
+      "subject": "icedit.danny.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -302,7 +302,7 @@
     "alice.tmms@ICEdit.CS2104": {
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.ICEdit.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "icedit.alice.tmms@gmail.tmt",
       "name": "Alice Betsy</option></td></div>'\"",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000009",
@@ -311,7 +311,7 @@
     "charlie.tmms@ICEdit.CS2104": {
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.ICEdit.CS2104",
-      "email": "charlie.d.tmms@gmail.tmt",
+      "email": "icedit.charlie.tmms@gmail.tmt",
       "name": "Charlie Davis",
       "comments": "This student's name is Charlie Davis",
       "accountId": "00000000-0000-4000-8000-000000000010",
@@ -320,7 +320,7 @@
     "danny.tmms@ICEdit.CS2104": {
       "id": "00000000-0000-4000-8000-000000000603",
       "courseId": "tm.e2e.ICEdit.CS2104",
-      "email": "danny.e.tmms@gmail.tmt",
+      "email": "icedit.danny.tmms@gmail.tmt",
       "name": "Danny Engrid",
       "comments": "This student's name is Danny Engrid",
       "accountId": "00000000-0000-4000-8000-000000000011",

--- a/src/e2e/resources/data/InstructorCourseEnrollPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseEnrollPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Instructor of Course CS2104",
       "email": "icenroll.instr1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICEnroll.instr1"
+      "subject": "icenroll.instr1@gmail.tmt"
     }
   },
   "courses": {

--- a/src/e2e/resources/data/InstructorCourseJoinConfirmationPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseJoinConfirmationPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "icjoinconf.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICJoinConf.instr"
+      "subject": "icjoinconf.instr@gmail.tmt"
     },
     "ICJoinConf.instr.CS1101": {
       "id": "00000000-0000-4000-8000-000000000101",
@@ -21,7 +21,7 @@
       "name": "Teammates Test 2",
       "email": "icjoinconf.instr2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "icjoinconf.instr2"
+      "subject": "icjoinconf.instr2@gmail.tmt"
     },
     "ICJoinConf.newinstr": {
       "id": "00000000-0000-4000-8000-000000000201",
@@ -29,7 +29,7 @@
       "name": "Teammates Test 3",
       "email": "icjoinconf.newinstr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "icjoinconf.newinstr"
+      "subject": "icjoinconf.newinstr@gmail.tmt"
     }
   },
   "accountVerificationRequests": {

--- a/src/e2e/resources/data/InstructorCourseStudentDetailsEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseStudentDetailsEditPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "icsdetedit.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICSDetEdit.instr"
+      "subject": "icsdetedit.instr@gmail.tmt"
     },
     "José Gómez": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "José Gómez",
       "email": "icsdetedit.jose.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICSDetEdit.jose.tmms"
+      "subject": "icsdetedit.jose.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorCourseStudentDetailsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCourseStudentDetailsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "icsdet.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICSDet.instr"
+      "subject": "icsdet.instr@gmail.tmt"
     },
     "José Gómez": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "José Gómez",
       "email": "icsdet.jose.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICSDet.jose.tmms"
+      "subject": "icsdet.jose.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorCoursesPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Demo Instr",
       "email": "ics.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICs.instructor"
+      "subject": "ics.instructor@gmail.tmt"
     },
     "tm.e2e.ICs.student1": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "student1",
       "email": "ics.student1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICs.student1"
+      "subject": "ics.student1@gmail.tmt"
     },
     "tm.e2e.ICs.student2": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,7 +29,7 @@
       "name": "student2",
       "email": "ics.student2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ICs.student2"
+      "subject": "ics.student2@gmail.tmt"
     }
   },
   "courses": {

--- a/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackEditPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "instfep.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.InstFEP.instr"
+      "subject": "instfep.instr@gmail.tmt"
     },
     "José Gómez": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "José Gómez",
       "email": "instfep.jose.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.InstFEP.jose.tmms"
+      "subject": "instfep.jose.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackReportPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test 1",
       "email": "ifrep.instr1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.instr"
+      "subject": "ifrep.instr1@gmail.tmt"
     },
     "tm.e2e.IFRep.instr2": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Teammates Test 2",
       "email": "ifrep.instr2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.instr2"
+      "subject": "ifrep.instr2@gmail.tmt"
     },
     "tm.e2e.IFRep.alice.b": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,7 +29,7 @@
       "name": "Alice Betsy",
       "email": "ifrep.alice.b@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.alice.b"
+      "subject": "ifrep.alice.b@gmail.tmt"
     },
     "tm.e2e.IFRep.benny.c": {
       "id": "00000000-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "Benny Charles",
       "email": "ifrep.benny.c@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.benny.c"
+      "subject": "ifrep.benny.c@gmail.tmt"
     },
     "tm.e2e.IFRep.charlie.d": {
       "id": "00000000-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "Charlie Davis",
       "email": "ifrep.charlie.d@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.charlie.d"
+      "subject": "ifrep.charlie.d@gmail.tmt"
     },
     "tm.e2e.IFRep.danny.e": {
       "id": "00000000-0000-4000-8000-000000000006",
@@ -53,7 +53,7 @@
       "name": "Danny Engrid",
       "email": "ifrep.danny.e@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.danny.e"
+      "subject": "ifrep.danny.e@gmail.tmt"
     },
     "tm.e2e.IFRep.emily.f": {
       "id": "00000000-0000-4000-8000-000000000007",
@@ -61,7 +61,7 @@
       "name": "Emily F.",
       "email": "ifrep.emily.f@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.emily.f"
+      "subject": "ifrep.emily.f@gmail.tmt"
     },
     "tm.e2e.IFRep.fred.g": {
       "id": "00000000-0000-4000-8000-000000000008",
@@ -69,7 +69,7 @@
       "name": "Fred G.",
       "email": "ifrep.fred.g@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFRep.fred.g"
+      "subject": "ifrep.fred.g@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorFeedbackSessionsPageE2ETest.json
@@ -11,25 +11,25 @@
       "id": "00000001-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.IFSessionPage.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "ifsessionpage.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFSessionPage.alice.tmms"
+      "subject": "ifsessionpage.alice.tmms@gmail.tmt"
     },
     "IFSessionPage.benny": {
       "id": "00000001-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.IFSessionPage.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "ifsessionpage.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFSessionPage.benny.tmms"
+      "subject": "ifsessionpage.benny.tmms@gmail.tmt"
     },
     "IFSessionPage.charlie": {
       "id": "00000001-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.IFSessionPage.charlie.tmms",
       "name": "Charlie Davis",
-      "email": "charlie.tmms@gmail.tmt",
+      "email": "ifsessionpage.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFSessionPage.charlie.tmms"
+      "subject": "ifsessionpage.charlie.tmms@gmail.tmt"
     },
     "IFSessionPage.danny": {
       "id": "00000001-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "Danny Engrid",
       "email": "ifsessionpage.danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFSessionPage.danny.tmms"
+      "subject": "ifsessionpage.danny.tmms@gmail.tmt"
     },
     "IFSessionPage.emma": {
       "id": "00000001-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "Emma Farrell",
       "email": "ifsessionpage.emma.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFSessionPage.emma.tmms"
+      "subject": "ifsessionpage.emma.tmms@gmail.tmt"
     },
     "IFSessionPage.instr1": {
       "id": "00000000-0000-4000-8000-000000000001",
@@ -53,7 +53,7 @@
       "name": "Instructor 1",
       "email": "ifsessionpage.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IFSessionPage.instr1"
+      "subject": "ifsessionpage.instr@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -127,7 +127,7 @@
     "IFSessionPage.alice": {
       "id": "00000001-0000-4000-8000-000000000501",
       "courseId": "tm.e2e.CS2104",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "ifsessionpage.alice.tmms@gmail.tmt",
       "name": "Alice Betsy",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000001-0000-4000-8000-000000000001",
@@ -136,7 +136,7 @@
     "IFSessionPage.benny": {
       "id": "00000001-0000-4000-8000-000000000502",
       "courseId": "tm.e2e.CS2104",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "ifsessionpage.benny.tmms@gmail.tmt",
       "name": "Benny Charles",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000001-0000-4000-8000-000000000002",
@@ -145,7 +145,7 @@
     "IFSessionPage.charlie": {
       "id": "00000001-0000-4000-8000-000000000503",
       "courseId": "tm.e2e.CS2104",
-      "email": "charlie.tmms@gmail.tmt",
+      "email": "ifsessionpage.charlie.tmms@gmail.tmt",
       "name": "Charlie Davis",
       "comments": "This student's name is Charlie Davis",
       "accountId": "00000001-0000-4000-8000-000000000003",

--- a/src/e2e/resources/data/InstructorHomePageE2ETest.json
+++ b/src/e2e/resources/data/InstructorHomePageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "ihome.instructor.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.IHome.instructor.tmms"
+      "subject": "ihome.instructor.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorNotificationsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorNotificationsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test",
       "email": "inotifs.instr@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.INotifs.instr"
+      "subject": "inotifs.instr@gmail.tmt"
     }
   },
   "courses": {

--- a/src/e2e/resources/data/InstructorSearchPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorSearchPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Instructor 1 of Course 1",
       "email": "isearch.instr1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISearch.instr1"
+      "subject": "isearch.instr1@gmail.tmt"
     },
     "student1InCourse1": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Student 1 in course 1",
       "email": "isearch.student1@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISearch.student1"
+      "subject": "isearch.student1@gmail.tmt"
     },
     "student2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,7 +29,7 @@
       "name": "Student in two courses",
       "email": "isearch.student2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISearch.student2"
+      "subject": "isearch.student2@gmail.tmt"
     },
     "student2.2InCourse1": {
       "id": "00000000-0000-4000-8000-000000000004",
@@ -37,7 +37,7 @@
       "name": "Student in two courses",
       "email": "isearch.student2.2@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISearch.student2.2"
+      "subject": "isearch.student2.2@gmail.tmt"
     },
     "student3InCourse1": {
       "id": "00000000-0000-4000-8000-000000000005",
@@ -45,7 +45,7 @@
       "name": "Student 3 in course 1",
       "email": "isearch.student3@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISearch.student3"
+      "subject": "isearch.student3@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorSessionIndividualExtensionPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorSessionIndividualExtensionPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Instructor 1",
       "email": "instructor1.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.instructor1"
+      "subject": "instructor1.tmms@gmail.tmt"
     },
     "ISesIe.instructor2": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Instructor 2",
       "email": "instructor2.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.instructor2"
+      "subject": "instructor2.tmms@gmail.tmt"
     },
     "alice.tmms@ISesIe.CS2104": {
       "id": "00000000-0000-4000-8000-000000000003",
@@ -29,23 +29,23 @@
       "name": "Alice Betsy",
       "email": "alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.alice.tmms"
+      "subject": "alice.tmms@gmail.tmt"
     },
     "benny.tmms@ISesIe.CS2104": {
       "id": "00000000-0000-4000-8000-000000000004",
       "googleId": "tm.e2e.ISesIe.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "isesie.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.benny.tmms"
+      "subject": "isesie.benny.tmms@gmail.tmt"
     },
     "charlie.tmms@ISesIe.CS2104": {
       "id": "00000000-0000-4000-8000-000000000005",
       "googleId": "tm.e2e.ISesIe.charlie.tmms",
       "name": "Charlie Davis",
-      "email": "charlie.tmms@gmail.tmt",
+      "email": "isesie.charlie.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.charlie.tmms"
+      "subject": "isesie.charlie.tmms@gmail.tmt"
     },
     "danny.tmms@ISesIe.CS2104": {
       "id": "00000000-0000-4000-8000-000000000006",
@@ -53,7 +53,7 @@
       "name": "Danny Engrid",
       "email": "danny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.danny.tmms"
+      "subject": "danny.tmms@gmail.tmt"
     },
     "emma.tmms@ISesIe.CS2104": {
       "id": "00000000-0000-4000-8000-000000000007",
@@ -61,7 +61,7 @@
       "name": "Emma Farrell",
       "email": "emma.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISesIe.emma.tmms"
+      "subject": "emma.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -127,7 +127,7 @@
       "id": "00000000-0000-4000-8000-000000000602",
       "courseId": "tm.e2e.ISesIe.CS2104",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "isesie.benny.tmms@gmail.tmt",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000004",
       "teamId": "00000000-0000-4000-8000-000000000201"
@@ -136,7 +136,7 @@
       "id": "00000000-0000-4000-8000-000000000603",
       "courseId": "tm.e2e.ISesIe.CS2104",
       "name": "Charlie Davis",
-      "email": "charlie.tmms@gmail.tmt",
+      "email": "isesie.charlie.tmms@gmail.tmt",
       "comments": "This student's name is Charlie Davis",
       "accountId": "00000000-0000-4000-8000-000000000005",
       "teamId": "00000000-0000-4000-8000-000000000202"

--- a/src/e2e/resources/data/InstructorStudentActivityLogsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorStudentActivityLogsPageE2ETest.json
@@ -11,25 +11,25 @@
       "id": "00000000-0000-4000-8000-000000000001",
       "googleId": "tm.e2e.ISActLogs.instructor",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "isactlogs.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISActLogs.instructor"
+      "subject": "isactlogs.instructor@gmail.tmt"
     },
     "alice.tmms@ISActLogs.CS2104": {
       "id": "00000000-0000-4000-8000-000000000002",
       "googleId": "tm.e2e.ISActLogs.alice.tmms",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "isactlogs.alice.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISActLogs.alice.tmms"
+      "subject": "isactlogs.alice.tmms@gmail.tmt"
     },
     "benny.tmms@ISActLogs.CS2104": {
       "id": "00000000-0000-4000-8000-000000000003",
       "googleId": "tm.e2e.ISActLogs.benny.tmms",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "isactlogs.benny.tmms@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISActLogs.benny.tmms"
+      "subject": "isactlogs.benny.tmms@gmail.tmt"
     }
   },
   "courses": {
@@ -59,7 +59,7 @@
       "id": "00000000-0000-4000-8000-000000000301",
       "courseId": "tm.e2e.ISActLogs.CS2104",
       "name": "Teammates Test",
-      "email": "tmms.test@gmail.tmt",
+      "email": "isactlogs.instructor@gmail.tmt",
       "role": "COOWNER",
       "isDisplayedToStudents": true,
       "displayName": "Co-owner",
@@ -71,7 +71,7 @@
       "id": "00000000-0000-4000-8000-000000000401",
       "courseId": "tm.e2e.ISActLogs.CS2104",
       "name": "Alice Betsy",
-      "email": "alice.b.tmms@gmail.tmt",
+      "email": "isactlogs.alice.tmms@gmail.tmt",
       "comments": "This student's name is Alice Betsy",
       "accountId": "00000000-0000-4000-8000-000000000002",
       "teamId": "00000000-0000-4000-8000-000000000201"
@@ -80,7 +80,7 @@
       "id": "00000000-0000-4000-8000-000000000402",
       "courseId": "tm.e2e.ISActLogs.CS2104",
       "name": "Benny Charles",
-      "email": "benny.tmms@gmail.tmt",
+      "email": "isactlogs.benny.tmms@gmail.tmt",
       "comments": "This student's name is Benny Charles",
       "accountId": "00000000-0000-4000-8000-000000000003",
       "teamId": "00000000-0000-4000-8000-000000000201"

--- a/src/e2e/resources/data/InstructorStudentListPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorStudentListPageE2ETest.json
@@ -18,7 +18,7 @@
       "email": "islist.instr1@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISList.instr1"
+      "subject": "islist.instr1@gmail.tmt"
     },
     "Student3Course3": {
       "googleId": "tm.e2e.ISList.charlie.tmms",
@@ -26,7 +26,7 @@
       "email": "islist.charlie.tmms@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISList.charlie.tmms"
+      "subject": "islist.charlie.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/InstructorStudentRecordsPageE2ETest.json
+++ b/src/e2e/resources/data/InstructorStudentRecordsPageE2ETest.json
@@ -13,15 +13,15 @@
       "email": "teammates.test@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISRecords.teammates.test"
+      "subject": "teammates.test@gmail.tmt"
     },
     "benny.c.tmms@ISR.CS2104": {
       "googleId": "tm.e2e.ISRecords.benny.c.tmms",
       "name": "Benny Charlés",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "isrecords.benny.c.tmms@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.ISRecords.benny.c.tmms"
+      "subject": "isrecords.benny.c.tmms@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},
@@ -66,7 +66,7 @@
       "id": "00000000-0000-4000-8000-000000000601",
       "courseId": "tm.e2e.ISRecords.CS2104",
       "name": "Benny Charlés",
-      "email": "benny.c.tmms@gmail.tmt",
+      "email": "isrecords.benny.c.tmms@gmail.tmt",
       "accountId": "00000000-0000-4000-8000-000000000002",
       "teamId": "00000000-0000-4000-8000-000000000301"
     }

--- a/src/e2e/resources/data/NotificationsE2ETest.json
+++ b/src/e2e/resources/data/NotificationsE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Teammates Test Instructor",
       "email": "notif.instructor@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.notif.instructor"
+      "subject": "notif.instructor@gmail.tmt"
     },
     "notif.student": {
       "id": "00000000-0000-4000-8000-000000000002",
@@ -21,7 +21,7 @@
       "name": "Teammates Test Student",
       "email": "notif.student@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.notif.student"
+      "subject": "notif.student@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/StudentCourseDetailsPageE2ETest.json
+++ b/src/e2e/resources/data/StudentCourseDetailsPageE2ETest.json
@@ -10,10 +10,10 @@
     "SCDet.instr": {
       "googleId": "tm.e2e.SCDet.instr",
       "name": "Instructor",
-      "email": "tmms.test@gmail.tmt",
+      "email": "scdet.instr@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SCDet.instr"
+      "subject": "scdet.instr@gmail.tmt"
     },
     "SCDet.alice": {
       "googleId": "tm.e2e.SCDet.alice",
@@ -21,7 +21,7 @@
       "name": "Alice Betsy",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SCDet.alice"
+      "subject": "scdet.alice@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/StudentCourseJoinConfirmationPageE2ETest.json
+++ b/src/e2e/resources/data/StudentCourseJoinConfirmationPageE2ETest.json
@@ -13,7 +13,7 @@
       "email": "scjoinconf.instr@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SCJoinConf.instr"
+      "subject": "scjoinconf.instr@gmail.tmt"
     },
     "alice.tmms": {
       "googleId": "tm.e2e.SCJoinConf.alice",
@@ -21,7 +21,7 @@
       "email": "scjoinconf.alice@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SCJoinConf.alice"
+      "subject": "scjoinconf.alice@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/StudentHomePageE2ETest.json
+++ b/src/e2e/resources/data/StudentHomePageE2ETest.json
@@ -13,7 +13,7 @@
       "email": "shome.instr@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000001",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SHome.instr"
+      "subject": "shome.instr@gmail.tmt"
     },
     "SHome.student": {
       "googleId": "tm.e2e.SHome.student",
@@ -21,7 +21,7 @@
       "email": "shome.student@gmail.tmt",
       "id": "00000000-0000-4000-8000-000000000002",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SHome.student"
+      "subject": "shome.student@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/e2e/resources/data/StudentNotificationsPageE2ETest.json
+++ b/src/e2e/resources/data/StudentNotificationsPageE2ETest.json
@@ -13,7 +13,7 @@
       "name": "Alice B",
       "email": "snotifs.student@gmail.tmt",
       "provider": "TEAMMATES_DEV",
-      "subject": "tm.e2e.SNotifs.student"
+      "subject": "snotifs.student@gmail.tmt"
     }
   },
   "accountVerificationRequests": {},

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -145,6 +145,7 @@ public final class Const {
         public static final String USER_ID = "userid";
         public static final String STUDENT_ID = "googleid";
         public static final String ACCOUNT_ID = "accountid";
+        public static final String ACCOUNT_EMAIL = "accountemail";
         public static final String MASQUERADE_ACCOUNT_ID = "masqueradeaccountid";
 
         public static final String REGKEY = "key";

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -294,6 +294,14 @@ public class Logic {
     }
 
     /**
+     * Creates and returns an account for the given identity if it does not exist,
+     * otherwise returns the existing account.
+     */
+    public Account createOrGetAccount(Provider provider, String subject, String tenantId, String email) {
+        return accountsLogic.createOrGetAccount(provider, subject, tenantId, email);
+    }
+
+    /**
      * Deletes account associated with the {@code accountId}.
      *
      * <p>Fails silently if the account doesn't exist.</p>

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -63,6 +63,16 @@ public final class AccountsLogic {
     }
 
     /**
+     * Gets an account by auth identity.
+     */
+    public Account getAccountForAuthIdentity(Provider provider, String subject, @Nullable String tenantId) {
+        assert provider != null;
+        assert subject != null;
+
+        return accountsDb.getAccountByAuthIdentity(provider, subject, tenantId);
+    }
+
+    /**
      * Creates and returns an account for the given email if it does not exist,
      * otherwise just return the existing account.
      *
@@ -78,8 +88,7 @@ public final class AccountsLogic {
         Objects.requireNonNull(email);
 
         String googleId = email;
-        // TODO: Fetch account by provider, subject and tenantId.
-        Account account = getAccountForGoogleId(googleId);
+        Account account = getAccountForAuthIdentity(provider, subject, tenantId);
         if (account != null) {
             return account;
         }
@@ -87,7 +96,6 @@ public final class AccountsLogic {
         try {
             return createAccount(provider, subject, tenantId, email, googleId);
         } catch (EntityAlreadyExistsException e) {
-            // This should not happen.
             throw new IllegalStateException("Failed to create existing account for email: " + email, e);
         } catch (InvalidParametersException e) {
             throw new IllegalStateException("Failed to create account with invalid parameters: " + email, e);
@@ -120,7 +128,7 @@ public final class AccountsLogic {
 
         validateAccount(account);
 
-        if (getAccountForGoogleId(account.getGoogleId()) != null) {
+        if (getAccountForAuthIdentity(account.getProvider(), account.getSubject(), account.getTenantId()) != null) {
             throw new EntityAlreadyExistsException(String.format(ERROR_CREATE_ENTITY_ALREADY_EXISTS, account.toString()));
         }
 

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -66,8 +66,8 @@ public final class AccountsLogic {
      * Gets an account by auth identity.
      */
     public Account getAccountForAuthIdentity(Provider provider, String subject, @Nullable String tenantId) {
-        assert provider != null;
-        assert subject != null;
+        Objects.requireNonNull(provider);
+        Objects.requireNonNull(subject);
 
         return accountsDb.getAccountByAuthIdentity(provider, subject, tenantId);
     }

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -2,6 +2,12 @@ package teammates.storage.api;
 
 import java.util.UUID;
 
+import jakarta.annotation.Nullable;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
+
+import teammates.common.datatransfer.Provider;
 import teammates.common.util.HibernateUtil;
 import teammates.storage.entity.Account;
 
@@ -34,6 +40,25 @@ public final class AccountsDb {
      */
     public Account getAccountByGoogleId(String googleId) {
         return HibernateUtil.getBySimpleNaturalId(Account.class, googleId);
+    }
+
+    /**
+     * Returns an Account with the given auth identity or null if it does not exist.
+     */
+    public Account getAccountByAuthIdentity(Provider provider, String subject, @Nullable String tenantId) {
+        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
+        CriteriaQuery<Account> cr = cb.createQuery(Account.class);
+        Root<Account> root = cr.from(Account.class);
+
+        cr.select(root).where(cb.and(
+                cb.equal(root.get("provider"), provider),
+                cb.equal(root.get("subject"), subject),
+                tenantId == null
+                        ? cb.isNull(root.get("tenantId"))
+                        : cb.equal(root.get("tenantId"), tenantId)
+        ));
+
+        return HibernateUtil.createQuery(cr).getResultStream().findFirst().orElse(null);
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/GetUserCookieAction.java
+++ b/src/main/java/teammates/ui/webapi/GetUserCookieAction.java
@@ -4,14 +4,9 @@ import java.util.UUID;
 
 import teammates.common.datatransfer.Provider;
 import teammates.common.datatransfer.UserInfoCookie;
-import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
-import teammates.common.util.FieldValidator;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.StringHelper;
-import teammates.storage.entity.Account;
-import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.UnauthorizedAccessException;
 
 /**
@@ -31,35 +26,10 @@ public class GetUserCookieAction extends Action {
 
     @Override
     public JsonResult execute() {
-        String userId = getNonNullRequestParamValue(Const.ParamsNames.USER_ID);
-        UUID accountId = getOrCreateAccountId(userId);
+        String email = getNonNullRequestParamValue(Const.ParamsNames.ACCOUNT_EMAIL);
+        UUID accountId = logic.createOrGetAccount(Provider.TEAMMATES_DEV, email, null, email).getId();
         UserInfoCookie uic = new UserInfoCookie(accountId);
         return new JsonResult(StringHelper.encrypt(JsonUtils.toCompactJson(uic)));
-    }
-
-    private UUID getOrCreateAccountId(String userId) {
-        Account existingAccount = logic.getAccountForGoogleId(userId);
-        if (existingAccount != null) {
-            return existingAccount.getId();
-        }
-
-        String email = isValidEmail(userId) ? userId : getUniqueFallbackEmail();
-        try {
-            Account newAccount = logic.createAccount(Provider.TEAMMATES_DEV, userId, "test-tenant", email, userId);
-            return newAccount.getId();
-        } catch (EntityAlreadyExistsException e) {
-            throw new IllegalStateException("Failed to create existing account for email: " + email, e);
-        } catch (InvalidParametersException e) {
-            throw new InvalidHttpParameterException(e);
-        }
-    }
-
-    private boolean isValidEmail(String email) {
-        return FieldValidator.getInvalidityInfoForEmail(email).isEmpty();
-    }
-
-    private String getUniqueFallbackEmail() {
-        return "test.user." + UUID.randomUUID() + Const.TEST_EMAIL_DOMAIN;
     }
 
 }

--- a/src/test/java/teammates/logic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicTest.java
@@ -44,21 +44,6 @@ public class AccountsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testCreateOrGetAccountForEmail_accountExists_success() {
-        Account account = getTypicalAccount();
-        String email = account.getEmail();
-        Provider provider = account.getProvider();
-        String subject = account.getSubject();
-        String tenantId = account.getTenantId();
-
-        when(accountsDb.getAccountByGoogleId(email)).thenReturn(account);
-
-        Account result = accountsLogic.createOrGetAccount(provider, subject, tenantId, email);
-
-        assertEquals(result, account);
-    }
-
-    @Test
     public void testCreateOrGetAccountForEmail_accountDoesNotExist_success() {
         String email = "nonexistent@example.com";
         Provider provider = Provider.TEAMMATES_DEV;

--- a/src/test/java/teammates/storage/api/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/api/AccountsDbTest.java
@@ -41,6 +41,46 @@ public class AccountsDbTest extends BaseDbTestcase {
     }
 
     @Test(groups = GroupNames.DB)
+    public void getAccountByAuthIdentity_accountExists_returnsAccount() {
+        var account = given.account("account", a -> a
+                .authIdentity(Provider.TEAMMATES_DEV, "account-subject", "tenant-id"));
+        persistGivenData(given);
+
+        Account actual = inTransaction(() -> accountsDb.getAccountByAuthIdentity(
+                Provider.TEAMMATES_DEV, "account-subject", "tenant-id"));
+
+        assertNotNull(actual);
+        assertEquals(account.id(), actual.getId());
+    }
+
+    @Test(groups = GroupNames.DB)
+    public void getAccountByAuthIdentity_accountDoesNotExist_returnsNull() {
+        given.account("account", a -> a
+                .authIdentity(Provider.TEAMMATES_DEV, "account-subject", "tenant-id"));
+        persistGivenData(given);
+
+        Account actual = inTransaction(() -> accountsDb.getAccountByAuthIdentity(
+                Provider.TEAMMATES_DEV, "non-existent-subject", "tenant-id"));
+
+        assertNull(actual);
+    }
+
+    @Test(groups = GroupNames.DB)
+    public void getAccountByAuthIdentity_nullTenantId_matchesOnlyNullTenantId() {
+        var accountWithNullTenant = given.account("account-with-null-tenant", a -> a
+                .authIdentity(Provider.TEAMMATES_DEV, "shared-subject", null));
+        given.account("account-with-tenant", a -> a
+                .authIdentity(Provider.TEAMMATES_DEV, "shared-subject", "tenant-id"));
+        persistGivenData(given);
+
+        Account actual = inTransaction(() -> accountsDb.getAccountByAuthIdentity(
+                Provider.TEAMMATES_DEV, "shared-subject", null));
+
+        assertNotNull(actual);
+        assertEquals(accountWithNullTenant.id(), actual.getId());
+    }
+
+    @Test(groups = GroupNames.DB)
     public void persistAccount_accountIsNew_accountIsPersisted() {
         var accountId = given.uuid("account");
         Account account = buildDefaultAccount(accountId);

--- a/src/test/java/teammates/test/AbstractBackDoor.java
+++ b/src/test/java/teammates/test/AbstractBackDoor.java
@@ -255,10 +255,14 @@ public abstract class AbstractBackDoor {
     /**
      * Gets the cookie format for the given user ID.
      */
-    public String getUserCookie(String userId) {
+    public String getUserCookie(String userEmail) {
         Map<String, String> params = new HashMap<>();
-        params.put(Const.ParamsNames.USER_ID, userId);
+        params.put(Const.ParamsNames.ACCOUNT_EMAIL, userEmail);
         ResponseBodyAndCode response = executePostRequest(Const.ResourceURIs.USER_COOKIE, params, null);
+        if (response.responseCode != HttpStatus.SC_OK) {
+            throw new RuntimeException("Failed to get user cookie: [" + response.responseCode + "] "
+                    + response.responseBody);
+        }
 
         MessageOutput output = JsonUtils.fromJson(response.responseBody, MessageOutput.class);
         return output.getMessage();


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13918

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

As part of migration away from googleId, we need to migrate the e2e tests to stop identifying accounts by google id as well.