### PR TITLE
[#14229] Update unauthorized warning page messaging

### DIFF
--- a/src/web/app/page-unauthorized-warning/__snapshots__/unauthorized-warning-page.component.spec.ts.snap
+++ b/src/web/app/page-unauthorized-warning/__snapshots__/unauthorized-warning-page.component.spec.ts.snap
@@ -98,26 +98,13 @@ exports[`UnauthorizedWarningPageComponent snapshot > should match snapshot when 
         <p
           class="align-left"
         >
-           If you 'joined' a course in TEAMMATES using a Google account before, but cannot log in anymore, these are the possible reasons: 
+           If you 'joined' a course in TEAMMATES using an account before, but cannot log in anymore, these are the possible reasons: 
         </p>
         <ol
           class="align-left"
         >
           <li>
-             You used a different Google account to access TEAMMATES in the past. In that case, you need to use the same Google account to access TEAMMATES again. Log out and re-log in using the other Google account. If you don't remember which Google account you used previously, email us from the same email account to which you receive TEAMMATES emails. 
-          </li>
-          <li>
-             You changed the primary email from a non-Gmail address to a Gmail address recently. In that case, 
-            <a
-              href="/web/front/contact"
-              tmrouterlink="/web/front/contact"
-            >
-               email us 
-            </a>
-             so that we can reconfigure your account to use the new Gmail address. 
-          </li>
-          <li>
-             You joined this course just a few seconds ago and your data may be still in the process of propagating through our servers. In that case, please try this same page in a few minutes. 
+             You used a different account to access TEAMMATES in the past. In that case, you need to use the same account to access TEAMMATES again. Log out and re-log in using the other account. If you don't remember which account you used previously, email us from the same email account to which you receive TEAMMATES emails. 
           </li>
         </ol>
       </div>

--- a/src/web/app/page-unauthorized-warning/unauthorized-warning-page.component.html
+++ b/src/web/app/page-unauthorized-warning/unauthorized-warning-page.component.html
@@ -28,24 +28,14 @@
         }
         <hr />
         <p class="align-left">
-          If you 'joined' a course in TEAMMATES using a Google account before, but cannot log in anymore, these are the
+          If you 'joined' a course in TEAMMATES using an account before, but cannot log in anymore, these are the
           possible reasons:
         </p>
         <ol class="align-left">
           <li>
-            You used a different Google account to access TEAMMATES in the past. In that case, you need to use the same
-            Google account to access TEAMMATES again. Log out and re-log in using the other Google account. If you don't
-            remember which Google account you used previously, email us from the same email account to which you receive
-            TEAMMATES emails.
-          </li>
-          <li>
-            You changed the primary email from a non-Gmail address to a Gmail address recently. In that case,
-            <a tmRouterLink="/web/front/contact"> email us </a>
-            so that we can reconfigure your account to use the new Gmail address.
-          </li>
-          <li>
-            You joined this course just a few seconds ago and your data may be still in the process of propagating
-            through our servers. In that case, please try this same page in a few minutes.
+            You used a different account to access TEAMMATES in the past. In that case, you need to use the same account
+            to access TEAMMATES again. Log out and re-log in using the other account. If you don't remember which
+            account you used previously, email us from the same email account to which you receive TEAMMATES emails.
           </li>
         </ol>
       </div>


### PR DESCRIPTION
Fixes #14229.

This PR updates the unauthorized warning page to:
1. Mention generic "account" instead of "Google account".
2. Remove the outdated reasons for being unable to log in (primary email change / server propagation delay).