### PR TITLE
[#13918] Prevent account creation races with auth-identity upsert and tenant sentinel normalization

### DIFF
--- a/src/main/java/teammates/common/util/HibernateUtil.java
+++ b/src/main/java/teammates/common/util/HibernateUtil.java
@@ -13,6 +13,7 @@ import org.hibernate.Transaction;
 import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.query.MutationQuery;
+import org.hibernate.query.NativeQuery;
 import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import teammates.storage.entity.Account;
@@ -198,6 +199,14 @@ public final class HibernateUtil {
      */
     public static MutationQuery createNativeMutationQuery(String sqlStatement) {
         return getCurrentSession().createNativeMutationQuery(sqlStatement);
+    }
+
+    /**
+     * Returns a typed native query for the given SQL statement string.
+     * @see Session#createNativeQuery(String, Class)
+     */
+    public static <T> NativeQuery<T> createNativeQuery(String sqlStatement, Class<T> resultClass) {
+        return getCurrentSession().createNativeQuery(sqlStatement, resultClass);
     }
 
     public static void setSessionFactory(SessionFactory sessionFactory) {

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -88,15 +88,11 @@ public final class AccountsLogic {
         Objects.requireNonNull(email);
 
         String googleId = email;
-        Account account = getAccountForAuthIdentity(provider, subject, tenantId);
-        if (account != null) {
-            return account;
-        }
+        Account account = new Account(googleId, provider, subject, tenantId, "User", email);
 
         try {
-            return createAccount(provider, subject, tenantId, email, googleId);
-        } catch (EntityAlreadyExistsException e) {
-            throw new IllegalStateException("Failed to create existing account for email: " + email, e);
+            validateAccount(account);
+            return accountsDb.upsertAccount(account);
         } catch (InvalidParametersException e) {
             throw new IllegalStateException("Failed to create account with invalid parameters: " + email, e);
         }

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPermissionSet;
 import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.Provider;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.HibernateUtil;
@@ -161,6 +162,9 @@ public final class DataBundleLogic {
         for (Account account : accounts) {
             UUID placeholderId = account.getId();
             account.setId(generateId(placeholderId, seed));
+            if (account.getProvider() == Provider.TEAMMATES_DEV) {
+                account.setTenantId(Account.NO_TENANT);
+            }
             accountsMap.put(placeholderId, account);
         }
 

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -46,6 +46,7 @@ public final class AccountsDb {
      * Returns an Account with the given auth identity or null if it does not exist.
      */
     public Account getAccountByAuthIdentity(Provider provider, String subject, @Nullable String tenantId) {
+        String normalizedTenantId = Account.normalizeTenantId(tenantId);
         CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
         CriteriaQuery<Account> cr = cb.createQuery(Account.class);
         Root<Account> root = cr.from(Account.class);
@@ -53,9 +54,7 @@ public final class AccountsDb {
         cr.select(root).where(cb.and(
                 cb.equal(root.get("provider"), provider),
                 cb.equal(root.get("subject"), subject),
-                tenantId == null
-                        ? cb.isNull(root.get("tenantId"))
-                        : cb.equal(root.get("tenantId"), tenantId)
+                cb.equal(root.get("tenantId"), normalizedTenantId)
         ));
 
         return HibernateUtil.createQuery(cr).getResultStream().findFirst().orElse(null);
@@ -67,6 +66,33 @@ public final class AccountsDb {
     public Account persistAccount(Account account) {
         HibernateUtil.persist(account);
         return account;
+    }
+
+    /**
+     * Atomically inserts or updates an Account by auth identity and returns the persisted row.
+     */
+    public Account upsertAccount(Account account) {
+        String sql = """
+                INSERT INTO accounts (id, created_at, email, google_id, name, provider, subject, tenant_id, updated_at)
+                VALUES (:id, CURRENT_TIMESTAMP, :email, :googleId, :name, :provider, :subject, :tenantId,
+                        CURRENT_TIMESTAMP)
+                ON CONFLICT (provider, subject, tenant_id)
+                DO UPDATE SET email = EXCLUDED.email,
+                              google_id = EXCLUDED.google_id,
+                              name = EXCLUDED.name,
+                              updated_at = CURRENT_TIMESTAMP
+                RETURNING *
+                """;
+
+        return HibernateUtil.createNativeQuery(sql, Account.class)
+                .setParameter("id", account.getId())
+                .setParameter("email", account.getEmail())
+                .setParameter("googleId", account.getGoogleId())
+                .setParameter("name", account.getName())
+                .setParameter("provider", account.getProvider().name())
+                .setParameter("subject", account.getSubject())
+                .setParameter("tenantId", account.getTenantId())
+                .getSingleResult();
     }
 
     /**

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -69,7 +69,7 @@ public final class AccountsDb {
     }
 
     /**
-     * Atomically inserts or updates an Account by auth identity and returns the persisted row.
+     * Atomically creates or gets an Account by auth identity and returns the persisted row.
      */
     public Account upsertAccount(Account account) {
         String sql = """
@@ -77,10 +77,7 @@ public final class AccountsDb {
                 VALUES (:id, CURRENT_TIMESTAMP, :email, :googleId, :name, :provider, :subject, :tenantId,
                         CURRENT_TIMESTAMP)
                 ON CONFLICT (provider, subject, tenant_id)
-                DO UPDATE SET email = EXCLUDED.email,
-                              google_id = EXCLUDED.google_id,
-                              name = EXCLUDED.name,
-                              updated_at = CURRENT_TIMESTAMP
+                DO UPDATE SET updated_at = accounts.updated_at
                 RETURNING *
                 """;
 

--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -33,6 +33,8 @@ import teammates.common.util.SanitizationHelper;
         }
 )
 public class Account extends BaseEntity {
+    public static final String NO_TENANT = "__NO_TENANT__";
+
     @Id
     private UUID id;
 
@@ -43,7 +45,7 @@ public class Account extends BaseEntity {
     @Column(nullable = false)
     private String subject;
 
-    @Column
+    @Column(nullable = false)
     private String tenantId;
 
     @NaturalId
@@ -121,7 +123,12 @@ public class Account extends BaseEntity {
     }
 
     public void setTenantId(String tenantId) {
-        this.tenantId = SanitizationHelper.sanitizeTenantId(tenantId);
+        this.tenantId = normalizeTenantId(tenantId);
+    }
+
+    public static String normalizeTenantId(String tenantId) {
+        String sanitizedTenantId = SanitizationHelper.sanitizeTenantId(tenantId);
+        return sanitizedTenantId == null ? NO_TENANT : sanitizedTenantId;
     }
 
     public String getGoogleId() {

--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -227,7 +227,6 @@ public class Account extends BaseEntity {
     @Override
     public String toString() {
         return "Account [id=" + id + ", googleId=" + googleId + ", name=" + name + ", email=" + email
-                + ", readNotifications=" + readNotifications + ", createdAt=" + getCreatedAt()
-                + ",updatedAt=" + updatedAt + "]";
+                + ", createdAt=" + getCreatedAt() + ",updatedAt=" + updatedAt + "]";
     }
 }

--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -126,6 +126,9 @@ public class Account extends BaseEntity {
         this.tenantId = normalizeTenantId(tenantId);
     }
 
+    /**
+     * Normalizes the tenant ID, returning a default value if the input is null.
+     */
     public static String normalizeTenantId(String tenantId) {
         String sanitizedTenantId = SanitizationHelper.sanitizeTenantId(tenantId);
         return sanitizedTenantId == null ? NO_TENANT : sanitizedTenantId;

--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -128,11 +128,11 @@ public class Account extends BaseEntity {
     }
 
     /**
-     * Normalizes the tenant ID, returning a default value if the input is null.
+     * Normalizes the tenant ID, returning a default value if the input is null or empty.
      */
     public static String normalizeTenantId(String tenantId) {
         String sanitizedTenantId = SanitizationHelper.sanitizeTenantId(tenantId);
-        return sanitizedTenantId == null ? NO_TENANT : sanitizedTenantId;
+        return (sanitizedTenantId == null || sanitizedTenantId.isEmpty()) ? NO_TENANT : sanitizedTenantId;
     }
 
     public String getGoogleId() {

--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -29,7 +29,8 @@ import teammates.common.util.SanitizationHelper;
 @Entity
 @Table(name = "Accounts",
         uniqueConstraints = {
-                @UniqueConstraint(name = "UniqueOidc", columnNames = {"provider", "subject", "tenantId"}),
+                @UniqueConstraint(name = "unique_provider_subject_tenant",
+                        columnNames = {"provider", "subject", "tenantId"}),
         }
 )
 public class Account extends BaseEntity {

--- a/src/main/resources/db/changelog/migrations/20260618-account-tenant-sentinel.xml
+++ b/src/main/resources/db/changelog/migrations/20260618-account-tenant-sentinel.xml
@@ -1,0 +1,12 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="samuelfangjw" id="20260618-account-tenant-sentinel-1">
+        <sql>UPDATE accounts SET tenant_id = '__NO_TENANT__' WHERE tenant_id IS NULL;</sql>
+
+        <dropUniqueConstraint constraintName="UniqueOidc" tableName="accounts"/>
+
+        <addNotNullConstraint tableName="accounts" columnName="tenant_id" columnDataType="VARCHAR(255)"/>
+
+        <addUniqueConstraint columnNames="provider, subject, tenant_id" constraintName="unique_provider_subject_tenant" tableName="accounts"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/teammates/logic/core/AccountsLogicTest.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicTest.java
@@ -50,12 +50,11 @@ public class AccountsLogicTest extends BaseTestCase {
         String subject = "nonexistentSubject";
         String tenantId = "nonexistentTenantId";
 
-        when(accountsDb.getAccountByGoogleId(email)).thenReturn(null);
-        when(accountsDb.persistAccount(any(Account.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(accountsDb.upsertAccount(any(Account.class))).thenAnswer(inv -> inv.getArgument(0));
 
         Account result = accountsLogic.createOrGetAccount(provider, subject, tenantId, email);
 
-        verify(accountsDb, times(1)).persistAccount(result);
+        verify(accountsDb, times(1)).upsertAccount(result);
         assertNotNull(result);
         assertEquals(result.getEmail(), email);
     }

--- a/src/test/java/teammates/storage/api/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/api/AccountsDbTest.java
@@ -1,6 +1,7 @@
 package teammates.storage.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -100,19 +101,19 @@ public class AccountsDbTest extends BaseDbTestcase {
         persistGivenData(given);
 
         Account updatedAccount = new Account(
-                "updated-google-id",
+                "should-not-update-google-id",
                 Provider.TEAMMATES_DEV,
                 "shared-subject",
                 null,
-                "Updated Name",
-                "updated@example.com");
+                "Should Not Update Name",
+                "should-not-update@example.com");
 
         Account actual = inTransaction(() -> accountsDb.upsertAccount(updatedAccount));
 
         assertEquals(existingAccount.id(), actual.getId());
-        assertEquals("updated-google-id", actual.getGoogleId());
-        assertEquals("updated@example.com", actual.getEmail());
-        assertEquals("Updated Name", actual.getName());
+        assertEquals("original-google-id", actual.getGoogleId());
+        assertEquals("original@example.com", actual.getEmail());
+        assertNotEquals("Should Not Update Name", actual.getName());
         assertEquals(Account.NO_TENANT, actual.getTenantId());
     }
 

--- a/src/test/java/teammates/storage/api/AccountsDbTest.java
+++ b/src/test/java/teammates/storage/api/AccountsDbTest.java
@@ -81,6 +81,42 @@ public class AccountsDbTest extends BaseDbTestcase {
     }
 
     @Test(groups = GroupNames.DB)
+    public void upsertAccount_accountDoesNotExist_accountIsInserted() {
+        var accountId = given.uuid("account");
+        Account account = buildDefaultAccount(accountId);
+
+        Account actual = inTransaction(() -> accountsDb.upsertAccount(account));
+
+        assertEquals(accountId, actual.getId());
+        verifyPresentInDatabase(Account.class, accountId);
+    }
+
+    @Test(groups = GroupNames.DB)
+    public void upsertAccount_accountExists_returnsExistingAccount() {
+        var existingAccount = given.account("account", a -> a
+                .googleId("original-google-id")
+                .email("original@example.com")
+                .authIdentity(Provider.TEAMMATES_DEV, "shared-subject", null));
+        persistGivenData(given);
+
+        Account updatedAccount = new Account(
+                "updated-google-id",
+                Provider.TEAMMATES_DEV,
+                "shared-subject",
+                null,
+                "Updated Name",
+                "updated@example.com");
+
+        Account actual = inTransaction(() -> accountsDb.upsertAccount(updatedAccount));
+
+        assertEquals(existingAccount.id(), actual.getId());
+        assertEquals("updated-google-id", actual.getGoogleId());
+        assertEquals("updated@example.com", actual.getEmail());
+        assertEquals("Updated Name", actual.getName());
+        assertEquals(Account.NO_TENANT, actual.getTenantId());
+    }
+
+    @Test(groups = GroupNames.DB)
     public void persistAccount_accountIsNew_accountIsPersisted() {
         var accountId = given.uuid("account");
         Account account = buildDefaultAccount(accountId);

--- a/src/test/java/teammates/test/scenariobuilder/GivenAccount.java
+++ b/src/test/java/teammates/test/scenariobuilder/GivenAccount.java
@@ -65,7 +65,7 @@ public final class GivenAccount extends GivenBase<Account> {
         String googleId = accountId.toString();
         Provider provider = Provider.TEAMMATES_DEV;
         String subject = "sub:" + accountId.toString();
-        String tenantId = "";
+        String tenantId = Account.NO_TENANT;
         String name = "name:" + accountId.toString();
         String email = accountId.toString() + "@teammates.tmt";
         Account a = new Account(googleId, provider, subject, tenantId, name, email);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13918

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

This PR fixes a race in account provisioning by replacing the current check-then-insert flow with an atomic database upsert keyed on auth identity.

It also normalizes missing tenantId values to a single sentinel so (provider, subject, tenant_id) can be enforced reliably as the canonical unique identity, including for TEAMMATES_DEV. This solves a schema gap: UniqueOidc(provider, subject, tenant_id) did not reliably protect identities with tenant_id = null, which allowed logically duplicate auth identities to exist.