### PR TITLE
[#14181] Simplify date/time selection in deadline extension modal

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSessionIndividualExtensionPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSessionIndividualExtensionPage.java
@@ -198,8 +198,7 @@ public class InstructorSessionIndividualExtensionPage extends AppPage {
 
     private void extendDeadlineBy(String by, boolean notifyUsers) {
         click(extendDeadlinesButton);
-        WebElement dropdown = waitForElementPresence(By.id("extend-by-dropdown"));
-        selectDropdownOptionByValue(dropdown, by);
+        click(waitForElementPresence(By.cssSelector("input[name='deadlineOption'][value='" + by + "']")));
         click(browser.driver.findElement(By.className("modal-btn-ok")));
         confirmChangesToDeadlineExtensions(notifyUsers);
     }
@@ -210,7 +209,7 @@ public class InstructorSessionIndividualExtensionPage extends AppPage {
         Instant extendedDeadline = session.getEndTime().plus(Duration.ofDays(1));
         extendedDeadline = TimeHelper.getMidnightAdjustedInstantBasedOnZone(extendedDeadline,
                 session.getCourse().getTimeZone(), false);
-        click(waitForElementPresence(By.id("extend-deadline-to")));
+        click(waitForElementPresence(By.cssSelector("input[name='deadlineOption'][value='Custom']")));
 
         WebElement dateTimePicker = browser.driver.findElement(By.id("submission-end-datetime"));
         fillDatePicker(dateTimePicker, extendedDeadline, session.getCourse().getTimeZone());

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
@@ -40,10 +40,10 @@ exports[`IndividualExtensionDateModalComponent > should snap with a preset selec
     </b>
      instructor(s):
   </div><div
-    class="px-3"
+    class="px-4"
   >
     <div
-      class="d-flex flex-column gap-1"
+      class="d-flex flex-column"
     >
       <label
         class="me-3"
@@ -98,7 +98,6 @@ exports[`IndividualExtensionDateModalComponent > should snap with a preset selec
           value="Custom"
         />
          Custom 
-         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
     </div>
     <br />
@@ -161,10 +160,10 @@ exports[`IndividualExtensionDateModalComponent > should snap with custom selecte
     </b>
      instructor(s):
   </div><div
-    class="px-3"
+    class="px-4"
   >
     <div
-      class="d-flex flex-column gap-1"
+      class="d-flex flex-column"
     >
       <label
         class="me-3"
@@ -219,7 +218,6 @@ exports[`IndividualExtensionDateModalComponent > should snap with custom selecte
           value="Custom"
         />
          Custom 
-         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
     </div>
     <div
@@ -451,10 +449,10 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
     </b>
      instructor(s):
   </div><div
-    class="px-3"
+    class="px-4"
   >
     <div
-      class="d-flex flex-column gap-1"
+      class="d-flex flex-column"
     >
       <label
         class="me-3"
@@ -509,7 +507,6 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
           value="Custom"
         />
          Custom 
-         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
     </div>
     <br />
@@ -573,10 +570,10 @@ exports[`IndividualExtensionDateModalComponent > should snap with the warning mo
     </b>
      instructor(s):
   </div><div
-    class="px-3"
+    class="px-4"
   >
     <div
-      class="d-flex flex-column gap-1"
+      class="d-flex flex-column"
     >
       <label
         class="me-3"
@@ -631,7 +628,6 @@ exports[`IndividualExtensionDateModalComponent > should snap with the warning mo
           value="Custom"
         />
          Custom 
-         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
     </div>
     <br />

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
@@ -521,7 +521,6 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
     </button>
     <button
       class="btn btn-success modal-btn-ok"
-      disabled=""
       type="button"
     >
        Save Changes 
@@ -642,7 +641,6 @@ exports[`IndividualExtensionDateModalComponent > should snap with the warning mo
     </button>
     <button
       class="btn btn-success modal-btn-ok"
-      disabled=""
       type="button"
     >
        Save Changes 

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/__snapshots__/individual-extension-date-modal.component.spec.ts.snap
@@ -1,24 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`IndividualExtensionDateModalComponent > should snap with the extend by radio option 1`] = `
+exports[`IndividualExtensionDateModalComponent > should snap with a preset selected 1`] = `
 <tm-individual-extension-date-modal
-  MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
-  MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
-  RadioOptions={[Function Object]}
+  DEADLINE_OPTIONS={[Function Array]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
+  customTimestamp={[Function Function]}
   dateFormatService={[Function _DateFormatService]}
-  extendByDatePicker={[Function Object]}
-  extendByDeadlineKey={[Function String]}
-  extendByDeadlineOptions={[Function Map]}
-  extendToTimestamp="0"
   feedbackSessionEndingTimestamp="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
-  radioOption={[Function Number]}
+  selectedPreset={[Function Function]}
   simpleModalService={[Function _SimpleModalService]}
-  sortMapByOriginalOrder={[Function Function]}
 >
   <div
     class="modal-header alert alert-primary alert-no-bottom"
@@ -46,86 +40,66 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
     </b>
      instructor(s):
   </div><div
-    class="container ms-1"
+    class="px-3"
   >
     <div
-      class="row ps-3"
+      class="d-flex flex-column gap-1"
     >
       <label
-        class="me-2"
+        class="me-3"
       >
         <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-by"
-          name="optradio"
+          name="deadlineOption"
           type="radio"
+          value="12 hours"
         />
-         Extend deadline by 
+         12 hours 
+         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
-      <label>
-        <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-to"
-          name="optradio"
-          type="radio"
-        />
-         Extend deadline to 
-      </label>
-    </div>
-    <div>
-      <small>
-        Extend the feedback session by:
-      </small>
-      <div
-        id="submission-start-date"
+      <label
+        class="me-3"
       >
-        <div
-          class="input-group w-75"
-        >
-          <select
-            class="form-control form-select ng-untouched ng-pristine ng-valid"
-            id="extend-by-dropdown"
-          >
-            <option
-              value="12 hours"
-            >
-               12 hours 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 day"
-            >
-               1 day 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="3 days"
-            >
-               3 days 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 week"
-            >
-               1 week 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="Customize"
-            >
-               Customize 
-            </option>
-          </select>
-        </div>
-      </div>
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 day"
+        />
+         1 day 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="3 days"
+        />
+         3 days 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 week"
+        />
+         1 week 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="Custom"
+        />
+         Custom 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
     </div>
     <br />
   </div><div
@@ -135,7 +109,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
       class="btn btn-light"
       type="button"
     >
-      No, cancel the Operation
+      Cancel
     </button>
     <button
       class="btn btn-success modal-btn-ok"
@@ -147,217 +121,19 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend by 
 </tm-individual-extension-date-modal>
 `;
 
-exports[`IndividualExtensionDateModalComponent > should snap with the extend by radio option with customize 1`] = `
+exports[`IndividualExtensionDateModalComponent > should snap with custom selected 1`] = `
 <tm-individual-extension-date-modal
-  MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
-  MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
-  RadioOptions={[Function Object]}
+  DEADLINE_OPTIONS={[Function Array]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
+  customTimestamp={[Function Function]}
   dateFormatService={[Function _DateFormatService]}
-  extendByDatePicker={[Function Object]}
-  extendByDeadlineKey={[Function String]}
-  extendByDeadlineOptions={[Function Map]}
-  extendToTimestamp="0"
-  feedbackSessionEndingTimestamp="0"
-  feedbackSessionTimeZone=""
-  numInstructors={[Function Number]}
-  numStudents={[Function Number]}
-  radioOption={[Function Number]}
-  simpleModalService={[Function _SimpleModalService]}
-  sortMapByOriginalOrder={[Function Function]}
->
-  <div
-    class="modal-header alert alert-primary alert-no-bottom"
-  >
-    <h5
-      class="modal-title"
-    >
-      Select the new deadline for extension
-    </h5>
-    <button
-      aria-label="Close"
-      class="btn-close"
-      type="button"
-    />
-  </div><div
-    class="modal-body"
-  >
-     Extending the feedback session for 
-    <b>
-      10
-    </b>
-     student(s) and 
-    <b>
-      20
-    </b>
-     instructor(s):
-  </div><div
-    class="container ms-1"
-  >
-    <div
-      class="row ps-3"
-    >
-      <label
-        class="me-2"
-      >
-        <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-by"
-          name="optradio"
-          type="radio"
-        />
-         Extend deadline by 
-      </label>
-      <label>
-        <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-to"
-          name="optradio"
-          type="radio"
-        />
-         Extend deadline to 
-      </label>
-    </div>
-    <div>
-      <small>
-        Extend the feedback session by:
-      </small>
-      <div
-        id="submission-start-date"
-      >
-        <div
-          class="input-group w-75"
-        >
-          <select
-            class="form-control form-select ng-untouched ng-pristine ng-valid"
-            id="extend-by-dropdown"
-          >
-            <option
-              value="12 hours"
-            >
-               12 hours 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 day"
-            >
-               1 day 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="3 days"
-            >
-               3 days 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 week"
-            >
-               1 week 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="Customize"
-            >
-               Customize 
-            </option>
-          </select>
-        </div>
-      </div>
-    </div>
-    <div>
-      <form
-        class="container ng-untouched ng-pristine ng-valid"
-        novalidate=""
-      >
-        <div
-          class="row"
-        >
-          <div
-            class="col-sm ps-0"
-          >
-            <small>
-              Hours
-            </small>
-            <input
-              class="form-control ng-untouched ng-pristine ng-valid"
-              id="form-hours"
-              name="form-hours"
-              placeholder="Hours"
-              type="number"
-            />
-          </div>
-          <div
-            class="col-sm"
-          >
-            <small>
-              Days
-            </small>
-            <input
-              class="form-control ng-untouched ng-pristine ng-valid"
-              id="form-days"
-              name="form-days"
-              placeholder="Days"
-              type="number"
-            />
-          </div>
-        </div>
-      </form>
-      <br />
-      <p
-        class="mb-0"
-      >
-         The new extended deadline will be: Sat, 5 Apr 2000 2:00 +08 
-      </p>
-    </div>
-    <br />
-  </div><div
-    class="modal-footer"
-  >
-    <button
-      class="btn btn-light"
-      type="button"
-    >
-      No, cancel the Operation
-    </button>
-    <button
-      class="btn btn-success modal-btn-ok"
-      type="button"
-    >
-       Save Changes 
-    </button>
-  </div>
-</tm-individual-extension-date-modal>
-`;
-
-exports[`IndividualExtensionDateModalComponent > should snap with the extend to radio option with timepicker 1`] = `
-<tm-individual-extension-date-modal
-  MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
-  MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
-  RadioOptions={[Function Object]}
-  activeModal={[Function NgbActiveModal]}
-  confirmCallbackEvent={[Function EventEmitter_]}
-  dateFormatService={[Function _DateFormatService]}
-  extendByDatePicker={[Function Object]}
-  extendByDeadlineKey=""
-  extendByDeadlineOptions={[Function Map]}
-  extendToTimestamp={[Function Number]}
   feedbackSessionEndingTimestamp="0"
   feedbackSessionTimeZone={[Function String]}
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
-  radioOption={[Function Number]}
+  selectedPreset={[Function Function]}
   simpleModalService={[Function _SimpleModalService]}
-  sortMapByOriginalOrder={[Function Function]}
 >
   <div
     class="modal-header alert alert-primary alert-no-bottom"
@@ -385,33 +161,70 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend to 
     </b>
      instructor(s):
   </div><div
-    class="container ms-1"
+    class="px-3"
   >
     <div
-      class="row ps-3"
+      class="d-flex flex-column gap-1"
     >
       <label
-        class="me-2"
+        class="me-3"
       >
         <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-by"
-          name="optradio"
+          name="deadlineOption"
           type="radio"
+          value="12 hours"
         />
-         Extend deadline by 
+         12 hours 
+         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
-      <label>
+      <label
+        class="me-3"
+      >
         <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-to"
-          name="optradio"
+          name="deadlineOption"
           type="radio"
+          value="1 day"
         />
-         Extend deadline to 
+         1 day 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="3 days"
+        />
+         3 days 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 week"
+        />
+         1 week 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="Custom"
+        />
+         Custom 
+         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
     </div>
-    <div>
+    <div
+      class="mt-2"
+    >
       <small>
         The new deadline of the feedback session will be:
       </small>
@@ -586,7 +399,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend to 
       class="btn btn-light"
       type="button"
     >
-      No, cancel the Operation
+      Cancel
     </button>
     <button
       class="btn btn-success modal-btn-ok"
@@ -600,23 +413,17 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extend to 
 
 exports[`IndividualExtensionDateModalComponent > should snap with the extended students 1`] = `
 <tm-individual-extension-date-modal
-  MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
-  MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
-  RadioOptions={[Function Object]}
+  DEADLINE_OPTIONS={[Function Array]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
+  customTimestamp={[Function Function]}
   dateFormatService={[Function _DateFormatService]}
-  extendByDatePicker={[Function Object]}
-  extendByDeadlineKey=""
-  extendByDeadlineOptions={[Function Map]}
-  extendToTimestamp="0"
   feedbackSessionEndingTimestamp="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
-  radioOption={[Function Number]}
+  selectedPreset={[Function Function]}
   simpleModalService={[Function _SimpleModalService]}
-  sortMapByOriginalOrder={[Function Function]}
 >
   <div
     class="modal-header alert alert-primary alert-no-bottom"
@@ -644,86 +451,66 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
     </b>
      instructor(s):
   </div><div
-    class="container ms-1"
+    class="px-3"
   >
     <div
-      class="row ps-3"
+      class="d-flex flex-column gap-1"
     >
       <label
-        class="me-2"
+        class="me-3"
       >
         <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-by"
-          name="optradio"
+          name="deadlineOption"
           type="radio"
+          value="12 hours"
         />
-         Extend deadline by 
+         12 hours 
+         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
-      <label>
-        <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-to"
-          name="optradio"
-          type="radio"
-        />
-         Extend deadline to 
-      </label>
-    </div>
-    <div>
-      <small>
-        Extend the feedback session by:
-      </small>
-      <div
-        id="submission-start-date"
+      <label
+        class="me-3"
       >
-        <div
-          class="input-group w-75"
-        >
-          <select
-            class="form-control form-select ng-untouched ng-pristine ng-valid"
-            id="extend-by-dropdown"
-          >
-            <option
-              value="12 hours"
-            >
-               12 hours 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 day"
-            >
-               1 day 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="3 days"
-            >
-               3 days 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 week"
-            >
-               1 week 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="Customize"
-            >
-               Customize 
-            </option>
-          </select>
-        </div>
-      </div>
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 day"
+        />
+         1 day 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="3 days"
+        />
+         3 days 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 week"
+        />
+         1 week 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="Custom"
+        />
+         Custom 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
     </div>
     <br />
   </div><div
@@ -733,7 +520,7 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
       class="btn btn-light"
       type="button"
     >
-      No, cancel the Operation
+      Cancel
     </button>
     <button
       class="btn btn-success modal-btn-ok"
@@ -748,23 +535,17 @@ exports[`IndividualExtensionDateModalComponent > should snap with the extended s
 
 exports[`IndividualExtensionDateModalComponent > should snap with the warning modal 1`] = `
 <tm-individual-extension-date-modal
-  MAX_EPOCH_TIME_IN_DAYS={[Function Number]}
-  MAX_EPOCH_TIME_IN_MILLISECONDS={[Function Number]}
-  RadioOptions={[Function Object]}
+  DEADLINE_OPTIONS={[Function Array]}
   activeModal={[Function NgbActiveModal]}
   confirmCallbackEvent={[Function EventEmitter_]}
+  customTimestamp={[Function Function]}
   dateFormatService={[Function _DateFormatService]}
-  extendByDatePicker={[Function Object]}
-  extendByDeadlineKey=""
-  extendByDeadlineOptions={[Function Map]}
-  extendToTimestamp="0"
   feedbackSessionEndingTimestamp="0"
   feedbackSessionTimeZone=""
   numInstructors={[Function Number]}
   numStudents={[Function Number]}
-  radioOption={[Function Number]}
+  selectedPreset={[Function Function]}
   simpleModalService={[Function _SimpleModalService]}
-  sortMapByOriginalOrder={[Function Function]}
 >
   <div
     class="modal-header alert alert-primary alert-no-bottom"
@@ -792,86 +573,66 @@ exports[`IndividualExtensionDateModalComponent > should snap with the warning mo
     </b>
      instructor(s):
   </div><div
-    class="container ms-1"
+    class="px-3"
   >
     <div
-      class="row ps-3"
+      class="d-flex flex-column gap-1"
     >
       <label
-        class="me-2"
+        class="me-3"
       >
         <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-by"
-          name="optradio"
+          name="deadlineOption"
           type="radio"
+          value="12 hours"
         />
-         Extend deadline by 
+         12 hours 
+         (Sat, 5 Apr 2000 2:00 +08) 
       </label>
-      <label>
-        <input
-          class="ng-untouched ng-pristine ng-valid"
-          id="extend-deadline-to"
-          name="optradio"
-          type="radio"
-        />
-         Extend deadline to 
-      </label>
-    </div>
-    <div>
-      <small>
-        Extend the feedback session by:
-      </small>
-      <div
-        id="submission-start-date"
+      <label
+        class="me-3"
       >
-        <div
-          class="input-group w-75"
-        >
-          <select
-            class="form-control form-select ng-untouched ng-pristine ng-valid"
-            id="extend-by-dropdown"
-          >
-            <option
-              value="12 hours"
-            >
-               12 hours 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 day"
-            >
-               1 day 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="3 days"
-            >
-               3 days 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="1 week"
-            >
-               1 week 
-              <div>
-                (Sat, 5 Apr 2000 2:00 +08)
-              </div>
-            </option>
-            <option
-              value="Customize"
-            >
-               Customize 
-            </option>
-          </select>
-        </div>
-      </div>
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 day"
+        />
+         1 day 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="3 days"
+        />
+         3 days 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="1 week"
+        />
+         1 week 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
+      <label
+        class="me-3"
+      >
+        <input
+          name="deadlineOption"
+          type="radio"
+          value="Custom"
+        />
+         Custom 
+         (Sat, 5 Apr 2000 2:00 +08) 
+      </label>
     </div>
     <br />
   </div><div
@@ -881,10 +642,11 @@ exports[`IndividualExtensionDateModalComponent > should snap with the warning mo
       class="btn btn-light"
       type="button"
     >
-      No, cancel the Operation
+      Cancel
     </button>
     <button
       class="btn btn-success modal-btn-ok"
+      disabled=""
       type="button"
     >
        Save Changes 

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
@@ -6,57 +6,32 @@
   Extending the feedback session for <b>{{ numStudents }}</b> student(s) and <b>{{ numInstructors }}</b> instructor(s):
 </div>
 
-<div class="container ms-1">
-  <div class="row ps-3">
-    <label class="me-2"
-      ><input
-        id="extend-deadline-by"
-        type="radio"
-        name="optradio"
-        [value]="RadioOptions.EXTEND_BY"
-        [(ngModel)]="radioOption"
-      />
-      Extend deadline by
-    </label>
-    <label
-      ><input
-        id="extend-deadline-to"
-        type="radio"
-        name="optradio"
-        [(ngModel)]="radioOption"
-        [value]="RadioOptions.EXTEND_TO"
-      />
-      Extend deadline to
-    </label>
+<div class="px-4">
+  <div class="d-flex flex-column gap-1">
+    @for (option of DEADLINE_OPTIONS; track option.label) {
+      <label class="me-3">
+        <input
+          type="radio"
+          name="deadlineOption"
+          [value]="option.label"
+          [checked]="selectedPreset() === option.label"
+          (change)="selectedPreset.set(option.label)"
+        />
+        {{ option.label }}
+        @if (option.hours !== null) {
+          ({{ extendAndFormatEndTimeBy(option.hours) }})
+        }
+      </label>
+    }
   </div>
 
-  @if (isRadioExtendBy()) {
-    <div>
-      <small>Extend the feedback session by:</small>
-      <div id="submission-start-date">
-        <div class="input-group w-75">
-          <select id="extend-by-dropdown" class="form-control form-select" [(ngModel)]="extendByDeadlineKey">
-            @for (deadlineOption of extendByDeadlineOptions | keyvalue: sortMapByOriginalOrder; track deadlineOption) {
-              <option [value]="deadlineOption.key">
-                {{ deadlineOption.key }}
-                @if (deadlineOption.key !== 'Customize') {
-                  <div>({{ extendAndFormatEndTimeBy(deadlineOption.value, 0) }})</div>
-                }
-              </option>
-            }
-          </select>
-        </div>
-      </div>
-    </div>
-  }
-
-  @if (isRadioExtendTo()) {
-    <div>
+  @if (isCustom()) {
+    <div class="mt-2">
       <small>The new deadline of the feedback session will be:</small>
       <div id="submission-start-date">
         <tm-datetimepicker
           id="submission-end-datetime"
-          [timestamp]="extendToTimestamp"
+          [timestamp]="customTimestamp()"
           [minTimestamp]="feedbackSessionEndingTimestamp"
           [timeZone]="feedbackSessionTimeZone"
           (timestampChange)="onChangeDateTime($event)"
@@ -66,58 +41,11 @@
     </div>
   }
 
-  @if (isCustomize()) {
-    <div>
-      <form class="container">
-        <div class="row">
-          <div class="col-sm ps-0">
-            <small>Hours</small>
-            <input
-              class="form-control"
-              id="form-hours"
-              name="form-hours"
-              type="number"
-              placeholder="Hours"
-              [(ngModel)]="extendByDatePicker.hours"
-            />
-          </div>
-          <div class="col-sm">
-            <small>Days</small>
-            <input
-              class="form-control"
-              id="form-days"
-              name="form-days"
-              type="number"
-              placeholder="Days"
-              [(ngModel)]="extendByDatePicker.days"
-            />
-          </div>
-        </div>
-      </form>
-      <br />
-      @if (!isCustomizeDateTimeIntegers()) {
-        <p class="text-danger m-0"><span class="fa fa-times"></span> Please input only integers into both blanks.</p>
-      }
-      @if (!isDateSelectedLaterThanCurrentEndingTimestamp()) {
-        <p class="text-danger m-0">
-          <span class="fa fa-times"></span> Please input a date later than the current session ending date.
-        </p>
-      }
-      @if (!isCustomizeBeforeMaxDate()) {
-        <p class="text-danger m-0"><span class="fa fa-times"></span> Please input a valid date.</p>
-      }
-      <p class="mb-0">
-        The new extended deadline will be:
-        {{ extendAndFormatEndTimeBy(extendByDatePicker.hours, extendByDatePicker.days) }}
-      </p>
-    </div>
-  }
-
   <br />
 </div>
 
 <div class="modal-footer">
-  <button type="button" class="btn btn-light" (click)="activeModal.dismiss()">No, cancel the Operation</button>
+  <button type="button" class="btn btn-light" (click)="activeModal.dismiss()">Cancel</button>
   <button type="button" class="btn btn-success modal-btn-ok" (click)="onConfirm()" [disabled]="!isValidForm()">
     Save Changes
   </button>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.html
@@ -7,7 +7,7 @@
 </div>
 
 <div class="px-4">
-  <div class="d-flex flex-column gap-1">
+  <div class="d-flex flex-column">
     @for (option of DEADLINE_OPTIONS; track option.label) {
       <label class="me-3">
         <input
@@ -18,7 +18,7 @@
           (change)="selectedPreset.set(option.label)"
         />
         {{ option.label }}
-        @if (option.hours !== null) {
+        @if (option.label !== 'Custom') {
           ({{ extendAndFormatEndTimeBy(option.hours) }})
         }
       </label>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.spec.ts
@@ -2,18 +2,16 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
-import { IndividualExtensionDateModalComponent, RadioOptions } from './individual-extension-date-modal.component';
+import { IndividualExtensionDateModalComponent } from './individual-extension-date-modal.component';
 import { SimpleModalService } from '../../../../services/simple-modal.service';
 import { TimezoneService } from '../../../../services/timezone.service';
 import { createMockNgbModalRef } from '../../../../test-helpers/mock-ngb-modal-ref';
 import { Hours, Milliseconds } from '../../../../types/datetime-const';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
-import { FormatDateDetailPipe } from '../../../components/teammates-common/format-date-detail.pipe';
 import { Mock } from 'vitest';
 
 describe('IndividualExtensionDateModalComponent', () => {
   const testTimeString = 'Sat, 5 Apr 2000 2:00 +08';
-  const MAX_EPOCH_TIME_IN_DAYS = 100000000;
 
   let component: IndividualExtensionDateModalComponent;
   let fixture: ComponentFixture<IndividualExtensionDateModalComponent>;
@@ -23,7 +21,7 @@ describe('IndividualExtensionDateModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      providers: [NgbActiveModal, FormatDateDetailPipe, provideHttpClient(), provideHttpClientTesting()],
+      providers: [NgbActiveModal, provideHttpClient(), provideHttpClientTesting()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(IndividualExtensionDateModalComponent);
@@ -33,6 +31,8 @@ describe('IndividualExtensionDateModalComponent', () => {
     formatSpy = vi.spyOn(timeZoneService, 'formatToString').mockReturnValue(testTimeString);
     component.numStudents = 10;
     component.numInstructors = 20;
+    component.feedbackSessionEndingTimestamp = 0;
+    component.feedbackSessionTimeZone = '';
     fixture.detectChanges();
   });
 
@@ -45,120 +45,52 @@ describe('IndividualExtensionDateModalComponent', () => {
     expect(fixture).toMatchSnapshot();
   });
 
-  it('should snap with the extend by radio option', () => {
-    component.extendByDeadlineKey = '12 hours';
-    component.radioOption = RadioOptions.EXTEND_BY;
+  it('should snap with a preset selected', () => {
+    component.selectedPreset.set('12 hours');
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
   });
 
-  it('should display correct time with the extend by radio option', () => {
+  it('should snap with custom selected', () => {
+    component.feedbackSessionTimeZone = 'UTC';
+    component.selectedPreset.set('Custom');
+    component.customTimestamp.set(Date.UTC(2022, 9, 10, 10, 30));
+    fixture.detectChanges();
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should display correct time with preset options', () => {
     formatSpy.mockRestore();
-    component.radioOption = RadioOptions.EXTEND_BY;
     component.feedbackSessionTimeZone = 'Asia/Singapore';
     component.feedbackSessionEndingTimestamp = 1600000000000;
-    expect(component.extendAndFormatEndTimeBy(0, 0)).toEqual('Sun, 13 Sep 2020, 08:26 PM +08');
+    expect(component.extendAndFormatEndTimeBy(0)).toEqual('Sun, 13 Sep 2020, 08:26 PM +08');
 
-    component.extendByDeadlineKey = '12 hours';
+    component.selectedPreset.set('12 hours');
     expect(component.getExtensionTimestamp()).toEqual(
       component.feedbackSessionEndingTimestamp + Hours.TWELVE * Milliseconds.IN_ONE_HOUR,
     );
-    expect(component.extendAndFormatEndTimeBy(Hours.TWELVE, 0)).toEqual('Mon, 14 Sep 2020, 08:26 AM +08');
+    expect(component.extendAndFormatEndTimeBy(Hours.TWELVE)).toEqual('Mon, 14 Sep 2020, 08:26 AM +08');
 
-    component.extendByDeadlineKey = '1 day';
+    component.selectedPreset.set('1 day');
     expect(component.getExtensionTimestamp()).toEqual(
       component.feedbackSessionEndingTimestamp + Hours.IN_ONE_DAY * Milliseconds.IN_ONE_HOUR,
     );
-    expect(component.extendAndFormatEndTimeBy(Hours.IN_ONE_DAY, 0)).toEqual('Mon, 14 Sep 2020, 08:26 PM +08');
+    expect(component.extendAndFormatEndTimeBy(Hours.IN_ONE_DAY)).toEqual('Mon, 14 Sep 2020, 08:26 PM +08');
 
-    component.extendByDeadlineKey = '3 days';
+    component.selectedPreset.set('3 days');
     expect(component.getExtensionTimestamp()).toEqual(
       component.feedbackSessionEndingTimestamp + Hours.IN_THREE_DAYS * Milliseconds.IN_ONE_HOUR,
     );
-    expect(component.extendAndFormatEndTimeBy(Hours.IN_THREE_DAYS, 0)).toEqual('Wed, 16 Sep 2020, 08:26 PM +08');
+    expect(component.extendAndFormatEndTimeBy(Hours.IN_THREE_DAYS)).toEqual('Wed, 16 Sep 2020, 08:26 PM +08');
 
-    component.extendByDeadlineKey = '1 week';
+    component.selectedPreset.set('1 week');
     expect(component.getExtensionTimestamp()).toEqual(
       component.feedbackSessionEndingTimestamp + Hours.IN_ONE_WEEK * Milliseconds.IN_ONE_HOUR,
     );
-    expect(component.extendAndFormatEndTimeBy(Hours.IN_ONE_WEEK, 0)).toEqual('Sun, 20 Sep 2020, 08:26 PM +08');
-  });
-
-  it('should snap with the extend by radio option with customize', () => {
-    component.extendByDeadlineKey = 'Customize';
-    component.radioOption = RadioOptions.EXTEND_BY;
-    component.extendByDatePicker = { hours: 20, days: 100 };
-    fixture.detectChanges();
-    expect(fixture).toMatchSnapshot();
-  });
-
-  it('should display correct time with the extend by customize option', () => {
-    formatSpy.mockRestore();
-    component.radioOption = RadioOptions.EXTEND_BY;
-    component.extendByDeadlineKey = 'Customize';
-    component.feedbackSessionTimeZone = 'Asia/Singapore';
-    component.feedbackSessionEndingTimestamp = 1600000000000;
-    expect(component.extendAndFormatEndTimeBy(0, 0)).toEqual('Sun, 13 Sep 2020, 08:26 PM +08');
-    expect(component.extendAndFormatEndTimeBy(20, 0)).toEqual('Mon, 14 Sep 2020, 04:26 PM +08');
-    expect(component.extendAndFormatEndTimeBy(0, 20)).toEqual('Sat, 03 Oct 2020, 08:26 PM +08');
-    expect(component.extendAndFormatEndTimeBy(20, 20)).toEqual('Sun, 04 Oct 2020, 04:26 PM +08');
-    expect(component.extendAndFormatEndTimeBy(0, MAX_EPOCH_TIME_IN_DAYS)).toEqual('Invalid date');
-  });
-
-  it('should display only the message for date to be later than session ending timestamp as default', () => {
-    component.extendByDeadlineKey = 'Customize';
-    component.radioOption = RadioOptions.EXTEND_BY;
-    component.extendByDatePicker = { hours: 0, days: 0 };
-    component.feedbackSessionEndingTimestamp = new Date(testTimeString).getTime();
-    fixture.detectChanges();
-    expect(component.isCustomizeBeforeMaxDate()).toBeTruthy();
-    expect(component.isCustomizeDateTimeIntegers()).toBeTruthy();
-    expect(component.isDateSelectedLaterThanCurrentEndingTimestamp()).toBeFalsy();
-  });
-
-  it('should display the message for date to be later than session ending timestamp', () => {
-    component.extendByDeadlineKey = 'Customize';
-    component.radioOption = RadioOptions.EXTEND_BY;
-    component.extendByDatePicker = { hours: -10, days: 0 };
-    component.feedbackSessionEndingTimestamp = new Date(testTimeString).getTime();
-    fixture.detectChanges();
-    expect(component.isDateSelectedLaterThanCurrentEndingTimestamp()).toBeFalsy();
-  });
-
-  it('should display the message for date to be before maximum date', () => {
-    component.extendByDeadlineKey = 'Customize';
-    component.radioOption = RadioOptions.EXTEND_BY;
-    component.extendByDatePicker.days = MAX_EPOCH_TIME_IN_DAYS;
-    component.feedbackSessionEndingTimestamp = new Date(testTimeString).getTime();
-    fixture.detectChanges();
-    expect(component.isCustomizeBeforeMaxDate()).toBeFalsy();
-  });
-
-  it('should display the message for non-integer date or time', () => {
-    component.extendByDeadlineKey = 'Customize';
-    component.radioOption = RadioOptions.EXTEND_BY;
-    component.feedbackSessionEndingTimestamp = new Date(testTimeString).getTime();
-    component.extendByDatePicker = { hours: 0.5, days: 0 };
-    fixture.detectChanges();
-    expect(component.isCustomizeDateTimeIntegers()).toBeFalsy();
-    component.extendByDatePicker = { hours: 0, days: 0.5 };
-    fixture.detectChanges();
-    expect(component.isCustomizeDateTimeIntegers()).toBeFalsy();
-    component.extendByDatePicker = { hours: 0.5, days: 0.5 };
-    fixture.detectChanges();
-    expect(component.isCustomizeDateTimeIntegers()).toBeFalsy();
-  });
-
-  it('should snap with the extend to radio option with timepicker', () => {
-    component.feedbackSessionTimeZone = 'UTC';
-    component.radioOption = RadioOptions.EXTEND_TO;
-    component.extendToTimestamp = Date.UTC(2022, 9, 10, 10, 30);
-    fixture.detectChanges();
-    expect(fixture).toMatchSnapshot();
+    expect(component.extendAndFormatEndTimeBy(Hours.IN_ONE_WEEK)).toEqual('Sun, 20 Sep 2020, 08:26 PM +08');
   });
 
   it('should snap with the warning modal', () => {
-    // Set mocked picked time to be lesser than current system time
     vi.useFakeTimers().setSystemTime(new Date('2021-01-01').getTime());
     vi.spyOn(component, 'getExtensionTimestamp').mockReturnValue(new Date('2020-10-10').valueOf());
     const modalSpy = vi.spyOn(simpleModalService, 'openConfirmationModal').mockImplementation(() =>

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
@@ -1,70 +1,43 @@
-import { KeyValuePipe } from '@angular/common';
-import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, EventEmitter, Input, OnInit, Output, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { SimpleModalService } from '../../../../services/simple-modal.service';
 import { Hours, Milliseconds } from '../../../../types/datetime-const';
 import { DatetimepickerComponent } from '../../../components/datetimepicker/datetimepicker.component';
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
-import { FormatDateDetailPipe } from '../../../components/teammates-common/format-date-detail.pipe';
 import { DateFormatService } from '../../../../services/date-format.service';
-
-export enum RadioOptions {
-  EXTEND_TO = 1,
-  EXTEND_BY = 2,
-}
 
 @Component({
   selector: 'tm-individual-extension-date-modal',
   templateUrl: './individual-extension-date-modal.component.html',
-  imports: [FormsModule, DatetimepickerComponent, KeyValuePipe],
-  providers: [FormatDateDetailPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, DatetimepickerComponent],
 })
 export class IndividualExtensionDateModalComponent implements OnInit {
   activeModal = inject(NgbActiveModal);
-  private simpleModalService = inject(SimpleModalService);
-  private dateFormatService = inject(DateFormatService);
+  private readonly simpleModalService = inject(SimpleModalService);
+  private readonly dateFormatService = inject(DateFormatService);
 
-  @Input()
-  numStudents = 0;
+  @Input({ required: true }) numStudents = 0;
+  @Input({ required: true }) numInstructors = 0;
+  @Input({ required: true }) feedbackSessionEndingTimestamp = 0;
+  @Input({ required: true }) feedbackSessionTimeZone = '';
 
-  @Input()
-  numInstructors = 0;
+  @Output() confirmCallbackEvent: EventEmitter<number> = new EventEmitter();
 
-  @Input()
-  feedbackSessionEndingTimestamp = 0;
+  readonly DEADLINE_OPTIONS = [
+    { label: '12 hours', hours: Hours.TWELVE },
+    { label: '1 day', hours: Hours.IN_ONE_DAY },
+    { label: '3 days', hours: Hours.IN_THREE_DAYS },
+    { label: '1 week', hours: Hours.IN_ONE_WEEK },
+    { label: 'Custom', hours: Hours.ZERO },
+  ] as const;
 
-  @Input()
-  feedbackSessionTimeZone = '';
-
-  @Output()
-  confirmCallbackEvent: EventEmitter<number> = new EventEmitter();
-
-  RadioOptions!: typeof RadioOptions;
-  radioOption: RadioOptions = RadioOptions.EXTEND_BY;
-
-  extendByDeadlineKey = '';
-  extendByDeadlineOptions: Map<string, number> = new Map([
-    ['12 hours', Hours.TWELVE],
-    ['1 day', Hours.IN_ONE_DAY],
-    ['3 days', Hours.IN_THREE_DAYS],
-    ['1 week', Hours.IN_ONE_WEEK],
-    ['Customize', Hours.ZERO],
-  ]);
-  extendByDatePicker = { hours: 0, days: 0 };
-
-  MAX_EPOCH_TIME_IN_DAYS = 100000000;
-  MAX_EPOCH_TIME_IN_MILLISECONDS = this.MAX_EPOCH_TIME_IN_DAYS * Milliseconds.IN_ONE_DAY;
-  extendToTimestamp = 0;
-
-  sortMapByOriginalOrder = (): number => 0;
-
-  constructor() {
-    this.RadioOptions = RadioOptions;
-  }
+  readonly selectedPreset = signal('');
+  readonly customTimestamp = signal(0);
 
   ngOnInit(): void {
-    this.extendToTimestamp = this.feedbackSessionEndingTimestamp;
+    this.customTimestamp.set(this.feedbackSessionEndingTimestamp);
   }
 
   onConfirm(): void {
@@ -73,8 +46,8 @@ export class IndividualExtensionDateModalComponent implements OnInit {
       return;
     }
 
-    const extensionTimeString = this.adjustToFeedbackSessionTimeZone(this.getExtensionTimestamp());
-    const currentTimeString = this.adjustToFeedbackSessionTimeZone(Date.now());
+    const extensionTimeString = this.formatTimestamp(this.getExtensionTimestamp());
+    const currentTimeString = this.formatTimestamp(Date.now());
 
     this.simpleModalService
       .openConfirmationModal(
@@ -91,87 +64,31 @@ export class IndividualExtensionDateModalComponent implements OnInit {
   }
 
   onChangeDateTime(timestamp: number): void {
-    this.extendToTimestamp = timestamp;
+    this.customTimestamp.set(timestamp);
   }
 
   getExtensionTimestamp(): number {
-    if (this.isRadioExtendBy()) {
-      if (this.isCustomize()) {
-        return this.addTime(
-          this.feedbackSessionEndingTimestamp,
-          this.extendByDatePicker.hours,
-          this.extendByDatePicker.days,
-        );
-      }
-      if (this.extendByDeadlineOptions.has(this.extendByDeadlineKey)) {
-        return this.addTime(
-          this.feedbackSessionEndingTimestamp,
-          this.extendByDeadlineOptions.get(this.extendByDeadlineKey)!.valueOf(),
-          0,
-        );
-      }
+    if (this.isCustom()) {
+      return this.customTimestamp();
     }
-    if (this.isRadioExtendTo()) {
-      return this.extendToTimestamp;
-    }
-    return this.feedbackSessionEndingTimestamp;
+    const opt = this.DEADLINE_OPTIONS.find((o) => o.label === this.selectedPreset());
+    const hours = opt ? opt.hours : 0;
+    return this.feedbackSessionEndingTimestamp + hours * Milliseconds.IN_ONE_HOUR;
   }
 
-  extendAndFormatEndTimeBy(hours: number, days: number): string {
-    const time = this.addTime(this.feedbackSessionEndingTimestamp, hours, days);
-    return this.adjustToFeedbackSessionTimeZone(time);
+  extendAndFormatEndTimeBy(hours: number): string {
+    return this.formatTimestamp(this.feedbackSessionEndingTimestamp + hours * Milliseconds.IN_ONE_HOUR);
   }
 
-  private addTime(timestamp: number, hours: number, days: number): number {
-    return timestamp + hours * Milliseconds.IN_ONE_HOUR + days * Milliseconds.IN_ONE_DAY;
-  }
-
-  private adjustToFeedbackSessionTimeZone(time: number): string {
-    return this.dateFormatService.formatDateDetailed(time, this.feedbackSessionTimeZone);
+  isCustom(): boolean {
+    return this.selectedPreset() === 'Custom';
   }
 
   isValidForm(): boolean {
-    return this.isDateSelectedLaterThanCurrentEndingTimestamp() && this.isCustomizeValid();
-  }
-
-  isDateSelectedLaterThanCurrentEndingTimestamp(): boolean {
     return this.getExtensionTimestamp() > this.feedbackSessionEndingTimestamp;
   }
 
-  isCustomizeValid(): boolean {
-    return this.isCustomizeDateTimeIntegers() && this.isCustomizeBeforeMaxDate();
-  }
-
-  isCustomizeDateTimeIntegers(): boolean {
-    if (!this.isCustomize()) {
-      return true;
-    }
-
-    return Number.isInteger(this.extendByDatePicker.days) && Number.isInteger(this.extendByDatePicker.hours);
-  }
-
-  isCustomizeBeforeMaxDate(): boolean {
-    if (!this.isCustomize()) {
-      return true;
-    }
-
-    const timeSelected = this.addTime(
-      this.feedbackSessionEndingTimestamp,
-      this.extendByDatePicker.hours,
-      this.extendByDatePicker.days,
-    );
-    return timeSelected < this.MAX_EPOCH_TIME_IN_MILLISECONDS;
-  }
-
-  isRadioExtendBy(): boolean {
-    return this.radioOption === RadioOptions.EXTEND_BY;
-  }
-
-  isCustomize(): boolean {
-    return this.isRadioExtendBy() && this.extendByDeadlineKey === 'Customize';
-  }
-
-  isRadioExtendTo(): boolean {
-    return this.radioOption === RadioOptions.EXTEND_TO;
+  private formatTimestamp(time: number): string {
+    return this.dateFormatService.formatDateDetailed(time, this.feedbackSessionTimeZone);
   }
 }

--- a/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-individual-extension-page/individual-extension-date-modal/individual-extension-date-modal.component.ts
@@ -7,6 +7,16 @@ import { DatetimepickerComponent } from '../../../components/datetimepicker/date
 import { SimpleModalType } from '../../../components/simple-modal/simple-modal-type';
 import { DateFormatService } from '../../../../services/date-format.service';
 
+const DEADLINE_OPTIONS = [
+  { label: '12 hours', hours: Hours.TWELVE },
+  { label: '1 day', hours: Hours.IN_ONE_DAY },
+  { label: '3 days', hours: Hours.IN_THREE_DAYS },
+  { label: '1 week', hours: Hours.IN_ONE_WEEK },
+  { label: 'Custom', hours: Hours.ZERO },
+] as const;
+
+type DeadlineLabel = (typeof DEADLINE_OPTIONS)[number]['label'];
+
 @Component({
   selector: 'tm-individual-extension-date-modal',
   templateUrl: './individual-extension-date-modal.component.html',
@@ -25,15 +35,9 @@ export class IndividualExtensionDateModalComponent implements OnInit {
 
   @Output() confirmCallbackEvent: EventEmitter<number> = new EventEmitter();
 
-  readonly DEADLINE_OPTIONS = [
-    { label: '12 hours', hours: Hours.TWELVE },
-    { label: '1 day', hours: Hours.IN_ONE_DAY },
-    { label: '3 days', hours: Hours.IN_THREE_DAYS },
-    { label: '1 week', hours: Hours.IN_ONE_WEEK },
-    { label: 'Custom', hours: Hours.ZERO },
-  ] as const;
+  readonly DEADLINE_OPTIONS = DEADLINE_OPTIONS;
 
-  readonly selectedPreset = signal('');
+  readonly selectedPreset = signal<DeadlineLabel>(DEADLINE_OPTIONS[0].label);
   readonly customTimestamp = signal(0);
 
   ngOnInit(): void {
@@ -71,8 +75,7 @@ export class IndividualExtensionDateModalComponent implements OnInit {
     if (this.isCustom()) {
       return this.customTimestamp();
     }
-    const opt = this.DEADLINE_OPTIONS.find((o) => o.label === this.selectedPreset());
-    const hours = opt ? opt.hours : 0;
+    const { hours } = this.DEADLINE_OPTIONS.find((o) => o.label === this.selectedPreset())!;
     return this.feedbackSessionEndingTimestamp + hours * Milliseconds.IN_ONE_HOUR;
   }
 


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14181

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Previously, selecting date/time was a 2 step process. First select "extend to" or "extend by", then select the options.

This not only added user friction, there's non-trivial cognitive effort required to understand extend to or extend by.

This has been simplified to radio options with sensible defaults as well as a custom option which reveals the datetime picker.

<img width="454" height="385" alt="Screenshot 2026-06-16 at 19 01 10" src="https://github.com/user-attachments/assets/015d184c-ffef-4ff2-b9e7-01fcca304238" />
