### PR TITLE
[#14169] Move instructor welcome page to instructor routes

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -294,7 +294,7 @@ public final class Const {
         public static final String ACCOUNT_VERIFICATION_REQUEST_PAGE = FRONT_PAGE + "/request";
 
         public static final String INSTRUCTOR_WELCOME_PAGE = URI_PREFIX
-                + "/instructor-welcome/{accountVerificationRequestId}";
+                + "/instructor/welcome/{accountVerificationRequestId}";
     }
 
     /**

--- a/src/test/java/teammates/common/util/LinksUtilTest.java
+++ b/src/test/java/teammates/common/util/LinksUtilTest.java
@@ -136,7 +136,7 @@ public class LinksUtilTest extends BaseTestCase {
     @Test
     public void getInstructorWelcomeUrl_accountVerificationRequest_returnsAbsoluteUrlWithAccountVerificationRequestId() {
         UUID sampleAccountVerificationRequestId = UUID.fromString("33333333-3333-3333-3333-333333333333");
-        String expected = TEST_BASE_URL + "/web/instructor-welcome/" + sampleAccountVerificationRequestId;
+        String expected = TEST_BASE_URL + "/web/instructor/welcome/" + sampleAccountVerificationRequestId;
         assertEquals(expected, LinksUtil.getInstructorWelcomeUrl(sampleAccountVerificationRequestId));
     }
 

--- a/src/web/app/app.routes.ts
+++ b/src/web/app/app.routes.ts
@@ -30,21 +30,6 @@ const routes: Routes = [
         canActivateChild: [RoleGuard],
       },
       {
-        path: 'instructor-welcome/:accountVerificationRequestId',
-        component: PageComponent,
-        children: [
-          {
-            path: '',
-            loadComponent: () =>
-              import('./instructor-welcome-page/instructor-welcome-page.component').then(
-                (m) => m.InstructorWelcomePageComponent,
-              ),
-          },
-        ],
-        canActivate: [RoleGuard],
-        canActivateChild: [RoleGuard],
-      },
-      {
         path: 'sessions',
         component: PageComponent,
         children: [

--- a/src/web/app/pages-instructor/instructor.routes.ts
+++ b/src/web/app/pages-instructor/instructor.routes.ts
@@ -188,6 +188,13 @@ const routes: Routes = [
     },
   },
   {
+    path: 'welcome/:accountVerificationRequestId',
+    loadComponent: () =>
+      import('../instructor-welcome-page/instructor-welcome-page.component').then(
+        (m) => m.InstructorWelcomePageComponent,
+      ),
+  },
+  {
     path: '',
     pathMatch: 'full',
     redirectTo: 'home',

--- a/src/web/services/link.service.spec.ts
+++ b/src/web/services/link.service.spec.ts
@@ -32,7 +32,7 @@ describe('Link Service', () => {
 
   it('should generate the instructor welcome link', () => {
     expect(service.generateInstructorWelcomeLink('student-key-001')).toBe(
-      `${globalThis.location.origin}/web/instructor-welcome/student-key-001`,
+      `${globalThis.location.origin}/web/instructor/welcome/student-key-001`,
     );
   });
 

--- a/src/web/services/link.service.ts
+++ b/src/web/services/link.service.ts
@@ -26,7 +26,7 @@ export class LinkService {
    */
   generateInstructorWelcomeLink(accountVerificationRequestId: string): string {
     const frontendUrl: string = globalThis.location.origin;
-    return `${frontendUrl}${this.URI_PREFIX}/instructor-welcome/${accountVerificationRequestId}`;
+    return `${frontendUrl}${this.URI_PREFIX}/instructor/welcome/${accountVerificationRequestId}`;
   }
 
   /**

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -271,7 +271,7 @@ describe('SearchService', () => {
     expect(result.createdAtText).toBe('Sun, 29 Mar 2020, 09:18 PM +08:00');
     expect(result.createdDemoCourseAtText).toBe('Wed, 31 May 2023, 07:04 AM +08:00');
     expect(result.registrationLink).toBe(
-      `${globalThis.location.origin}/web/instructor-welcome/132efa02-b208-4195-a262-a8eae25ceb95`,
+      `${globalThis.location.origin}/web/instructor/welcome/132efa02-b208-4195-a262-a8eae25ceb95`,
     );
   });
 
@@ -286,7 +286,7 @@ describe('SearchService', () => {
     expect(result.createdAtText).toBe('Sun, 29 Mar 2020, 01:18 PM +00:00');
     expect(result.createdDemoCourseAtText).toBe(null);
     expect(result.registrationLink).toBe(
-      `${globalThis.location.origin}/web/instructor-welcome/132efa02-b208-4195-a262-a8eae25ceb95`,
+      `${globalThis.location.origin}/web/instructor/welcome/132efa02-b208-4195-a262-a8eae25ceb95`,
     );
   });
 });


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14169

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Now that #14223 is completed, we can move instructor welcome page to instructor routes. Previously, this was not possible as an instructor was only considered to be an instructor after the demo course was created.