### PR TITLE
[#13918] Replace UserInfo email to accountEmail

### DIFF
--- a/src/main/java/teammates/common/datatransfer/UserInfo.java
+++ b/src/main/java/teammates/common/datatransfer/UserInfo.java
@@ -18,9 +18,9 @@ public class UserInfo {
     public UUID accountId;
 
     /**
-     * The user's email address.
+     * The user's account email address.
      */
-    public String email;
+    public String accountEmail;
 
     /**
      * Indicates whether the user has admin privilege.
@@ -42,10 +42,10 @@ public class UserInfo {
      */
     public boolean isMaintainer;
 
-    public UserInfo(String googleId, UUID accountId, String email) {
+    public UserInfo(String googleId, UUID accountId, String accountEmail) {
         this.id = googleId;
         this.accountId = accountId;
-        this.email = email;
+        this.accountEmail = accountEmail;
     }
 
     public String getId() {
@@ -56,8 +56,8 @@ public class UserInfo {
         return accountId;
     }
 
-    public String getEmail() {
-        return email;
+    public String getAccountEmail() {
+        return accountEmail;
     }
 
     public boolean getIsAdmin() {

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -335,7 +335,7 @@ describe('InstructorCoursesPageComponent', () => {
       user: {
         id: 'test-user',
         accountId: 'test-account-id',
-        email: 'test@test.com',
+        accountEmail: 'test@test.com',
         isAdmin: false,
         isInstructor: true,
         isStudent: false,

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -57,7 +57,7 @@ describe('SessionResultPageComponent', () => {
     masquerade: false,
     user: {
       id: 'user-id',
-      email: 'user@teammates.tmt',
+      accountEmail: 'user@teammates.tmt',
       isAdmin: false,
       isInstructor: true,
       isStudent: false,

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -472,7 +472,7 @@ describe('SessionSubmissionPageComponent', () => {
     user: {
       id: 'user-id',
       accountId: 'account-id',
-      email: 'user@teammates.tmt',
+      accountEmail: 'user@teammates.tmt',
       isAdmin: false,
       isInstructor: false,
       isStudent: true,

--- a/src/web/app/pages-static/request-page/request-page.component.html
+++ b/src/web/app/pages-static/request-page/request-page.component.html
@@ -51,7 +51,7 @@
         <hr />
         @if (authInfo()?.user; as user) {
           <div class="alert alert-success" role="alert">
-            Signed in as: <strong>{{ user.email }}</strong>
+            Signed in as: <strong>{{ user.accountEmail }}</strong>
           </div>
           <tm-instructor-request-form
             (requestSubmissionEvent)="onRequestSubmitted($event)"

--- a/src/web/app/pages-static/request-page/request-page.component.spec.ts
+++ b/src/web/app/pages-static/request-page/request-page.component.spec.ts
@@ -13,7 +13,7 @@ const loggedInAuthInfo: AuthInfo = {
   user: {
     id: 'test@example.com',
     accountId: 'acc1',
-    email: 'user@teammates.tmt',
+    accountEmail: 'user@teammates.tmt',
     isAdmin: false,
     isInstructor: false,
     isStudent: false,

--- a/src/web/app/user-join-page.component.spec.ts
+++ b/src/web/app/user-join-page.component.spec.ts
@@ -179,7 +179,7 @@ describe('UserJoinPageComponent', () => {
         loginUrl: '/login',
         user: {
           id: 'user',
-          email: 'user@teammates.tmt',
+          accountEmail: 'user@teammates.tmt',
           isAdmin: false,
           isInstructor: false,
           isStudent: false,
@@ -210,7 +210,7 @@ describe('UserJoinPageComponent', () => {
         loginUrl: '/login',
         user: {
           id: 'user',
-          email: 'user@teammates.tmt',
+          accountEmail: 'user@teammates.tmt',
           isAdmin: false,
           isInstructor: false,
           isStudent: false,

--- a/src/web/route-guards/role.guard.spec.ts
+++ b/src/web/route-guards/role.guard.spec.ts
@@ -22,7 +22,7 @@ const authInfoFor = (role: 'student' | 'instructor' | 'admin' | 'maintainer' | n
     user: {
       id: `test_${role}`,
       accountId: `acc_${role}`,
-      email: 'user@teammates.tmt',
+      accountEmail: 'user@teammates.tmt',
       isStudent: role === 'student',
       isInstructor: role === 'instructor',
       isAdmin: role === 'admin',

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -602,7 +602,7 @@ export interface User extends ApiOutput {
 export interface UserInfo {
   id: string;
   accountId: string;
-  email: string;
+  accountEmail: string;
   isAdmin: boolean;
   isInstructor: boolean;
   isStudent: boolean;


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Replace email in `UserInfo` as accountEmail for better clarity.