### PR TITLE
[#14246] Rename login to sign in in UI components

### DIFF
--- a/src/main/resources/devServerLoginPage.html
+++ b/src/main/resources/devServerLoginPage.html
@@ -2,14 +2,14 @@
 <body>
 <form method="post" style="text-align: center; font: 13px sans-serif">
   <div style="width: 20em; margin: 1em auto; text-align: left; padding: 0 2em 1.25em 2em; background-color: #d6e9f8; border: 2px solid #67a7e3;">
-    <h3>Not logged in</h3>
+    <h3>Sign in</h3>
     <p style="padding: 0; margin: 0">
       <label for="email" style="width: 3em">Email:</label>
       <input type="text" name="email" id="email" value="app_admin@gmail.com">
     </p>
     <input type="hidden" name="continue" value="">
     <p style="margin-left: 3em;">
-      <input name="action" type="submit" value="Log In" id="btn-login">
+      <input name="action" type="submit" value="Sign in" id="btn-login">
     </p>
   </div>
 </form>

--- a/src/web/app/__snapshots__/user-join-page.component.spec.ts.snap
+++ b/src/web/app/__snapshots__/user-join-page.component.spec.ts.snap
@@ -27,13 +27,13 @@ exports[`UserJoinPageComponent > should snap if user is not logged in and has a 
         <h1
           class="mb-0 h3"
         >
-          Not logged in
+          Not signed in
         </h1>
       </div>
       <div
         class="card-body"
       >
-        You are not logged in. Please log in first.
+        You are not signed in. Please sign in first.
       </div>
     </div>
   </div>
@@ -181,13 +181,13 @@ exports[`UserJoinPageComponent > should snap with valid course join link that ha
         <h1
           class="mb-0 h3"
         >
-          Confirm your Google account
+          Confirm your account
         </h1>
       </div>
       <div
         class="card-body"
       >
-         You are currently logged in as 
+         You are currently signed in as 
         <strong
           id="user-id"
         >
@@ -195,7 +195,7 @@ exports[`UserJoinPageComponent > should snap with valid course join link that ha
         </strong>
         . 
         <br />
-        If this is not you, please log out and log in using your own Google account. 
+        If this is not you, please sign out and sign in using your own account. 
         <br />
         If this is you, please confirm below to complete your registration.
         <br />

--- a/src/web/app/components/account-verification-requests-table/admin-reject-with-reason-modal/admin-reject-with-reason-modal.component.ts
+++ b/src/web/app/components/account-verification-requests-table/admin-reject-with-reason-modal/admin-reject-with-reason-modal.component.ts
@@ -48,8 +48,8 @@ export class RejectWithReasonModalComponent implements OnInit {
     '<strong>Remedy:</strong> If you are a student but you still need an instructor account, ' +
     'please send your justification to {supportEmail}</p>\n\n' +
     '<p><strong>Reason:</strong> You already have an account for this email address and this institution.<br />' +
-    '<strong>Remedy:</strong> You can login to TEAMMATES using your existing account.</p>\n\n' +
-    '<p>If you are logged into multiple accounts, remember to logout from other accounts first, ' +
+    '<strong>Remedy:</strong> You can sign in to TEAMMATES using your existing account.</p>\n\n' +
+    '<p>If you are signed in to multiple accounts, remember to sign out from other accounts first, ' +
     "or use an incognito Browser window. Let us know (with a screenshot) if that doesn't work.</p>" +
     '<p>If you need further clarification or would like to appeal this decision, please ' +
     'feel free to contact us at {supportEmail}</p>' +

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -55,9 +55,7 @@
             </button>
             <div class="dropdown-menu-right" ngbDropdownMenu>
               <a class="dropdown-item" id="student-login-btn" tmRouterLink="/web/student/home">As Student</a>
-              <a class="dropdown-item" id="instructor-login-btn" tmRouterLink="/web/instructor/home"
-                >As Instructor</a
-              >
+              <a class="dropdown-item" id="instructor-login-btn" tmRouterLink="/web/instructor/home">As Instructor</a>
             </div>
           </li>
         } @else {

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -51,12 +51,12 @@
               tabindex="0"
               ngbDropdownToggle
             >
-              Login
+              Sign in
             </button>
             <div class="dropdown-menu-right" ngbDropdownMenu>
-              <a class="dropdown-item" id="student-login-btn" tmRouterLink="/web/student/home">Student Login</a>
+              <a class="dropdown-item" id="student-login-btn" tmRouterLink="/web/student/home">As Student</a>
               <a class="dropdown-item" id="instructor-login-btn" tmRouterLink="/web/instructor/home"
-                >Instructor Login</a
+                >As Instructor</a
               >
             </div>
           </li>
@@ -92,7 +92,7 @@
                 id="logout-btn"
                 style="cursor: pointer"
                 (click)="logout()"
-                >Log Out</a
+                >Sign out</a
               >
             </div>
           </li>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -186,14 +186,14 @@
     [hidden]="key && !showQuestion.includes(StudentsSectionQuestions.STUDENT_GOOGLE_ACCOUNT)"
     [id]="StudentsSectionQuestions.STUDENT_GOOGLE_ACCOUNT"
     [section]="Sections.students"
-    headerText="Is it compulsory for students to use Google accounts?"
+    headerText="Is it compulsory for students to link accounts?"
     [(isPanelExpanded)]="questionsToCollapsed[StudentsSectionQuestions.STUDENT_GOOGLE_ACCOUNT]"
   >
     <p>
-      Students can submit feedback and view results without having to log in to TEAMMATES, unless they choose to link
-      their Google account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and
-      results. However, the following non-essential features are available only to users who have joined a TEAMMATES
-      course using a Google account:
+      Students can submit feedback and view results without having to sign in to TEAMMATES, unless they choose to link
+      their account (optional). TEAMMATES will send students a unique URL to access their feedback sessions and results.
+      However, the following non-essential features are available only to users who have joined a TEAMMATES course using
+      an account:
     </p>
     <ol>
       <li>
@@ -209,15 +209,15 @@
     [hidden]="key && !showQuestion.includes(StudentsSectionQuestions.STUDENT_CHANGE_ID)"
     [id]="StudentsSectionQuestions.STUDENT_CHANGE_ID"
     [section]="Sections.students"
-    headerText="How do I change the Google ID associated with a student?"
+    headerText="How do I change the account associated with a student?"
     [(isPanelExpanded)]="questionsToCollapsed[StudentsSectionQuestions.STUDENT_CHANGE_ID]"
   >
     <p>
-      At the moment, there is no way for students to update their own (or instructors to update their students') Google
+      At the moment, there is no way for students to update their own (or instructors to update their students') account
       IDs.
       <br />
       Please ask the student to <a href="mailto:{{ supportEmail }}">contact us</a> for assistance changing his/her
-      Google ID.
+      account ID.
     </p>
   </tm-instructor-help-panel>
 </div>

--- a/src/web/app/pages-help/student-help-page/student-help-page.component.html
+++ b/src/web/app/pages-help/student-help-page/student-help-page.component.html
@@ -33,8 +33,8 @@
       These are the possible reasons:
       <ol>
         <li>
-          You used a different Google account to access TEAMMATES in the past. In that case, you need to use the same
-          Google account to access TEAMMATES again. Log out and re-log in using the other Google account.
+          You used a different account to access TEAMMATES in the past. In that case, you need to use the same account
+          to access TEAMMATES again. Sign out and sign in again using the other account.
         </li>
         <li>
           You changed the primary email from a non-Gmail address to a Gmail address recently. In that case, email

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -199,11 +199,11 @@ exports[`SessionResultPageComponent > should snap when session results failed to
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            sign in with an account
           </a>
            (recommended). 
         </div>
@@ -350,11 +350,11 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            sign in with an account
           </a>
            (recommended). 
         </div>
@@ -498,11 +498,11 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            sign in with an account
           </a>
            (recommended). 
         </div>
@@ -646,11 +646,11 @@ exports[`SessionResultPageComponent > should snap with session details and resul
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            sign in with an account
           </a>
            (recommended). 
         </div>
@@ -726,11 +726,11 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            sign in with an account
           </a>
            (recommended). 
         </div>
@@ -874,7 +874,7 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
         role="alert"
       >
         <div>
-           You are viewing feedback results as alice. If you wish to link your Google account (alice) with this user, 
+           You are viewing feedback results as alice. If you wish to link your account (alice) with this user, 
           <a
             href="#"
             id="join-course-btn"
@@ -1023,11 +1023,11 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
         role="alert"
       >
         <div>
-           You are viewing feedback results as alice. You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as alice. You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            sign in with an account
           </a>
            (recommended). 
         </div>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -37,9 +37,8 @@
       <div class="alert alert-primary" role="alert">
         @if (loggedInUser) {
           <div>
-            You are viewing feedback results as {{ personName }}. If you wish to link your Google account ({{
-              loggedInUser
-            }}) with this user,
+            You are viewing feedback results as {{ personName }}. If you wish to link your account ({{ loggedInUser }})
+            with this user,
             <a href="#" id="join-course-btn" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()"
               >click here</a
             >.
@@ -48,10 +47,8 @@
         @if (!loggedInUser) {
           <div>
             You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are
-            currently open and view results without logging in. To access other features you need to
-            <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()"
-              >log in using a Google account</a
-            >
+            currently open and view results without signing in. To access other features you need to
+            <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">sign in with an account</a>
             (recommended).
           </div>
         }

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -71,7 +71,7 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -244,7 +244,7 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -414,7 +414,7 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -817,7 +817,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -3897,7 +3897,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -7188,7 +7188,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -47,7 +47,7 @@
       </div>
     } @else {
       <div class="text-secondary">
-        <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">Log in here</a> (optional) to
+        <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">Sign in here</a> (optional) to
         link this submission to your account.
       </div>
     }

--- a/src/web/app/pages-static/features-page/features-page.component.html
+++ b/src/web/app/pages-static/features-page/features-page.component.html
@@ -105,10 +105,10 @@
     <img src="assets/images/feature-nosignuprequired.png" alt="No signup required for students" />
     <div>
       Students can submit responses and view published responses using the unique links TEAMMATES emails them, without
-      having to log in or sign up.
+      having to sign in or sign up.
       <br /><br />
-      If they log in to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one
-      page and access even more features such as setting up profiles.
+      If they sign in to TEAMMATES using their accounts (optional), they can access all TEAMMATES courses in one page
+      and access even more features such as setting up profiles.
     </div>
   </div>
 </section>

--- a/src/web/app/user-join-page.component.html
+++ b/src/web/app/user-join-page.component.html
@@ -2,9 +2,9 @@
   @if (!hasJoined && !userId && validUrl) {
     <div class="card bg-light mx-auto" style="max-width: 800px">
       <div class="card-header bg-warning">
-        <h1 class="mb-0 h3">Not logged in</h1>
+        <h1 class="mb-0 h3">Not signed in</h1>
       </div>
-      <div class="card-body">You are not logged in. Please log in first.</div>
+      <div class="card-body">You are not signed in. Please sign in first.</div>
     </div>
   }
   @if (userId && (!validUrl || hasJoined)) {
@@ -26,12 +26,12 @@
   @if (!hasJoined && userId && validUrl) {
     <div class="card bg-light mx-auto" style="max-width: 800px">
       <div class="card-header bg-primary text-white">
-        <h1 class="mb-0 h3">Confirm your Google account</h1>
+        <h1 class="mb-0 h3">Confirm your account</h1>
       </div>
       <div class="card-body">
-        You are currently logged in as <strong id="user-id">{{ userId }}</strong
-        >. <br />If this is not you, please log out and log in using your own Google account. <br />If this is you,
-        please confirm below to complete your registration.<br />
+        You are currently signed in as <strong id="user-id">{{ userId }}</strong
+        >. <br />If this is not you, please sign out and sign in using your own account. <br />If this is you, please
+        confirm below to complete your registration.<br />
         <div class="text-center" style="margin-top: 20px">
           <button id="btn-confirm" class="btn btn-success" (click)="joinCourse()">Register for course</button>
         </div>


### PR DESCRIPTION
Part of #14246

**Outline of Solution**
This PR only tackles the front-end components to use Sign in terminology instead of login. For the components modified, Google account also has been changed to a generic "account".

**Sign in dropdown**
<img width="169" height="138" alt="image" src="https://github.com/user-attachments/assets/8bd9f062-472c-40a5-a523-1defc2c21027" />

**Development server sign in**
<img width="353" height="170" alt="image" src="https://github.com/user-attachments/assets/dffaec54-f8eb-4317-87b8-c6270acfd073" />

**Sign out button**
<img width="218" height="220" alt="image" src="https://github.com/user-attachments/assets/c4a10465-d24f-4c1b-8ed1-0f4151b57a1c" />
