### PR TITLE
[#13721] Migrate remaining lookups by feedback session name

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackSessionsPageE2ETest.java
@@ -276,7 +276,7 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
         String sessionName = session.getName();
         boolean hasQuestion = testData.feedbackQuestions.values()
                 .stream()
-                .anyMatch(q -> q.getFeedbackSessionName().equals(sessionName));
+                .anyMatch(q -> q.getFeedbackSession().getName().equals(sessionName));
 
         if (!hasQuestion) {
             return "0 / 0";
@@ -290,7 +290,7 @@ public class InstructorFeedbackSessionsPageE2ETest extends BaseE2ETestCase {
         Set<ResponseGiver> uniqueGivers = new HashSet<>();
         testData.feedbackResponses.values()
                 .stream()
-                .filter(r -> r.getFeedbackQuestion().getFeedbackSessionName().equals(sessionName))
+                .filter(r -> r.getFeedbackQuestion().getFeedbackSession().getName().equals(sessionName))
                 .forEach(r -> uniqueGivers.add(r.getGiver()));
         int numResponses = uniqueGivers.size();
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorHomePageE2ETest.java
@@ -213,7 +213,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         String sessionName = session.getName();
         boolean hasQuestion = testData.feedbackQuestions.values()
                 .stream()
-                .anyMatch(q -> q.getFeedbackSessionName().equals(sessionName));
+                .anyMatch(q -> q.getFeedbackSession().getName().equals(sessionName));
 
         if (!hasQuestion) {
             return "0 / 0";
@@ -227,7 +227,7 @@ public class InstructorHomePageE2ETest extends BaseE2ETestCase {
         Set<ResponseGiver> uniqueGivers = new HashSet<>();
         testData.feedbackResponses.values()
                 .stream()
-                .filter(r -> r.getFeedbackQuestion().getFeedbackSessionName().equals(sessionName))
+                .filter(r -> r.getFeedbackQuestion().getFeedbackSession().getName().equals(sessionName))
                 .forEach(r -> uniqueGivers.add(r.getGiver()));
         int numResponses = uniqueGivers.size();
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentActivityLogsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentActivityLogsPageE2ETest.java
@@ -92,6 +92,6 @@ public class InstructorStudentActivityLogsPageE2ETest extends BaseE2ETestCase {
         studentActivityLogsPage.waitForPageToLoad();
         studentActivityLogsPage.startSearching();
 
-        assertTrue(studentActivityLogsPage.isLogPresentForSession(feedbackQuestion.getFeedbackSessionName()));
+        assertTrue(studentActivityLogsPage.isLogPresentForSession(feedbackQuestion.getFeedbackSession().getName()));
     }
 }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1134,7 +1134,8 @@ public class InstructorFeedbackResultsPage extends AppPage {
     // Methods for manipulating responses information
 
     private boolean isMissingResponse(FeedbackResponse response) {
-        return response.getFeedbackQuestion() == null || response.getFeedbackQuestion().getFeedbackSession().getName() == null;
+        return response.getFeedbackQuestion() == null
+                || response.getFeedbackQuestion().getFeedbackSession().getName() == null;
     }
 
     private List<FeedbackResponse> filterMissingResponses(List<FeedbackResponse> responses) {

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackResultsPage.java
@@ -1134,7 +1134,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     // Methods for manipulating responses information
 
     private boolean isMissingResponse(FeedbackResponse response) {
-        return response.getFeedbackQuestion() == null || response.getFeedbackQuestion().getFeedbackSessionName() == null;
+        return response.getFeedbackQuestion() == null || response.getFeedbackQuestion().getFeedbackSession().getName() == null;
     }
 
     private List<FeedbackResponse> filterMissingResponses(List<FeedbackResponse> responses) {

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -565,15 +565,6 @@ public class Logic {
     }
 
     /**
-     * Gets a feedback session for {@code feedbackSessionName} and {@code courseId}.
-     *
-     * @return null if not found.
-     */
-    public FeedbackSession getFeedbackSession(String feedbackSessionName, String courseId) {
-        return feedbackSessionsLogic.getFeedbackSession(feedbackSessionName, courseId);
-    }
-
-    /**
      * Returns a {@code List} of feedback sessions in the Recycle Bin for the
      * instructors.
      * <br>

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -862,9 +862,7 @@ public final class FeedbackQuestionsLogic {
                     .toList();
             break;
         case SESSION_CREATOR:
-            FeedbackSession feedbackSession =
-                    feedbackSessionsLogic.getFeedbackSession(fq.getFeedbackSessionName(), fq.getCourseId());
-            Instructor instructorGiver = feedbackSession.getSessionCreator();
+            Instructor instructorGiver = fq.getFeedbackSession().getSessionCreator();
             // If the instructorGiver is null, they have been deleted,
             // so we return an empty list of givers instead of a giver with null user.
             possibleGivers = instructorGiver != null

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -89,18 +89,6 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * Gets a feedback session for {@code feedbackSessionName} and {@code courseId}.
-     *
-     * @return null if not found.
-     */
-    public FeedbackSession getFeedbackSession(String feedbackSessionName, String courseId) {
-        assert feedbackSessionName != null;
-        assert courseId != null;
-
-        return fsDb.getFeedbackSession(feedbackSessionName, courseId);
-    }
-
-    /**
      * Gets all feedback sessions of a course, except those that are soft-deleted.
      */
     public List<FeedbackSession> getFeedbackSessionsForCourse(String courseId) {
@@ -352,19 +340,16 @@ public final class FeedbackSessionsLogic {
         validateFeedbackSession(feedbackSession);
         feedbackSession = fsDb.persistFeedbackSession(feedbackSession);
 
-        if (createRequest.getToCopyCourseId() != null) {
-            copyFeedbackQuestions(createRequest.getToCopyCourseId(), courseId,
-                    feedbackSessionName, createRequest.getToCopySessionName());
+        if (createRequest.getToCopySessionId() != null) {
+            copyFeedbackQuestions(createRequest.getToCopySessionId(), feedbackSession);
         }
 
         HibernateUtil.flushSession();
         return feedbackSession;
     }
 
-    private void copyFeedbackQuestions(String oldCourseId, String newCourseId,
-            String newFeedbackSessionName, String oldFeedbackSessionName) {
-        FeedbackSession oldFeedbackSession = getFeedbackSession(oldFeedbackSessionName, oldCourseId);
-        FeedbackSession newFeedbackSession = getFeedbackSession(newFeedbackSessionName, newCourseId);
+    private void copyFeedbackQuestions(UUID oldSessionId, FeedbackSession newFeedbackSession) {
+        FeedbackSession oldFeedbackSession = getFeedbackSession(oldSessionId);
         fqLogic.getFeedbackQuestionsForSession(oldFeedbackSession).forEach(question -> {
             FeedbackQuestion feedbackQuestion = question.makeDeepCopy();
             newFeedbackSession.addFeedbackQuestion(feedbackQuestion);

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -45,22 +45,6 @@ public final class FeedbackSessionsDb {
     }
 
     /**
-     * Gets a feedback session for {@code feedbackSessionName} and {@code courseId}.
-     *
-     * @return null if not found
-     */
-    public FeedbackSession getFeedbackSession(String feedbackSessionName, String courseId) {
-        CriteriaBuilder cb = HibernateUtil.getCriteriaBuilder();
-        CriteriaQuery<FeedbackSession> cq = cb.createQuery(FeedbackSession.class);
-        Root<FeedbackSession> fsRoot = cq.from(FeedbackSession.class);
-        Join<FeedbackSession, Course> fsJoin = fsRoot.join("course");
-        cq.select(fsRoot).where(cb.and(
-                cb.equal(fsRoot.get("name"), feedbackSessionName),
-                cb.equal(fsJoin.get("id"), courseId)));
-        return HibernateUtil.createQuery(cq).getResultStream().findFirst().orElse(null);
-    }
-
-    /**
      * Gets all non-soft-deleted feedback sessions for the given course IDs, excluding sessions in deleted courses.
      */
     public List<FeedbackSession> getFeedbackSessionsForCourses(List<String> courseIds) {

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -269,10 +269,6 @@ public abstract class FeedbackQuestion extends BaseEntity implements Comparable<
         return feedbackSession;
     }
 
-    public String getFeedbackSessionName() {
-        return feedbackSession.getName();
-    }
-
     public UUID getSessionId() {
         return sessionId;
     }

--- a/src/main/java/teammates/ui/request/FeedbackSessionCreateRequest.java
+++ b/src/main/java/teammates/ui/request/FeedbackSessionCreateRequest.java
@@ -1,5 +1,7 @@
 package teammates.ui.request;
 
+import java.util.UUID;
+
 import jakarta.annotation.Nullable;
 
 import teammates.ui.exception.InvalidHttpRequestBodyException;
@@ -10,32 +12,22 @@ import teammates.ui.exception.InvalidHttpRequestBodyException;
 public class FeedbackSessionCreateRequest extends FeedbackSessionBasicRequest {
     private String feedbackSessionName;
     @Nullable
-    private String toCopyCourseId;
-    @Nullable
-    private String toCopySessionName;
+    private UUID toCopySessionId;
 
     public String getFeedbackSessionName() {
         return feedbackSessionName;
     }
 
-    public String getToCopyCourseId() {
-        return toCopyCourseId;
-    }
-
-    public String getToCopySessionName() {
-        return toCopySessionName;
+    public UUID getToCopySessionId() {
+        return toCopySessionId;
     }
 
     public void setFeedbackSessionName(String feedbackSessionName) {
         this.feedbackSessionName = feedbackSessionName;
     }
 
-    public void setToCopyCourseId(String toCopyCourseId) {
-        this.toCopyCourseId = toCopyCourseId;
-    }
-
-    public void setToCopySessionName(String toCopySessionName) {
-        this.toCopySessionName = toCopySessionName;
+    public void setToCopySessionId(UUID toCopySessionId) {
+        this.toCopySessionId = toCopySessionId;
     }
 
     @Override
@@ -44,7 +36,5 @@ public class FeedbackSessionCreateRequest extends FeedbackSessionBasicRequest {
 
         validateTrue(feedbackSessionName != null, "Session name cannot be null");
         validateTrue(!feedbackSessionName.isEmpty(), "Session name cannot be empty");
-        validateTrue(toCopyCourseId == null || toCopySessionName != null,
-                "Session name to be copied from cannot be null if course ID to be copied from is not null");
     }
 }

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -18,11 +18,9 @@ import teammates.logic.api.RecaptchaVerifier;
 import teammates.logic.api.TaskQueuer;
 import teammates.logic.api.UserProvision;
 import teammates.storage.entity.Account;
-import teammates.storage.entity.FeedbackSession;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
 import teammates.storage.entity.User;
-import teammates.ui.exception.EntityNotFoundException;
 import teammates.ui.exception.InvalidHttpParameterException;
 import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.exception.InvalidOperationException;
@@ -243,14 +241,6 @@ public abstract class Action {
      */
     public boolean hasDefinedRequestBody() {
         return requestBody != null;
-    }
-
-    FeedbackSession getNonNullFeedbackSession(String feedbackSessionName, String courseId) {
-        FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionName, courseId);
-        if (feedbackSession == null) {
-            throw new EntityNotFoundException("Feedback session not found");
-        }
-        return feedbackSession;
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
+++ b/src/main/java/teammates/ui/webapi/GetFeedbackResponsesAction.java
@@ -28,9 +28,7 @@ public class GetFeedbackResponsesAction extends BasicFeedbackSubmissionAction {
             throw new EntityNotFoundException("Feedback Question not found");
         }
 
-        FeedbackSession feedbackSession =
-                getNonNullFeedbackSession(feedbackQuestion.getFeedbackSession().getName(),
-                                                feedbackQuestion.getCourseId());
+        FeedbackSession feedbackSession = feedbackQuestion.getFeedbackSession();
 
         verifyInstructorCanSeeQuestionIfInModeration(feedbackQuestion);
 

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicIT.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicIT.java
@@ -182,11 +182,10 @@ public class FeedbackSessionsLogicIT extends BaseTestCaseWithDatabaseAccess {
     public void testDeleteFeedbackSessionCascade_deleteSessionNotInRecycleBin_shouldDoCascadeDeletion() {
         FeedbackSession fs = typicalDataBundle.feedbackSessions.get("session1InCourse1");
 
-        FeedbackSession retrievedFs = inTransaction(() -> fsLogic.getFeedbackSession(fs.getName(), fs.getCourseId()));
+        FeedbackSession retrievedFs = inTransaction(() -> fsLogic.getFeedbackSession(fs.getId()));
 
         assertNotNull(retrievedFs);
-        assertFalse(inTransaction(() -> fsLogic.getFeedbackSession(
-                fs.getName(), fs.getCourseId()).getFeedbackQuestions().isEmpty()));
+        assertFalse(inTransaction(() -> fsLogic.getFeedbackSession(fs.getId()).getFeedbackQuestions().isEmpty()));
         assertFalse(inTransaction(() -> fqLogic.getFeedbackQuestionsForSession(retrievedFs)).isEmpty());
 
         // delete existing feedback session directly

--- a/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackSessionsLogicTest.java
@@ -92,22 +92,6 @@ public class FeedbackSessionsLogicTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetFeedbackSessionByNameAndCourse_sessionExists_success() {
-        Course course = getTypicalCourse();
-        FeedbackSession session = getTypicalFeedbackSessionForCourse(course);
-        String sessionName = session.getName();
-        String courseId = course.getId();
-
-        when(fsDb.getFeedbackSession(sessionName, courseId)).thenReturn(session);
-
-        FeedbackSession result = fsLogic.getFeedbackSession(sessionName, courseId);
-
-        assertNotNull(result);
-        assertEquals(session, result);
-        verify(fsDb, times(1)).getFeedbackSession(sessionName, courseId);
-    }
-
-    @Test
     public void testGetFeedbackSessionsForCourse_hasSession_success() {
         Course course = getTypicalCourse();
         FeedbackSession session1 = getTypicalFeedbackSessionForCourse(course);

--- a/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/storage/api/FeedbackSessionsDbTest.java
@@ -48,22 +48,6 @@ public class FeedbackSessionsDbTest extends BaseDbTestcase {
     }
 
     @Test(groups = GroupNames.DB)
-    public void getFeedbackSessionByNameAndCourse_feedbackSessionExists_returnsFeedbackSession() {
-        var course = given.course("course");
-        var feedbackSession = given.feedbackSession("feedback-session",
-                fs -> fs.course(course.alias()).name("Feedback Session Name"));
-        given.feedbackSession("same-name-feedback-session-in-another-course",
-                fs -> fs.course("another-course").name("Feedback Session Name"));
-        persistGivenData(given);
-
-        FeedbackSession actual = inTransaction(() -> feedbackSessionsDb.getFeedbackSession(
-                "Feedback Session Name", course.id()));
-
-        assertNotNull(actual);
-        assertEquals(feedbackSession.id(), actual.getId());
-    }
-
-    @Test(groups = GroupNames.DB)
     public void persistFeedbackSession_feedbackSessionIsNew_feedbackSessionIsPersisted() {
         var courseRef = given.course("course");
         var creatorRef = given.instructor("creator", i -> i.course(courseRef.alias()));

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -333,7 +333,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
                 assertEquals(ResponseEntityHelper.getIdentifier(feedbackResponse.getGiver()), giverEmail);
                 assertEquals(ResponseEntityHelper.getIdentifier(feedbackResponse.getRecipient()), recipientEmail);
 
-                assertEquals(session.getName(), feedbackQuestion.getFeedbackSessionName());
+                assertEquals(session.getName(), feedbackQuestion.getFeedbackSession().getName());
                 assertEquals(session.getCourseId(), feedbackQuestion.getCourseId());
 
                 FeedbackResponseDetails responseDetails = feedbackResponse.getFeedbackResponseDetailsCopy();

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -383,7 +383,7 @@ export class InstructorCoursesPageComponent implements OnInit {
             }
 
             result.selectedFeedbackSessionList.forEach((session: FeedbackSession) => {
-              this.copyFeedbackSession(session, result.newCourseId, result.newTimeZone, result.oldCourseId)
+              this.copyFeedbackSession(session, result.newCourseId, result.newTimeZone)
                 .pipe(
                   finalize(() => {
                     this.numberOfSessionsCopied += 1;
@@ -449,11 +449,10 @@ export class InstructorCoursesPageComponent implements OnInit {
     fromFeedbackSession: FeedbackSession,
     newCourseId: string,
     newTimeZone: string,
-    oldCourseId: string,
   ): Observable<FeedbackSession> {
     return this.feedbackSessionsService.createFeedbackSession(
       newCourseId,
-      this.toFbSessionCreationReqWithName(fromFeedbackSession, newTimeZone, oldCourseId),
+      this.toFbSessionCreationReqWithName(fromFeedbackSession, newTimeZone),
     );
   }
 
@@ -463,7 +462,6 @@ export class InstructorCoursesPageComponent implements OnInit {
   private toFbSessionCreationReqWithName(
     fromFeedbackSession: FeedbackSession,
     newTimeZone: string,
-    oldCourseId: string,
   ): FeedbackSessionCreateRequest {
     // Local constants
     const twoHoursBeforeNow = moment().tz(newTimeZone).subtract(2, 'hours').valueOf();
@@ -581,8 +579,7 @@ export class InstructorCoursesPageComponent implements OnInit {
 
     return {
       feedbackSessionName: fromFeedbackSession.feedbackSessionName,
-      toCopyCourseId: oldCourseId,
-      toCopySessionName: fromFeedbackSession.feedbackSessionName,
+      toCopySessionId: fromFeedbackSession.feedbackSessionId,
       instructions: fromFeedbackSession.instructions,
 
       submissionStartTimestamp: copiedSubmissionStartTimestamp,

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -227,7 +227,7 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
             }
 
             result.selectedFeedbackSessionList.forEach((session: FeedbackSession) => {
-              this.copyFeedbackSession(session, session.feedbackSessionName, result.newCourseId, result.oldCourseId)
+              this.copyFeedbackSession(session, session.feedbackSessionName, result.newCourseId)
                 .pipe(
                   finalize(() => {
                     this.numberOfSessionsCopied += 1;

--- a/src/web/app/pages-instructor/instructor-session-base-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-base-page.component.ts
@@ -110,7 +110,6 @@ export abstract class InstructorSessionBasePageComponent {
     fromFeedbackSession: FeedbackSession,
     newSessionName: string,
     newCourseId: string,
-    oldCourseId: string,
   ): Observable<FeedbackSession> {
     // Local constants
     const startHour = moment.utc(fromFeedbackSession.submissionStartTimestamp).tz(fromFeedbackSession.timeZone).hours();
@@ -251,8 +250,7 @@ export abstract class InstructorSessionBasePageComponent {
     return this.feedbackSessionsService.createFeedbackSession(newCourseId, {
       feedbackSessionName: newSessionName,
       instructions: fromFeedbackSession.instructions,
-      toCopySessionName: fromFeedbackSession.feedbackSessionName,
-      toCopyCourseId: oldCourseId,
+      toCopySessionId: fromFeedbackSession.feedbackSessionId,
 
       submissionStartTimestamp: copiedSubmissionStartTimestamp,
       submissionEndTimestamp: copiedSubmissionEndTimestamp,
@@ -370,12 +368,7 @@ export abstract class InstructorSessionBasePageComponent {
     const copySessionRequests: Observable<FeedbackSession>[] = [];
     result.copyToCourseList.forEach((copyToCourseId: string) => {
       copySessionRequests.push(
-        this.copyFeedbackSession(
-          model.feedbackSession,
-          result.newFeedbackSessionName,
-          copyToCourseId,
-          result.sessionToCopyCourseId,
-        ).pipe(
+        this.copyFeedbackSession(model.feedbackSession, result.newFeedbackSessionName, copyToCourseId).pipe(
           catchError((err: ErrorMessageOutput) => {
             this.failedToCopySessions[copyToCourseId] = err.error.message;
             return EMPTY;
@@ -410,7 +403,6 @@ export abstract class InstructorSessionBasePageComponent {
                 feedbackSessionView.feedbackSession,
                 result.newFeedbackSessionName,
                 copyToCourseId,
-                result.sessionToCopyCourseId,
               ),
             ),
             catchError((err: ErrorMessageOutput) => {

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -151,12 +151,7 @@ export class InstructorSessionsPageComponent extends InstructorSessionModalPageC
       .then((result: CopyFromOtherSessionsResult) => {
         this.coursesOfModifiedSession = [];
         this.modifiedSession = {};
-        this.copyFeedbackSession(
-          result.fromFeedbackSession,
-          result.newFeedbackSessionName,
-          result.copyToCourseId,
-          result.fromFeedbackSession.courseId,
-        )
+        this.copyFeedbackSession(result.fromFeedbackSession, result.newFeedbackSessionName, result.copyToCourseId)
           .pipe(
             finalize(() => {
               this.isCopyOtherSessionLoading = false;

--- a/src/web/types/api-request.ts
+++ b/src/web/types/api-request.ts
@@ -152,8 +152,7 @@ export interface FeedbackSessionBasicRequest extends BasicRequest {
 
 export interface FeedbackSessionCreateRequest extends FeedbackSessionBasicRequest {
   feedbackSessionName: string;
-  toCopyCourseId?: string;
-  toCopySessionName?: string;
+  toCopySessionId?: string;
 }
 
 export interface FeedbackSessionRemindRequest extends BasicRequest {


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Migrate remaining lookups by feedback session name. This sets us up to relax the constraints around feedback session name in the future since it is no longer used as part of the key of feedback session. 