### PR TITLE
[#13918] Refactor loginAsStudent to decouple from googleId

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AdminSearchPage.java
@@ -172,7 +172,7 @@ public class AdminSearchPage extends AppPage {
         for (WebElement row : rows) {
             List<WebElement> columns = row.findElements(By.tagName("td"));
             if (columns.size() >= 3 && (removeSpanFromText(columns.get(2)
-                    .getAttribute("innerHTML")).contains(instructor.getGoogleId())
+                    .getAttribute("innerHTML")).contains(instructor.getEmail())
                     || removeSpanFromText(columns.get(1)
                     .getAttribute("innerHTML")).contains(instructor.getName()))) {
                 return row;

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -200,9 +200,10 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * Logs in the user to the test environment as a student
      * (without admin rights or instructor rights).
      */
-    protected void loginAsStudent(String userId) {
+    protected void loginAsStudent(Student student) {
+        String studentEmail = student.getAccount().getEmail();
         inTransaction(() -> {
-            Account account = ensureAccountExists(userId);
+            Account account = ensureAccountExists(studentEmail);
             mockUserProvision.loginUser(account);
             mockUserProvision.setLogic(logic);
         });
@@ -347,7 +348,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         ______TS("Students cannot access");
         Student student = createTypicalStudent(course, "inaccessibleforstudents@teammates.tmt");
 
-        loginAsStudent(student.getAccount().getGoogleId());
+        loginAsStudent(student);
         verifyCannotAccess(params);
 
     }
@@ -465,7 +466,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
     void verifyAccessibleForStudentsOfTheSameCourse(Course course, String[] submissionParams) {
         ______TS("course students can access");
         Student student = createTypicalStudent(course, "accessibleforstudentsofthesamecourse@teammates.tmt");
-        loginAsStudent(student.getAccount().getGoogleId());
+        loginAsStudent(student);
         verifyCanAccess(submissionParams);
     }
 
@@ -476,7 +477,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
                 "inaccessibleforstudentsofothercourse-other@teammates.tmt");
         assert !course.getId().equals(courseOther.getId());
 
-        loginAsStudent(otherStudent.getAccount().getGoogleId());
+        loginAsStudent(otherStudent);
         verifyCannotAccess(submissionParams);
     }
 

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -202,8 +202,9 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      */
     protected void loginAsStudent(Student student) {
         String studentEmail = student.getAccount().getEmail();
+        String subject = student.getAccount().getSubject();
         inTransaction(() -> {
-            Account account = ensureAccountExists(studentEmail);
+            Account account = ensureAccountExists(subject, studentEmail);
             mockUserProvision.loginUser(account);
             mockUserProvision.setLogic(logic);
         });
@@ -234,7 +235,10 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
 
     private Account ensureAccountExists(String userId) {
         String email = userId.contains("@") ? userId : userId + "@example.com";
-        String subject = userId;
+        return ensureAccountExists(userId, email);
+    }
+
+    private Account ensureAccountExists(String subject, String email) {
         return logic.createOrGetAccount(Provider.TEAMMATES_DEV, subject, null, email);
     }
 

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackSessionLogActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackSessionLogActionIT.java
@@ -50,7 +50,7 @@ public class CreateFeedbackSessionLogActionIT extends BaseActionIT<CreateFeedbac
         Student student1 = typicalBundle.students.get("student1InCourse1");
         Student student2 = typicalBundle.students.get("student2InCourse1");
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1);
 
         ______TS("Failure case: not enough parameters");
         verifyHttpParameterFailure();
@@ -84,7 +84,7 @@ public class CreateFeedbackSessionLogActionIT extends BaseActionIT<CreateFeedbac
         assertEquals(FeedbackSessionLogType.ACCESS, persistedAccessLogs.get(0).getFeedbackSessionLogType());
 
         ______TS("Success case: typical submission");
-        loginAsStudent(student2.getAccount().getGoogleId());
+        loginAsStudent(student2);
 
         String[] paramsSuccessfulSubmission = {
                 Const.ParamsNames.FEEDBACK_SESSION_LOG_TYPE, FeedbackSessionLogType.SUBMISSION.name(),
@@ -126,7 +126,7 @@ public class CreateFeedbackSessionLogActionIT extends BaseActionIT<CreateFeedbac
                 Const.ParamsNames.FEEDBACK_SESSION_ID, fs1.getId().toString(),
         };
 
-        loginAsStudent(student1.getAccount().getGoogleId());
+        loginAsStudent(student1);
         verifyCanAccess(params);
 
         params = new String[] {

--- a/src/test/java/teammates/ui/webapi/GetCourseSessionResultsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetCourseSessionResultsActionIT.java
@@ -68,7 +68,7 @@ public class GetCourseSessionResultsActionIT extends BaseActionIT<GetCourseSessi
         verifyAccessibleForInstructorsOfTheSameCourse(course, params);
         verifyInaccessibleForInstructorsOfOtherCourses(course, params);
 
-        loginAsStudent(typicalBundle.students.get("student1InCourse1").getGoogleId());
+        loginAsStudent(typicalBundle.students.get("student1InCourse1"));
         verifyCannotAccess(params);
 
         verifyInaccessibleForStudentsOfOtherCourse(course, params);

--- a/src/test/java/teammates/ui/webapi/GetInstructorsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetInstructorsActionIT.java
@@ -111,7 +111,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     @Test(groups = GroupNames.INTEGRATION)
     public void courseNotFound_loggedInAsStudent_intentUndefined() {
         Student student = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "does-not-exist-id",
@@ -176,7 +176,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     @Test(groups = GroupNames.INTEGRATION)
     public void student_intentUndefined_canAccessOwnCourse() {
         Student student = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, student.getCourseId(),
@@ -192,7 +192,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
 
         assertNotEquals(otherStudent.getCourse(), student.getCourse());
 
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, otherStudent.getCourseId(),

--- a/src/test/java/teammates/ui/webapi/GetRegKeyValidityActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetRegKeyValidityActionIT.java
@@ -93,7 +93,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
 
         ______TS("Normal case: Correct logged in user for a used regkey; should be valid/used/allowed");
 
-        loginAsStudent(student1.getGoogleId());
+        loginAsStudent(student1);
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, student1Key,

--- a/src/test/java/teammates/ui/webapi/GetSessionSubmissionDataActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetSessionSubmissionDataActionIT.java
@@ -54,7 +54,7 @@ public class GetSessionSubmissionDataActionIT extends BaseActionIT<GetSessionSub
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
         ______TS("Student submission data contains questions, recipients, and responses");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
         GetSessionSubmissionDataAction action = getAction(buildParams(session, Intent.STUDENT_SUBMISSION));
         SessionSubmissionData output = getOutput(action);
 

--- a/src/test/java/teammates/ui/webapi/GetStudentsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentsActionIT.java
@@ -66,7 +66,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
         assertEquals(student.getCourseId(), firstStudentInStudents.getCourseId());
 
         logoutUser();
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
 
         ______TS("Typical Success Case with course id and team id, logged in as student");
         params = new String[] {
@@ -113,7 +113,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
                 Const.ParamsNames.TEAM_ID, student.getTeamId().toString(),
         };
 
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
 
         verifyCanAccess(params);
 

--- a/src/test/java/teammates/ui/webapi/GetUserSessionResultsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetUserSessionResultsActionIT.java
@@ -63,7 +63,7 @@ public class GetUserSessionResultsActionIT extends BaseActionIT<GetUserSessionRe
         assertTrue(isSessionResultsDataEqual(expectedResults, output));
 
         Student student = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
 
         params = new String[] {
                 Const.ParamsNames.FEEDBACK_SESSION_ID, accessibleFeedbackSession.getId().toString(),
@@ -102,7 +102,7 @@ public class GetUserSessionResultsActionIT extends BaseActionIT<GetUserSessionRe
                 Const.ParamsNames.INTENT, Intent.STUDENT_RESULT.name(),
         };
         Student student1InCourse1 = typicalBundle.students.get("student1InCourse1");
-        loginAsStudent(student1InCourse1.getGoogleId());
+        loginAsStudent(student1InCourse1);
         verifyCannotAccess(params);
 
         ______TS("Accessible for authenticated instructor when published");

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -88,7 +88,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private Student loginStudent(String studentId) {
         Student student = getStudent(studentId);
-        loginAsStudent(student.getGoogleId());
+        loginAsStudent(student);
         return student;
     }
 


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Pass in student for loginAsStudent.
* Extract the student account email and subject within loginAsStudent instead of googleId.
