### PR TITLE
[#14198] Show instructions for Prettier format failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "ng test",
     "coverage": "rimraf coverage && ng test --coverage",
     "format": "prettier . --write --log-level warn",
-    "format:check": "prettier . --check",
+    "format:check": "node scripts/check-format.mjs",
     "lint:eslint": "ng lint --cache",
     "lint:eslint:fix": "ng lint --fix --cache",
     "lint:css": "stylelint \"src/web/**/*.css\" \"src/web/**/*.scss\" --ignore-pattern \"src/web/dist/**/*\" --cache",

--- a/scripts/check-format.mjs
+++ b/scripts/check-format.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * Wrapper around `prettier --check` that prints a remediation hint when
+ * formatting issues are detected, so contributors know how to fix them.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync('npx', ['prettier', '.', '--check'], { stdio: 'inherit', shell: true });
+
+if (result.status !== 0) {
+  console.error('\nFormatting issues detected. To fix them, run:\n\n  npm run format\n');
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
Fixes #14198.

Currently, when `npm run lint` fails due to Prettier formatting issues, contributors see which files are problematic but are not told how to fix them.

This PR introduces a small Node.js wrapper script (`scripts/check-format.mjs`) that:
1. Runs `prettier . --check` as before.
2. On failure, prints a clear remediation message:

```
Formatting issues detected. To fix them, run:

  npm run format
```

The wrapper is cross-platform (works on Mac, Linux, and Windows) since it uses Node.js instead of shell-specific syntax.