### PR TITLE
[#14020] Introduce EmailQueueService

### DIFF
--- a/src/main/java/teammates/logic/email/EmailQueueService.java
+++ b/src/main/java/teammates/logic/email/EmailQueueService.java
@@ -1,0 +1,66 @@
+package teammates.logic.email;
+
+import java.util.Collections;
+import java.util.List;
+
+import teammates.common.util.EmailWrapper;
+import teammates.logic.api.TaskQueuer;
+
+/**
+ * Handles queueing of outbound emails.
+ */
+public class EmailQueueService {
+
+    private static final EmailQueueService instance = new EmailQueueService(TaskQueuer.inst());
+
+    private final TaskQueuer taskQueuer;
+
+    EmailQueueService(TaskQueuer taskQueuer) {
+        this.taskQueuer = taskQueuer;
+    }
+
+    public static EmailQueueService inst() {
+        return instance;
+    }
+
+    public static EmailQueueService withTaskQueuer(TaskQueuer taskQueuer) {
+        return new EmailQueueService(taskQueuer);
+    }
+
+    /**
+     * Enqueues the given email for priority sending. Priority emails are sent in a
+     * separate queue from bulk emails and are meant for time-sensitive
+     * notifications.
+     */
+    public void enqueuePriority(EmailWrapper email) {
+        enqueuePriority(Collections.singletonList(email));
+    }
+
+    /**
+     * Enqueues the given emails for priority sending. Priority emails are sent in a
+     * separate queue from bulk emails and are meant for time-sensitive
+     * notifications.
+     */
+    public void enqueuePriority(List<EmailWrapper> emails) {
+        taskQueuer.scheduleEmailsForPrioritySending(emails);
+    }
+
+    /**
+     * Enqueues the given email for standard sending. Standard emails are sent in a
+     * separate queue from priority emails and are meant for non-time-sensitive
+     * notifications.
+     */
+    public void enqueueStandard(EmailWrapper email) {
+        enqueueStandard(Collections.singletonList(email));
+    }
+
+    /**
+     * Enqueues the given emails for standard sending. Standard emails are sent in a
+     * separate queue from priority emails and are meant for non-time-sensitive
+     * notifications.
+     */
+    public void enqueueStandard(List<EmailWrapper> emails) {
+        taskQueuer.scheduleEmailsForSending(emails);
+    }
+
+}

--- a/src/main/java/teammates/logic/email/package-info.java
+++ b/src/main/java/teammates/logic/email/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains classes related to email sending and email templates.
+ */
+package teammates.logic.email;

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -15,7 +15,6 @@ import teammates.logic.api.EmailGenerator;
 import teammates.logic.api.EmailSender;
 import teammates.logic.api.Logic;
 import teammates.logic.api.RecaptchaVerifier;
-import teammates.logic.api.TaskQueuer;
 import teammates.logic.api.UserProvision;
 import teammates.logic.email.EmailQueueService;
 import teammates.storage.entity.Account;
@@ -40,7 +39,6 @@ public abstract class Action {
     GateKeeper gateKeeper = GateKeeper.inst();
     EmailGenerator emailGenerator = EmailGenerator.inst();
     EmailQueueService emailQueueService = EmailQueueService.inst();
-    TaskQueuer taskQueuer = TaskQueuer.inst();
     EmailSender emailSender = EmailSender.inst();
     RecaptchaVerifier recaptchaVerifier = RecaptchaVerifier.inst();
 
@@ -68,14 +66,6 @@ public abstract class Action {
 
     public void setUserProvision(UserProvision userProvision) {
         this.userProvision = userProvision;
-    }
-
-    /**
-     * Injects TaskQueuer, used in tests.
-     */
-    public void setTaskQueuer(TaskQueuer taskQueuer) {
-        this.taskQueuer = taskQueuer;
-        this.emailQueueService = EmailQueueService.withTaskQueuer(taskQueuer);
     }
 
     public void setEmailSender(EmailSender emailSender) {

--- a/src/main/java/teammates/ui/webapi/Action.java
+++ b/src/main/java/teammates/ui/webapi/Action.java
@@ -17,6 +17,7 @@ import teammates.logic.api.Logic;
 import teammates.logic.api.RecaptchaVerifier;
 import teammates.logic.api.TaskQueuer;
 import teammates.logic.api.UserProvision;
+import teammates.logic.email.EmailQueueService;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
@@ -38,6 +39,7 @@ public abstract class Action {
     UserProvision userProvision = UserProvision.inst();
     GateKeeper gateKeeper = GateKeeper.inst();
     EmailGenerator emailGenerator = EmailGenerator.inst();
+    EmailQueueService emailQueueService = EmailQueueService.inst();
     TaskQueuer taskQueuer = TaskQueuer.inst();
     EmailSender emailSender = EmailSender.inst();
     RecaptchaVerifier recaptchaVerifier = RecaptchaVerifier.inst();
@@ -68,12 +70,20 @@ public abstract class Action {
         this.userProvision = userProvision;
     }
 
+    /**
+     * Injects TaskQueuer, used in tests.
+     */
     public void setTaskQueuer(TaskQueuer taskQueuer) {
         this.taskQueuer = taskQueuer;
+        this.emailQueueService = EmailQueueService.withTaskQueuer(taskQueuer);
     }
 
     public void setEmailSender(EmailSender emailSender) {
         this.emailSender = emailSender;
+    }
+
+    public void setEmailQueueService(EmailQueueService emailQueueService) {
+        this.emailQueueService = emailQueueService;
     }
 
     public void setRecaptchaVerifier(RecaptchaVerifier recaptchaVerifier) {

--- a/src/main/java/teammates/ui/webapi/ApproveAccountVerificationRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/ApproveAccountVerificationRequestAction.java
@@ -42,7 +42,7 @@ public class ApproveAccountVerificationRequestAction extends AdminOnlyAction {
             EmailWrapper email = emailGenerator.generateNewInstructorAccountJoinEmail(
                     accountVerificationRequest.getEmail(), accountVerificationRequest.getName(),
                     LinksUtil.getInstructorWelcomeUrl(accountVerificationRequest.getId()));
-            emailSender.sendEmail(email);
+            emailQueueService.enqueuePriority(email);
         } catch (InvalidParametersException e) {
             throw new InvalidHttpRequestBodyException(e);
         }

--- a/src/main/java/teammates/ui/webapi/CreateAccountVerificationRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateAccountVerificationRequestAction.java
@@ -50,8 +50,8 @@ public class CreateAccountVerificationRequestAction extends LoggedInAction {
                 .generateNewAccountVerificationRequestAdminAlertEmail(accountVerificationRequest);
         EmailWrapper userAcknowledgementEmail = emailGenerator
                 .generateNewAccountVerificationRequestAcknowledgementEmail(accountVerificationRequest);
-        emailSender.sendEmail(adminAlertEmail);
-        emailSender.sendEmail(userAcknowledgementEmail);
+        emailQueueService.enqueuePriority(adminAlertEmail);
+        emailQueueService.enqueuePriority(userAcknowledgementEmail);
 
         AccountVerificationRequestData output = new AccountVerificationRequestData(accountVerificationRequest);
         return new JsonResult(output);

--- a/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/CreateInstructorAction.java
@@ -44,7 +44,7 @@ public class CreateInstructorAction extends LoggedInAction {
             EmailWrapper email = emailGenerator.generateInstructorCourseJoinEmail(inviter, createdInstructor, course);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
-            taskQueuer.scheduleEmailsForPrioritySending(emails);
+            emailQueueService.enqueuePriority(emails);
 
             return new JsonResult(new InstructorData(createdInstructor));
         } catch (EntityAlreadyExistsException e) {

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosedRemindersAction.java
@@ -22,7 +22,7 @@ public class FeedbackSessionClosedRemindersAction extends AutomatedServiceAction
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionClosedEmails(session);
             try {
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                emailQueueService.enqueueStandard(emailsToBeSent);
                 session.setClosedEmailSent(true);
             } catch (Exception e) {
                 log.severe("Unexpected error", e);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionClosingSoonRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionClosingSoonRemindersAction.java
@@ -25,7 +25,7 @@ public class FeedbackSessionClosingSoonRemindersAction extends AutomatedServiceA
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionClosingSoonEmails(session);
             try {
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                emailQueueService.enqueueStandard(emailsToBeSent);
                 session.setClosingSoonEmailSent(true);
             } catch (Exception e) {
                 log.severe("Unexpected error", e);
@@ -49,7 +49,7 @@ public class FeedbackSessionClosingSoonRemindersAction extends AutomatedServiceA
 
             List<EmailWrapper> emailsToBeSent = emailGenerator
                     .generateFeedbackSessionClosingWithExtensionEmails(session, deadlineExtensions);
-            taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+            emailQueueService.enqueueStandard(emailsToBeSent);
 
             for (var de : deadlineExtensions) {
                 de.setClosingSoonEmailSent(true);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionOpenedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionOpenedRemindersAction.java
@@ -22,7 +22,7 @@ public class FeedbackSessionOpenedRemindersAction extends AutomatedServiceAction
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionOpenedEmails(session);
             try {
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                emailQueueService.enqueueStandard(emailsToBeSent);
                 session.setOpenedEmailSent(true);
             } catch (Exception e) {
                 log.severe("Unexpected error", e);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionOpeningSoonRemindersAction.java
@@ -20,7 +20,7 @@ public class FeedbackSessionOpeningSoonRemindersAction extends AutomatedServiceA
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionOpeningSoonEmails(session);
             try {
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                emailQueueService.enqueueStandard(emailsToBeSent);
                 session.setOpeningSoonEmailSent(true);
             } catch (Exception e) {
                 log.severe("Unexpected error", e);

--- a/src/main/java/teammates/ui/webapi/FeedbackSessionPublishedRemindersAction.java
+++ b/src/main/java/teammates/ui/webapi/FeedbackSessionPublishedRemindersAction.java
@@ -21,7 +21,7 @@ public class FeedbackSessionPublishedRemindersAction extends AutomatedServiceAct
             RequestTracer.checkRemainingTime();
             List<EmailWrapper> emailsToBeSent = emailGenerator.generateFeedbackSessionPublishedEmails(session);
             try {
-                taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+                emailQueueService.enqueueStandard(emailsToBeSent);
                 session.setPublishedEmailSent(true);
                 logic.adjustFeedbackSessionEmailStatusAfterUpdate(session);
             } catch (Exception e) {

--- a/src/main/java/teammates/ui/webapi/JoinCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/JoinCourseAction.java
@@ -46,6 +46,6 @@ public class JoinCourseAction extends LoggedInAction {
         Course course = logic.getCourse(courseId);
         EmailWrapper email = emailGenerator.generateUserCourseRegisteredEmail(
                 userName, userEmail, requestContext.getAccount().getGoogleId(), isInstructor, course);
-        emailSender.sendEmail(email);
+        emailQueueService.enqueuePriority(email);
     }
 }

--- a/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/PublishFeedbackSessionAction.java
@@ -45,7 +45,7 @@ public class PublishFeedbackSessionAction extends LoggedInAction {
         if (feedbackSession.isPublishedEmailEnabled()) {
             List<EmailWrapper> emailsToBeSent =
                     emailGenerator.generateFeedbackSessionPublishedEmails(feedbackSession);
-            taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+            emailQueueService.enqueueStandard(emailsToBeSent);
             feedbackSession.setPublishedEmailSent(true);
         }
     }

--- a/src/main/java/teammates/ui/webapi/RegenerateUserKeyAction.java
+++ b/src/main/java/teammates/ui/webapi/RegenerateUserKeyAction.java
@@ -6,7 +6,6 @@ import teammates.common.datatransfer.UserType;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.UserUpdateException;
 import teammates.common.util.Const;
-import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.User;
@@ -25,12 +24,8 @@ public class RegenerateUserKeyAction extends AdminOnlyAction {
             "User's key for this course has been successfully regenerated,";
 
     /** Message indicating that the key regeneration was successful, and corresponding email was sent. */
-    public static final String SUCCESSFUL_REGENERATION_WITH_EMAIL_SENT =
-            SUCCESSFUL_REGENERATION + " and the email has been sent.";
-
-    /** Message indicating that the key regeneration was successful, but corresponding email could not be sent. */
-    public static final String SUCCESSFUL_REGENERATION_BUT_EMAIL_FAILED =
-            SUCCESSFUL_REGENERATION + " but the email failed to send.";
+    public static final String SUCCESSFUL_REGENERATION_WITH_EMAIL_QUEUED =
+            SUCCESSFUL_REGENERATION + " and the email has been queued.";
 
     @Override
     public JsonResult execute() {
@@ -45,24 +40,20 @@ public class RegenerateUserKeyAction extends AdminOnlyAction {
             throw new UnexpectedServerException(ex);
         }
 
-        boolean emailSent = sendEmail(updatedUser);
-        String statusMessage = emailSent
-                ? SUCCESSFUL_REGENERATION_WITH_EMAIL_SENT
-                : SUCCESSFUL_REGENERATION_BUT_EMAIL_FAILED;
+        sendEmail(updatedUser);
+        String statusMessage = SUCCESSFUL_REGENERATION_WITH_EMAIL_QUEUED;
 
         return new JsonResult(new RegenerateKeyData(statusMessage, updatedUser.getRegKey()));
     }
 
     /**
-     * Sends the regenerated course join and feedback session links to the user.
-     * @return true if the email was sent successfully, and false otherwise.
+     * Queues the regenerated course join and feedback session links to the user.
      */
-    private boolean sendEmail(User user) {
+    private void sendEmail(User user) {
         EmailType emailType = user.getUserType() == UserType.STUDENT
                 ? EmailType.STUDENT_COURSE_LINKS_REGENERATED
                 : EmailType.INSTRUCTOR_COURSE_LINKS_REGENERATED;
         EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(user, emailType);
-        EmailSendingStatus status = emailSender.sendEmail(email);
-        return status.isSuccess();
+        emailQueueService.enqueuePriority(email);
     }
 }

--- a/src/main/java/teammates/ui/webapi/RegenerateUserKeyAction.java
+++ b/src/main/java/teammates/ui/webapi/RegenerateUserKeyAction.java
@@ -25,7 +25,7 @@ public class RegenerateUserKeyAction extends AdminOnlyAction {
 
     /** Message indicating that the key regeneration was successful, and corresponding email was sent. */
     public static final String SUCCESSFUL_REGENERATION_WITH_EMAIL_QUEUED =
-            SUCCESSFUL_REGENERATION + " and the email has been queued.";
+            SUCCESSFUL_REGENERATION + " and the email has been sent.";
 
     @Override
     public JsonResult execute() {

--- a/src/main/java/teammates/ui/webapi/RejectAccountVerificationRequestAction.java
+++ b/src/main/java/teammates/ui/webapi/RejectAccountVerificationRequestAction.java
@@ -49,7 +49,7 @@ public class RejectAccountVerificationRequestAction extends AdminOnlyAction {
                         accountVerificationRequest,
                         accountVerificationRequestRejectionRequest.getReasonTitle(),
                         accountVerificationRequestRejectionRequest.getReasonBody());
-                emailSender.sendEmail(email);
+                emailQueueService.enqueuePriority(email);
             }
         } catch (InvalidParametersException e) {
             throw new InvalidHttpRequestBodyException(e);

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionResultAction.java
@@ -76,7 +76,7 @@ public class RemindFeedbackSessionResultAction extends LoggedInAction {
                 feedbackSession, studentsToRemindList, instructorsToRemindList,
                 Collections.singletonList(instructorToNotify));
 
-        taskQueuer.scheduleEmailsForPrioritySending(emails);
+        emailQueueService.enqueuePriority(emails);
 
         return new JsonResult("Reminders sent");
     }

--- a/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/RemindFeedbackSessionSubmissionAction.java
@@ -76,7 +76,7 @@ public class RemindFeedbackSessionSubmissionAction extends LoggedInAction {
         List<EmailWrapper> emails = emailGenerator.generateFeedbackSessionReminderEmails(
                 feedbackSession, studentsToRemindList, instructorsToRemindList, instructorToNotify);
 
-        taskQueuer.scheduleEmailsForPrioritySending(emails);
+        emailQueueService.enqueuePriority(emails);
 
         return new JsonResult("Reminders sent");
     }

--- a/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
+++ b/src/main/java/teammates/ui/webapi/SendJoinReminderEmailAction.java
@@ -45,7 +45,7 @@ public class SendJoinReminderEmailAction extends LoggedInAction {
             EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
-            taskQueuer.scheduleEmailsForPrioritySending(emails);
+            emailQueueService.enqueuePriority(emails);
             statusMsg = new JsonResult("An email has been sent to " + student.getEmail());
 
         } else if (user instanceof Instructor instructorData) {
@@ -57,7 +57,7 @@ public class SendJoinReminderEmailAction extends LoggedInAction {
             EmailWrapper email = emailGenerator.generateInstructorCourseJoinEmail(inviter, instructorData, course);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
-            taskQueuer.scheduleEmailsForPrioritySending(emails);
+            emailQueueService.enqueuePriority(emails);
             statusMsg = new JsonResult("An email has been sent to " + instructorData.getEmail());
 
         } else {
@@ -68,7 +68,7 @@ public class SendJoinReminderEmailAction extends LoggedInAction {
                 EmailWrapper email = emailGenerator.generateStudentCourseJoinEmail(course, student);
                 emails.add(email);
             }
-            taskQueuer.scheduleEmailsForPrioritySending(emails);
+            emailQueueService.enqueuePriority(emails);
             statusMsg = new JsonResult("Emails have been sent to unregistered students.");
         }
 

--- a/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
+++ b/src/main/java/teammates/ui/webapi/SessionLinksRecoveryAction.java
@@ -35,7 +35,7 @@ public class SessionLinksRecoveryAction extends PublicAction {
                 ? emailGenerator.generateSessionLinksRecoveryEmailForNonExistentStudent(recoveryEmailAddress)
                 : emailGenerator.generateSessionLinksRecoveryEmailForExistingStudent(
                         recoveryEmailAddress, studentsForEmail);
-        taskQueuer.scheduleEmailsForPrioritySending(List.of(email));
+        emailQueueService.enqueuePriority(List.of(email));
 
         return new JsonResult(new SessionLinksRecoveryResponseData(
                     "The recovery links for your feedback sessions have been sent to the "

--- a/src/main/java/teammates/ui/webapi/UnlinkAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/UnlinkAccountAction.java
@@ -38,14 +38,14 @@ public class UnlinkAccountAction extends AdminOnlyAction {
                     .generateStudentCourseRejoinEmailAfterUnlinkAccount(course, existingStudent);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
-            taskQueuer.scheduleEmailsForPrioritySending(emails);
+            emailQueueService.enqueuePriority(emails);
         } else if (existingUser instanceof Instructor existingInstructor) {
             // Generate and queue rejoin email to priority queue
             EmailWrapper email = emailGenerator
                     .generateInstructorCourseRejoinEmailAfterUnlinkAccount(existingInstructor, course);
             List<EmailWrapper> emails = new ArrayList<>();
             emails.add(email);
-            taskQueuer.scheduleEmailsForPrioritySending(emails);
+            emailQueueService.enqueuePriority(emails);
         }
 
         return new JsonResult("Account unlinked successfully.");

--- a/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/UnpublishFeedbackSessionAction.java
@@ -46,7 +46,7 @@ public class UnpublishFeedbackSessionAction extends LoggedInAction {
         if (feedbackSession.isPublishedEmailEnabled()) {
             List<EmailWrapper> emailsToBeSent =
                     emailGenerator.generateFeedbackSessionUnpublishedEmails(feedbackSession);
-            taskQueuer.scheduleEmailsForSending(emailsToBeSent);
+            emailQueueService.enqueueStandard(emailsToBeSent);
         }
     }
 }

--- a/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateDeadlineExtensionsAction.java
@@ -72,6 +72,6 @@ public class UpdateDeadlineExtensionsAction extends LoggedInAction {
             emailsToSend.add(email);
         }
 
-        taskQueuer.scheduleEmailsForSending(emailsToSend);
+        emailQueueService.enqueueStandard(emailsToSend);
     }
 }

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -7,7 +7,6 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
-import teammates.common.util.EmailSendingStatus;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.storage.entity.Student;
@@ -28,14 +27,9 @@ public class UpdateStudentAction extends LoggedInAction {
     public static final String SUCCESSFUL_UPDATE = "Student has been updated";
     /**
      * Message indicating that the student information was successfully updated,
-     * and email was successfully sent to the student's new email address.
+     * and email was queued to the student's new email address.
      */
-    public static final String SUCCESSFUL_UPDATE_WITH_EMAIL = SUCCESSFUL_UPDATE + " and email sent";
-    /**
-     * Message indicating that the student information was successfully updated,
-     * but email failed to be sent to the student's new email address.
-     */
-    public static final String SUCCESSFUL_UPDATE_BUT_EMAIL_FAILED = SUCCESSFUL_UPDATE + " but email failed to send";
+    public static final String SUCCESSFUL_UPDATE_WITH_EMAIL = SUCCESSFUL_UPDATE + " and email queued";
     /**
      * Message indicating that the update operation failed because the requested new email address
      * for the student is already being used by another student in the system.
@@ -78,25 +72,20 @@ public class UpdateStudentAction extends LoggedInAction {
         }
 
         if (updateRequest.getIsSessionSummarySendEmail()) {
-            boolean emailSent = sendEmail(updatedStudent);
-            String statusMessage = emailSent ? SUCCESSFUL_UPDATE_WITH_EMAIL
-                    : SUCCESSFUL_UPDATE_BUT_EMAIL_FAILED;
-            return new JsonResult(statusMessage);
+            sendEmail(updatedStudent);
+            return new JsonResult(SUCCESSFUL_UPDATE_WITH_EMAIL);
         }
 
         return new JsonResult(SUCCESSFUL_UPDATE);
     }
 
     /**
-     * Sends the feedback session summary as an email.
-     *
-     * @return The true if email was sent successfully or false otherwise.
+     * Queues the feedback session summary email.
      */
-    private boolean sendEmail(Student student) {
+    private void sendEmail(Student student) {
         EmailWrapper email = emailGenerator.generateFeedbackSessionSummaryOfCourse(
                 student, EmailType.STUDENT_EMAIL_CHANGED);
-        EmailSendingStatus status = emailSender.sendEmail(email);
-        return status.isSuccess();
+        emailQueueService.enqueuePriority(email);
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/UpdateStudentAction.java
@@ -29,7 +29,7 @@ public class UpdateStudentAction extends LoggedInAction {
      * Message indicating that the student information was successfully updated,
      * and email was queued to the student's new email address.
      */
-    public static final String SUCCESSFUL_UPDATE_WITH_EMAIL = SUCCESSFUL_UPDATE + " and email queued";
+    public static final String SUCCESSFUL_UPDATE_WITH_EMAIL = SUCCESSFUL_UPDATE + " and email sent";
     /**
      * Message indicating that the update operation failed because the requested new email address
      * for the student is already being used by another student in the system.

--- a/src/test/java/teammates/ui/webapi/ApproveAccountVerificationRequestActionIT.java
+++ b/src/test/java/teammates/ui/webapi/ApproveAccountVerificationRequestActionIT.java
@@ -66,7 +66,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         assertEquals(accountVerificationRequest.getInstitute().getName(), data.getInstitute());
         assertEquals(AccountVerificationRequestStatus.APPROVED, data.getStatus());
         assertEquals(accountVerificationRequest.getComments(), data.getComments());
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsQueued(1);
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -84,7 +84,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         assertEquals(200, result.getStatusCode());
         AccountVerificationRequestData data = (AccountVerificationRequestData) result.getOutput();
         assertEquals(AccountVerificationRequestStatus.APPROVED, data.getStatus());
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsQueued(1);
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -108,7 +108,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         assertEquals(200, result.getStatusCode());
         AccountVerificationRequestData data = (AccountVerificationRequestData) result.getOutput();
         assertEquals(AccountVerificationRequestStatus.APPROVED, data.getStatus());
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsQueued(1);
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -128,7 +128,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         assertEquals(200, result.getStatusCode());
         AccountVerificationRequestData data = (AccountVerificationRequestData) result.getOutput();
         assertEquals(AccountVerificationRequestStatus.APPROVED, data.getStatus());
-        verifyNumberOfEmailsSent(1);
+        verifyNumberOfEmailsQueued(1);
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -136,7 +136,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         String[] params = new String[] {Const.ParamsNames.ACCOUNT_VERIFICATION_REQUEST_ID, "invalid"};
         InvalidHttpParameterException ihpe = verifyHttpParameterFailure(params);
         assertEquals("Expected UUID value for id parameter, but found: [invalid]", ihpe.getMessage());
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -145,7 +145,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         String[] params = new String[] {Const.ParamsNames.ACCOUNT_VERIFICATION_REQUEST_ID, uuid};
         EntityNotFoundException enfe = verifyEntityNotFound(params);
         assertEquals(String.format("Account verification request with id = %s not found", uuid), enfe.getMessage());
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -160,7 +160,7 @@ public class ApproveAccountVerificationRequestActionIT extends BaseActionIT<Appr
         InvalidOperationException ipe = verifyInvalidOperation(params);
         assertEquals("Account verification request with id " + accountVerificationRequest.getId()
                 + " is already approved.", ipe.getMessage());
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Override

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -34,6 +34,7 @@ import teammates.logic.api.MockRecaptchaVerifier;
 import teammates.logic.api.MockTaskQueuer;
 import teammates.logic.api.MockUserProvision;
 import teammates.logic.core.CoursesLogic;
+import teammates.logic.email.EmailQueueService;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Institute;
@@ -115,7 +116,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         try {
             @SuppressWarnings("unchecked")
             T action = (T) ActionFactory.getAction(req, getRequestMethod());
-            action.setTaskQueuer(mockTaskQueuer);
+            action.setEmailQueueService(EmailQueueService.withTaskQueuer(mockTaskQueuer));
             action.setEmailSender(mockEmailSender);
             mockUserProvision.setLogic(logic);
             action.setUserProvision(mockUserProvision);

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -27,6 +27,7 @@ import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.HibernateUtil;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.TaskWrapper;
 import teammates.logic.api.Logic;
 import teammates.logic.api.MockEmailSender;
 import teammates.logic.api.MockRecaptchaVerifier;
@@ -49,6 +50,7 @@ import teammates.ui.exception.InvalidHttpRequestBodyException;
 import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.request.BasicRequest;
+import teammates.ui.request.SendEmailRequest;
 
 /**
  * Base class for all action tests.
@@ -688,10 +690,36 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
     }
 
     /**
+     * Verifies that the executed action does not result in any email being queued.
+     */
+    protected void verifyNoEmailsQueued() {
+        assertTrue(getQueuedEmails().isEmpty());
+    }
+
+    /**
      * Returns the list of emails sent as part of the executed action.
      */
     protected List<EmailWrapper> getEmailsSent() {
         return mockEmailSender.getEmailsSent();
+    }
+
+    /**
+     * Returns the list of tasks added as part of the executed action.
+     */
+    protected List<TaskWrapper> getTasksAdded() {
+        return mockTaskQueuer.getTasksAdded();
+    }
+
+    /**
+     * Returns the list of emails queued as part of the executed action.
+     */
+    protected List<EmailWrapper> getQueuedEmails() {
+        List<EmailWrapper> queuedEmails = new ArrayList<>();
+        for (TaskWrapper task : getTasksAdded()) {
+            SendEmailRequest request = (SendEmailRequest) task.getRequestBody();
+            queuedEmails.add(request.getEmail());
+        }
+        return queuedEmails;
     }
 
     /**
@@ -700,6 +728,13 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      */
     protected void verifyNumberOfEmailsSent(int emailCount) {
         assertEquals(emailCount, mockEmailSender.getEmailsSent().size());
+    }
+
+    /**
+     * Verifies that the executed action results in the specified number of emails being queued.
+     */
+    protected void verifyNumberOfEmailsQueued(int emailCount) {
+        assertEquals(emailCount, getQueuedEmails().size());
     }
 
     // TODO: createXX methods should be deprecated and replaced with proper test data builders.

--- a/src/test/java/teammates/ui/webapi/BaseActionTest.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionTest.java
@@ -25,6 +25,7 @@ import teammates.common.util.StringHelper;
 import teammates.logic.api.MockEmailSender;
 import teammates.logic.api.MockRecaptchaVerifier;
 import teammates.logic.api.MockTaskQueuer;
+import teammates.logic.email.EmailQueueService;
 import teammates.test.BaseTestCaseWithDatabaseAccess;
 import teammates.ui.output.ApiOutput;
 import teammates.ui.request.BasicRequest;
@@ -58,7 +59,7 @@ public abstract class BaseActionTest<T extends Action, R extends ApiOutput> exte
             throw new RuntimeException("Failed to instantiate action class: " + actionClass.getName(), e);
         }
 
-        action.setTaskQueuer(mockTaskQueuer);
+        action.setEmailQueueService(EmailQueueService.withTaskQueuer(mockTaskQueuer));
         action.setEmailSender(mockEmailSender);
         action.setRecaptchaVerifier(mockRecaptchaVerifier);
         inTransaction(() -> action.init(request));

--- a/src/test/java/teammates/ui/webapi/CreateAccountVerificationRequestActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateAccountVerificationRequestActionIT.java
@@ -144,9 +144,9 @@ public class CreateAccountVerificationRequestActionIT extends BaseActionIT<Creat
         assertEquals(AccountVerificationRequestStatus.PENDING, accountVerificationRequest.getStatus());
         assertEquals("My road leads into the desert. I can see it.", accountVerificationRequest.getComments());
         assertNull(accountVerificationRequest.getCreatedDemoCourseAt());
-        verifyNumberOfEmailsSent(2);
-        EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(0);
-        EmailWrapper sentAcknowledgementEmail = mockEmailSender.getEmailsSent().get(1);
+        verifyNumberOfEmailsQueued(2);
+        EmailWrapper sentAdminAlertEmail = getQueuedEmails().get(0);
+        EmailWrapper sentAcknowledgementEmail = getQueuedEmails().get(1);
         assertEquals(EmailType.NEW_ACCOUNT_VERIFICATION_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
         assertEquals(EmailType.NEW_ACCOUNT_VERIFICATION_REQUEST_ACKNOWLEDGEMENT, sentAcknowledgementEmail.getType());
     }
@@ -175,9 +175,9 @@ public class CreateAccountVerificationRequestActionIT extends BaseActionIT<Creat
         assertEquals(AccountVerificationRequestStatus.PENDING, accountVerificationRequest.getStatus());
         assertNull(accountVerificationRequest.getComments());
         assertNull(accountVerificationRequest.getCreatedDemoCourseAt());
-        verifyNumberOfEmailsSent(2);
-        EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(0);
-        EmailWrapper sentAcknowledgementEmail = mockEmailSender.getEmailsSent().get(1);
+        verifyNumberOfEmailsQueued(2);
+        EmailWrapper sentAdminAlertEmail = getQueuedEmails().get(0);
+        EmailWrapper sentAcknowledgementEmail = getQueuedEmails().get(1);
         assertEquals(EmailType.NEW_ACCOUNT_VERIFICATION_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
         assertEquals(EmailType.NEW_ACCOUNT_VERIFICATION_REQUEST_ACKNOWLEDGEMENT, sentAcknowledgementEmail.getType());
     }
@@ -214,9 +214,9 @@ public class CreateAccountVerificationRequestActionIT extends BaseActionIT<Creat
         assertEquals(AccountVerificationRequestStatus.PENDING, accountVerificationRequest.getStatus());
         assertEquals("My road leads into the desert. I can see it.", accountVerificationRequest.getComments());
         assertNull(accountVerificationRequest.getCreatedDemoCourseAt());
-        verifyNumberOfEmailsSent(2);
-        EmailWrapper sentAdminAlertEmail = mockEmailSender.getEmailsSent().get(0);
-        EmailWrapper sentAcknowledgementEmail = mockEmailSender.getEmailsSent().get(1);
+        verifyNumberOfEmailsQueued(2);
+        EmailWrapper sentAdminAlertEmail = getQueuedEmails().get(0);
+        EmailWrapper sentAcknowledgementEmail = getQueuedEmails().get(1);
         assertEquals(EmailType.NEW_ACCOUNT_VERIFICATION_REQUEST_ADMIN_ALERT, sentAdminAlertEmail.getType());
         assertEquals(EmailType.NEW_ACCOUNT_VERIFICATION_REQUEST_ACKNOWLEDGEMENT, sentAcknowledgementEmail.getType());
     }

--- a/src/test/java/teammates/ui/webapi/JoinCourseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/JoinCourseActionIT.java
@@ -60,8 +60,8 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
         JoinCourseAction joinCourseAction = getAction(regKeyRequest);
         getJsonResult(joinCourseAction);
 
-        verifyNumberOfEmailsSent(1);
-        EmailWrapper email = mockEmailSender.getEmailsSent().get(0);
+        verifyNumberOfEmailsQueued(1);
+        EmailWrapper email = getQueuedEmails().get(0);
         assertEquals(
                 String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 4", "course-4"),
                 email.getSubject());
@@ -73,7 +73,7 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
         InvalidOperationException ioe = verifyInvalidOperation(regKeyRequest);
         assertEquals("User has already joined course", ioe.getMessage());
 
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
 
         ______TS("success: instructor joins course");
 
@@ -84,8 +84,8 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
         joinCourseAction = getAction(regKeyRequest);
         getJsonResult(joinCourseAction);
 
-        verifyNumberOfEmailsSent(1);
-        email = mockEmailSender.getEmailsSent().get(0);
+        verifyNumberOfEmailsQueued(1);
+        email = getQueuedEmails().get(0);
         assertEquals(
                 String.format(EmailType.USER_COURSE_REGISTER.getSubject(), "Typical Course 4", "course-4"),
                 email.getSubject());
@@ -97,7 +97,7 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
         ioe = verifyInvalidOperation(regKeyRequest);
         assertEquals("User has already joined course", ioe.getMessage());
 
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
 
         ______TS("failure: invalid regkey");
 
@@ -105,7 +105,7 @@ public class JoinCourseActionIT extends BaseActionIT<JoinCourseAction> {
 
         verifyEntityNotFound(regKeyRequest);
 
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Override

--- a/src/test/java/teammates/ui/webapi/RegenerateUserKeyActionIT.java
+++ b/src/test/java/teammates/ui/webapi/RegenerateUserKeyActionIT.java
@@ -104,10 +104,10 @@ public class RegenerateUserKeyActionIT extends BaseActionIT<RegenerateUserKeyAct
 
         RegenerateKeyData response = (RegenerateKeyData) actionOutput.getOutput();
 
-        assertEquals(RegenerateUserKeyAction.SUCCESSFUL_REGENERATION_WITH_EMAIL_SENT, response.getMessage());
+        assertEquals(RegenerateUserKeyAction.SUCCESSFUL_REGENERATION_WITH_EMAIL_QUEUED, response.getMessage());
         assertNotEquals(oldRegKey, response.getNewRegistrationKey());
 
-        EmailWrapper emailSent = mockEmailSender.getEmailsSent().get(mockEmailSender.getEmailsSent().size() - 1);
+        EmailWrapper emailSent = getQueuedEmails().get(getQueuedEmails().size() - 1);
         assertEquals(String.format(emailType.getSubject(), course.getName(), user.getCourseId()),
                 emailSent.getSubject());
         assertEquals(user.getEmail(), emailSent.getRecipient());

--- a/src/test/java/teammates/ui/webapi/RejectAccountVerificationRequestActionIT.java
+++ b/src/test/java/teammates/ui/webapi/RejectAccountVerificationRequestActionIT.java
@@ -96,8 +96,8 @@ public class RejectAccountVerificationRequestActionIT extends BaseActionIT<Rejec
         assertEquals(AccountVerificationRequestStatus.REJECTED, data.getStatus());
         assertEquals(accountVerificationRequest.getComments(), data.getComments());
 
-        verifyNumberOfEmailsSent(1);
-        EmailWrapper sentEmail = mockEmailSender.getEmailsSent().get(0);
+        verifyNumberOfEmailsQueued(1);
+        EmailWrapper sentEmail = getQueuedEmails().get(0);
         assertEquals(EmailType.ACCOUNT_VERIFICATION_REQUEST_REJECTION, sentEmail.getType());
         assertEquals(Config.SUPPORT_EMAIL, sentEmail.getBcc());
         assertEquals(accountVerificationRequest.getEmail(), sentEmail.getRecipient());
@@ -132,7 +132,7 @@ public class RejectAccountVerificationRequestActionIT extends BaseActionIT<Rejec
         assertEquals(AccountVerificationRequestStatus.REJECTED, data.getStatus());
         assertEquals(accountVerificationRequest.getComments(), data.getComments());
 
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -154,7 +154,7 @@ public class RejectAccountVerificationRequestActionIT extends BaseActionIT<Rejec
         InvalidHttpRequestBodyException ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
 
         assertEquals("Both reason body and title need to be null to reject silently", ihrbe.getMessage());
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Test(groups = GroupNames.INTEGRATION)
@@ -176,7 +176,7 @@ public class RejectAccountVerificationRequestActionIT extends BaseActionIT<Rejec
         InvalidHttpRequestBodyException ihrbe = verifyHttpRequestBodyFailure(requestBody, params);
 
         assertEquals("Both reason body and title need to be null to reject silently", ihrbe.getMessage());
-        verifyNoEmailsSent();
+        verifyNoEmailsQueued();
     }
 
     @Test(groups = GroupNames.INTEGRATION)

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
@@ -81,15 +81,15 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
         JsonResult actionOutput = getJsonResult(updateAction);
 
         MessageOutput msgOutput = (MessageOutput) actionOutput.getOutput();
-        assertEquals("Student has been updated and email sent", msgOutput.getMessage());
-        verifyNumberOfEmailsSent(1);
+        assertEquals("Student has been updated and email queued", msgOutput.getMessage());
+        verifyNumberOfEmailsQueued(1);
 
         Student updatedStudent = inTransaction(() -> logic.getStudent(student1.getId()));
         assertEquals(updatedStudent.getEmail(), newStudentEmail);
         assertEquals(updatedStudent.getTeamName(), newStudentTeam);
         assertEquals(updatedStudent.getComments(), newStudentComments);
 
-        EmailWrapper email = getEmailsSent().get(0);
+        EmailWrapper email = getQueuedEmails().get(0);
         String courseName = inTransaction(() -> logic.getCourse(student1.getCourseId()).getName());
         assertEquals(String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), courseName,
                 student1.getCourseId()), email.getSubject());
@@ -120,7 +120,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
         JsonResult outputToBeTrimmed = getJsonResult(actionToBeTrimmed);
 
         MessageOutput msgTrimmedOutput = (MessageOutput) outputToBeTrimmed.getOutput();
-        assertEquals("Student has been updated and email sent", msgTrimmedOutput.getMessage());
+        assertEquals("Student has been updated and email queued", msgTrimmedOutput.getMessage());
 
         resetStudent(student1.getId(), originalEmail, originalTeam, originalComments);
     }

--- a/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateStudentActionIT.java
@@ -81,7 +81,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
         JsonResult actionOutput = getJsonResult(updateAction);
 
         MessageOutput msgOutput = (MessageOutput) actionOutput.getOutput();
-        assertEquals("Student has been updated and email queued", msgOutput.getMessage());
+        assertEquals("Student has been updated and email sent", msgOutput.getMessage());
         verifyNumberOfEmailsQueued(1);
 
         Student updatedStudent = inTransaction(() -> logic.getStudent(student1.getId()));
@@ -120,7 +120,7 @@ public class UpdateStudentActionIT extends BaseActionIT<UpdateStudentAction> {
         JsonResult outputToBeTrimmed = getJsonResult(actionToBeTrimmed);
 
         MessageOutput msgTrimmedOutput = (MessageOutput) outputToBeTrimmed.getOutput();
-        assertEquals("Student has been updated and email queued", msgTrimmedOutput.getMessage());
+        assertEquals("Student has been updated and email sent", msgTrimmedOutput.getMessage());
 
         resetStudent(student1.getId(), originalEmail, originalTeam, originalComments);
     }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14020

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Introduces an EmailQueueService that wraps TaskQueuer. This service handles queueing of emails. A new package has been introduced for this, `logic.email`

Existing email sending is routed through this service. Emails that are sent directly are modified to use the priority queue instead.

The long term plan is to have email sending orchestrated in the logic layer. Allowing API layer to directly call EmailQueueService is temporary.

This is part of efforts to modernise the application as well as efforts to clean up email generation and sending.