### PR TITLE
[#13918] Update session pages loggedInUser to accountEmail

### DIFF
--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`SessionResultPageComponent > should snap when previewing results 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -24,7 +25,6 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
   isPreviewHintExpanded="false"
   key=""
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail={[Function String]}
@@ -150,6 +150,7 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
 exports[`SessionResultPageComponent > should snap when session results failed to load 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -171,7 +172,6 @@ exports[`SessionResultPageComponent > should snap when session results failed to
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -199,11 +199,11 @@ exports[`SessionResultPageComponent > should snap when session results failed to
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            Sign in using an account
           </a>
            (recommended). 
         </div>
@@ -301,6 +301,7 @@ exports[`SessionResultPageComponent > should snap when session results failed to
 exports[`SessionResultPageComponent > should snap with an open feedback session with no questions 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -322,7 +323,6 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -350,11 +350,11 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            Sign in using an account
           </a>
            (recommended). 
         </div>
@@ -449,6 +449,7 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
 exports[`SessionResultPageComponent > should snap with default fields 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -470,7 +471,6 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -498,11 +498,11 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            Sign in using an account
           </a>
            (recommended). 
         </div>
@@ -597,6 +597,7 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
 exports[`SessionResultPageComponent > should snap with session details and results are loading 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -618,7 +619,6 @@ exports[`SessionResultPageComponent > should snap with session details and resul
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -646,11 +646,11 @@ exports[`SessionResultPageComponent > should snap with session details and resul
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            Sign in using an account
           </a>
            (recommended). 
         </div>
@@ -677,6 +677,7 @@ exports[`SessionResultPageComponent > should snap with session details and resul
 exports[`SessionResultPageComponent > should snap with session details loaded and results are loading 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -698,7 +699,6 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -726,11 +726,11 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
         role="alert"
       >
         <div>
-           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as . You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            Sign in using an account
           </a>
            (recommended). 
         </div>
@@ -825,6 +825,7 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
 exports[`SessionResultPageComponent > should snap with user that is logged in and using session link 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail={[Function String]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -846,7 +847,6 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser={[Function String]}
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -874,7 +874,7 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
         role="alert"
       >
         <div>
-           You are viewing feedback results as alice. If you wish to link your Google account (alice) with this user, 
+           You are viewing feedback results as alice. If you wish to link your account (alice@example.com) with this user, 
           <a
             href="#"
             id="join-course-btn"
@@ -974,6 +974,7 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
 exports[`SessionResultPageComponent > should snap with user that is not logged in and using session link 1`] = `
 <tm-session-result-page
   Intent={[Function Object]}
+  accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
   courseId=""
@@ -995,7 +996,6 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
   isPreviewHintExpanded="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   navigationService={[Function _NavigationService]}
   ngbModal={[Function NgbModal]}
   personEmail=""
@@ -1023,11 +1023,11 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
         role="alert"
       >
         <div>
-           You are viewing feedback results as alice. You may submit feedback for sessions that are currently open and view results without logging in. To access other features you need to 
+           You are viewing feedback results as alice. You may submit feedback for sessions that are currently open and view results without signing in. To access other features you need to 
           <a
             href="#"
           >
-            log in using a Google account
+            Sign in using an account
           </a>
            (recommended). 
         </div>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -35,22 +35,22 @@
   <div class="row">
     <div class="col-12">
       <div class="alert alert-primary" role="alert">
-        @if (loggedInUser) {
+        @if (accountEmail) {
           <div>
-            You are viewing feedback results as {{ personName }}. If you wish to link your Google account ({{
-              loggedInUser
+            You are viewing feedback results as {{ personName }}. If you wish to link your account ({{
+              accountEmail
             }}) with this user,
             <a href="#" id="join-course-btn" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()"
               >click here</a
             >.
           </div>
         }
-        @if (!loggedInUser) {
+        @if (!accountEmail) {
           <div>
             You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are
-            currently open and view results without logging in. To access other features you need to
+            currently open and view results without signing in. To access other features you need to
             <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()"
-              >log in using a Google account</a
+              >Sign in using an account</a
             >
             (recommended).
           </div>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -37,15 +37,13 @@
       <div class="alert alert-primary" role="alert">
         @if (accountEmail) {
           <div>
-            You are viewing feedback results as {{ personName }}. If you wish to link your account ({{
-              accountEmail
-            }}) with this user,
+            You are viewing feedback results as {{ personName }}. If you wish to link your account ({{ accountEmail }})
+            with this user,
             <a href="#" id="join-course-btn" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()"
               >click here</a
             >.
           </div>
-        }
-        @if (!accountEmail) {
+        } @else {
           <div>
             You are viewing feedback results as {{ personName }}. You may submit feedback for sessions that are
             currently open and view results without signing in. To access other features you need to

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -57,7 +57,7 @@ describe('SessionResultPageComponent', () => {
     masquerade: false,
     user: {
       id: 'user-id',
-      accountEmail: 'user@teammates.tmt',
+      accountEmail: 'account@teammates.tmt',
       isAdmin: false,
       isInstructor: true,
       isStudent: false,
@@ -165,7 +165,7 @@ describe('SessionResultPageComponent', () => {
 
   it('should snap with user that is logged in and using session link', () => {
     component.key = 'session-link-key';
-    component.loggedInUser = 'alice';
+    component.accountEmail = 'alice@example.com';
     component.personName = 'alice';
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
@@ -173,7 +173,7 @@ describe('SessionResultPageComponent', () => {
 
   it('should snap with user that is not logged in and using session link', () => {
     component.key = 'session-link-key';
-    component.loggedInUser = '';
+    component.accountEmail = '';
     component.personName = 'alice';
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
@@ -221,7 +221,7 @@ describe('SessionResultPageComponent', () => {
 
     expect(component.feedbackSessionId).toEqual('test-session-id');
     expect(component.key).toEqual('reg-key');
-    expect(component.loggedInUser).toEqual('user-id');
+    expect(component.accountEmail).toEqual('account@teammates.tmt');
   });
 
   it('should verify allowed access and used reg key', () => {
@@ -287,10 +287,10 @@ describe('SessionResultPageComponent', () => {
     expect(navSpy).toHaveBeenCalledTimes(1);
     expect(navSpy).toHaveBeenLastCalledWith(
       '/web/front',
-      `You are trying to access TEAMMATES using the Google account user-id, which
-                        is not linked to this TEAMMATES account. If you used a different Google account to
-                        join/access TEAMMATES before, please use that Google account to access TEAMMATES. If you
-                        cannot remember which Google account you used before, please email us at
+      `You are trying to access TEAMMATES using the account ${component.accountEmail}, which
+                        is not linked to this TEAMMATES account. If you used a different account to
+                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
+                        cannot remember which account you used before, please email us at
                         ${environment.supportEmail} for help.`,
     );
   });
@@ -328,7 +328,7 @@ describe('SessionResultPageComponent', () => {
 
   it('should navigate to join course when user click on join course link', () => {
     component.key = 'reg-key';
-    component.loggedInUser = 'user';
+    component.accountEmail = 'account@example.com';
     const navSpy = vi.spyOn(navService, 'navigateByURL').mockResolvedValue(true);
 
     fixture.detectChanges();

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -287,11 +287,7 @@ describe('SessionResultPageComponent', () => {
     expect(navSpy).toHaveBeenCalledTimes(1);
     expect(navSpy).toHaveBeenLastCalledWith(
       '/web/front',
-      `You are trying to access TEAMMATES using the account ${component.accountEmail}, which
-                        is not linked to this TEAMMATES account. If you used a different account to
-                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
-                        cannot remember which account you used before, please email us at
-                        ${environment.supportEmail} for help.`,
+      `You are signed in as ${component.accountEmail}, but this course is linked to a different TEAMMATES account. If you used a different account to join/access TEAMMATES before, please use that account to access TEAMMATES. If you cannot remember which account you used before, please email us at ${environment.supportEmail} for help.`,
     );
   });
 

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -138,7 +138,7 @@ export class SessionResultPageComponent implements OnInit {
             next: (resp: RegkeyValidity) => {
               if (resp.isAllowedAccess) {
                 if (resp.isUsed) {
-                  // The logged in user matches the registration key; redirect to the logged in URL
+                  // The signed in user matches the registration key; redirect to the signed in URL
 
                   this.navigationService.navigateByURL(
                     `/web/${this.entityType}/sessions/${this.feedbackSessionId}/result`,
@@ -150,14 +150,10 @@ export class SessionResultPageComponent implements OnInit {
               } else if (resp.isValid) {
                 // At this point, registration key must already be used, otherwise access would be granted
                 if (this.accountEmail) {
-                  // Registration key belongs to another user who is not the logged in user
+                  // Registration key belongs to another user who is not the signed in user
                   this.navigationService.navigateWithErrorMessage(
                     '/web/front',
-                    `You are trying to access TEAMMATES using the account ${this.accountEmail}, which
-                        is not linked to this TEAMMATES account. If you used a different account to
-                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
-                        cannot remember which account you used before, please email us at
-                        ${environment.supportEmail} for help.`,
+                    `You are signed in as ${this.accountEmail}, but this course is linked to a different TEAMMATES account. If you used a different account to join/access TEAMMATES before, please use that account to access TEAMMATES. If you cannot remember which account you used before, please email us at ${environment.supportEmail} for help.`,
                   );
                 } else {
                   // There is no logged in user for a valid, used registration key, redirect to login page
@@ -179,7 +175,7 @@ export class SessionResultPageComponent implements OnInit {
             },
           });
         } else if (this.accountEmail) {
-          // Load information based on logged in user
+          // Load information based on signed in user
           // This will also cover preview cases
           this.loadFeedbackSession();
         } else {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -92,7 +92,7 @@ export class SessionResultPageComponent implements OnInit {
   @Input() key = '';
   @Input() previewAs = '';
   @Input() entityType = 'student';
-  loggedInUser = '';
+  accountEmail = '';
   visibilityRecipient: FeedbackVisibilityType = FeedbackVisibilityType.RECIPIENT;
 
   isPreviewHintExpanded = false;
@@ -126,7 +126,7 @@ export class SessionResultPageComponent implements OnInit {
       next: (auth: AuthInfo) => {
         const isPreview = !!(auth.user && this.previewAs);
         if (auth.user) {
-          this.loggedInUser = auth.user.id;
+          this.accountEmail = auth.user.accountEmail;
         }
         // prevent having both key and previewas parameters in URL
         if (this.key && isPreview) {
@@ -149,14 +149,14 @@ export class SessionResultPageComponent implements OnInit {
                 }
               } else if (resp.isValid) {
                 // At this point, registration key must already be used, otherwise access would be granted
-                if (this.loggedInUser) {
+                if (this.accountEmail) {
                   // Registration key belongs to another user who is not the logged in user
                   this.navigationService.navigateWithErrorMessage(
                     '/web/front',
-                    `You are trying to access TEAMMATES using the Google account ${this.loggedInUser}, which
-                        is not linked to this TEAMMATES account. If you used a different Google account to
-                        join/access TEAMMATES before, please use that Google account to access TEAMMATES. If you
-                        cannot remember which Google account you used before, please email us at
+                    `You are trying to access TEAMMATES using the account ${this.accountEmail}, which
+                        is not linked to this TEAMMATES account. If you used a different account to
+                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
+                        cannot remember which account you used before, please email us at
                         ${environment.supportEmail} for help.`,
                   );
                 } else {
@@ -178,7 +178,7 @@ export class SessionResultPageComponent implements OnInit {
               );
             },
           });
-        } else if (this.loggedInUser) {
+        } else if (this.accountEmail) {
           // Load information based on logged in user
           // This will also cover preview cases
           this.loadFeedbackSession();

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -34,7 +35,6 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -71,7 +71,7 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -178,6 +178,7 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -207,7 +208,6 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -244,7 +244,7 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -348,6 +348,7 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -377,7 +378,6 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -414,7 +414,7 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -518,6 +518,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail={[Function String]}
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -547,7 +548,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser={[Function String]}
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -586,7 +586,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
       <a
         href="#"
       >
-        logged-in-user
+        account@example.com
       </a>
       . 
     </div>
@@ -751,6 +751,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -780,7 +781,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -817,7 +817,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -3831,6 +3831,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -3860,7 +3861,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   isSubmissionFormsDisabled={[Function Boolean]}
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -3897,7 +3897,7 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>
@@ -6949,6 +6949,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail={[Function String]}
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -6978,7 +6979,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser={[Function String]}
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -7017,7 +7017,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
       <a
         href="#"
       >
-        alice
+        alice@example.com
       </a>
       . 
     </div>
@@ -7121,6 +7121,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
+  accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -7150,7 +7151,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   isSubmissionFormsDisabled="false"
   key={[Function String]}
   logService={[Function _LogService]}
-  loggedInUser=""
   moderatedPerson=""
   moderatedQuestionId=""
   navigationService={[Function _NavigationService]}
@@ -7188,7 +7188,7 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
       <a
         href="#"
       >
-        Log in here
+        Sign in here
       </a>
        (optional) to link this submission to your account. 
     </div>

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -39,15 +39,15 @@
     >.
   </div>
   @if (key) {
-    @if (loggedInUser) {
+    @if (accountEmail) {
       <div class="text-secondary">
         Link this submission to your account:
-        <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">{{ loggedInUser }}</a
+        <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">{{ accountEmail }}</a
         >.
       </div>
     } @else {
       <div class="text-secondary">
-        <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">Log in here</a> (optional) to
+        <a href="#" (click)="joinCourseForUnregisteredEntity(); $event.preventDefault()">Sign in here</a> (optional) to
         link this submission to your account.
       </div>
     }

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -703,11 +703,7 @@ describe('SessionSubmissionPageComponent', () => {
     expect(navSpy).toHaveBeenCalledTimes(1);
     expect(navSpy).toHaveBeenLastCalledWith(
       '/web/front',
-      `You are trying to access TEAMMATES using the account ${component.accountEmail}, which
-                        is not linked to this TEAMMATES account. If you used a different account to
-                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
-                        cannot remember which account you used before, please email us at
-                        ${environment.supportEmail} for help.`,
+      `You are signed in as ${component.accountEmail}, but this course is linked to a different TEAMMATES account. If you used a different account to join/access TEAMMATES before, please use that account to access TEAMMATES. If you cannot remember which account you used before, please email us at ${environment.supportEmail} for help.`,
     );
   });
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -593,7 +593,7 @@ describe('SessionSubmissionPageComponent', () => {
 
   it('should snap with user that is logged in and using session link', () => {
     component.key = 'reg-key';
-    component.loggedInUser = 'alice';
+    component.accountEmail = 'alice@example.com';
     component.personName = 'alice';
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
@@ -601,7 +601,7 @@ describe('SessionSubmissionPageComponent', () => {
 
   it('should snap with user that is not logged in and using session link', () => {
     component.key = 'reg-key';
-    component.loggedInUser = '';
+    component.accountEmail = '';
     component.personName = 'alice';
     fixture.detectChanges();
     expect(fixture).toMatchSnapshot();
@@ -611,7 +611,7 @@ describe('SessionSubmissionPageComponent', () => {
     component.courseId = 'test.exa-demo';
     component.feedbackSessionName = 'First team feedback session';
     component.key = 'reg-key';
-    component.loggedInUser = 'logged-in-user';
+    component.accountEmail = 'account@example.com';
     component.personName = 'person name';
     component.personEmail = 'person@email.com';
     component.courseName = 'Course name';
@@ -669,7 +669,7 @@ describe('SessionSubmissionPageComponent', () => {
     expect(component.intent).toEqual(Intent.STUDENT_SUBMISSION);
     expect(component.feedbackSessionId).toEqual(testQueryParams.fsid);
     expect(component.key).toEqual(testQueryParams.key);
-    expect(component.loggedInUser).toEqual(testInfo.user?.id);
+    expect(component.accountEmail).toEqual(testInfo.user?.accountEmail);
   });
 
   it('should verify allowed access with used reg key', () => {
@@ -703,10 +703,10 @@ describe('SessionSubmissionPageComponent', () => {
     expect(navSpy).toHaveBeenCalledTimes(1);
     expect(navSpy).toHaveBeenLastCalledWith(
       '/web/front',
-      `You are trying to access TEAMMATES using the Google account user-id, which
-                        is not linked to this TEAMMATES account. If you used a different Google account to
-                        join/access TEAMMATES before, please use that Google account to access TEAMMATES. If you
-                        cannot remember which Google account you used before, please email us at
+      `You are trying to access TEAMMATES using the account ${component.accountEmail}, which
+                        is not linked to this TEAMMATES account. If you used a different account to
+                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
+                        cannot remember which account you used before, please email us at
                         ${environment.supportEmail} for help.`,
     );
   });

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -181,7 +181,7 @@ export class SessionSubmissionPageComponent implements OnInit {
             next: (resp: RegkeyValidity) => {
               if (resp.isAllowedAccess) {
                 if (resp.isUsed) {
-                  // The logged in user matches the registration key; redirect to the logged in URL
+                  // The signed in user matches the registration key; redirect to the signed in URL
                   this.navigationService.navigateByURL(
                     `/web/${this.entityType}/sessions/${this.feedbackSessionId}/submission`,
                   );
@@ -192,14 +192,10 @@ export class SessionSubmissionPageComponent implements OnInit {
               } else if (resp.isValid) {
                 // At this point, registration key must already be used, otherwise access would be granted
                 if (this.accountEmail) {
-                  // Registration key belongs to another user who is not the logged in user
+                  // Registration key belongs to another user who is not the signed in user
                   this.navigationService.navigateWithErrorMessage(
                     '/web/front',
-                    `You are trying to access TEAMMATES using the account ${this.accountEmail}, which
-                        is not linked to this TEAMMATES account. If you used a different account to
-                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
-                        cannot remember which account you used before, please email us at
-                        ${environment.supportEmail} for help.`,
+                    `You are signed in as ${this.accountEmail}, but this course is linked to a different TEAMMATES account. If you used a different account to join/access TEAMMATES before, please use that account to access TEAMMATES. If you cannot remember which account you used before, please email us at ${environment.supportEmail} for help.`,
                   );
                 } else {
                   this.loadFeedbackSession(true, auth);
@@ -220,7 +216,7 @@ export class SessionSubmissionPageComponent implements OnInit {
             },
           });
         } else if (this.accountEmail) {
-          // Load information based on logged in user
+          // Load information based on signed in user
           // This will also cover moderation/preview cases
           this.loadFeedbackSession(false, auth);
         } else {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -109,7 +109,7 @@ export class SessionSubmissionPageComponent implements OnInit {
 
   courseId = '';
   feedbackSessionName = '';
-  loggedInUser = '';
+  accountEmail = '';
 
   // the name of the person involved
   // (e.g. the student name for unregistered student, the name of instructor being moderated)
@@ -174,7 +174,7 @@ export class SessionSubmissionPageComponent implements OnInit {
       next: (auth: AuthInfo) => {
         const isPreviewOrModeration = !!(auth.user && (this.moderatedPerson || this.previewAs));
         if (auth.user) {
-          this.loggedInUser = auth.user.id;
+          this.accountEmail = auth.user.accountEmail;
         }
         if (this.key && !isPreviewOrModeration) {
           this.authService.getAuthRegkeyValidity(this.key, this.intent).subscribe({
@@ -191,14 +191,14 @@ export class SessionSubmissionPageComponent implements OnInit {
                 }
               } else if (resp.isValid) {
                 // At this point, registration key must already be used, otherwise access would be granted
-                if (this.loggedInUser) {
+                if (this.accountEmail) {
                   // Registration key belongs to another user who is not the logged in user
                   this.navigationService.navigateWithErrorMessage(
                     '/web/front',
-                    `You are trying to access TEAMMATES using the Google account ${this.loggedInUser}, which
-                        is not linked to this TEAMMATES account. If you used a different Google account to
-                        join/access TEAMMATES before, please use that Google account to access TEAMMATES. If you
-                        cannot remember which Google account you used before, please email us at
+                    `You are trying to access TEAMMATES using the account ${this.accountEmail}, which
+                        is not linked to this TEAMMATES account. If you used a different account to
+                        join/access TEAMMATES before, please use that account to access TEAMMATES. If you
+                        cannot remember which account you used before, please email us at
                         ${environment.supportEmail} for help.`,
                   );
                 } else {
@@ -219,7 +219,7 @@ export class SessionSubmissionPageComponent implements OnInit {
               );
             },
           });
-        } else if (this.loggedInUser) {
+        } else if (this.accountEmail) {
           // Load information based on logged in user
           // This will also cover moderation/preview cases
           this.loadFeedbackSession(false, auth);
@@ -404,7 +404,7 @@ export class SessionSubmissionPageComponent implements OnInit {
               {
                 onClosed: () =>
                   this.navigationService.navigateByURL(
-                    this.loggedInUser ? `/web/${this.entityType}/home` : '/web/front/home',
+                    this.accountEmail ? `/web/${this.entityType}/home` : '/web/front/home',
                   ),
               },
               { backdrop: 'static' },
@@ -421,7 +421,7 @@ export class SessionSubmissionPageComponent implements OnInit {
                 {
                   onClosed: () =>
                     this.navigationService.navigateByURL(
-                      this.loggedInUser ? `/web/${this.entityType}/home` : '/web/front/home',
+                      this.accountEmail ? `/web/${this.entityType}/home` : '/web/front/home',
                     ),
                 },
                 { backdrop: 'static' },


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Replace loggedInUser in session pages with accountEmail.

**Error Pop Up for RegKey belongs to another account**
<img width="1005" height="145" alt="image" src="https://github.com/user-attachments/assets/05b8d883-ff2a-4a4a-98d8-78d7b81c4615" />

