### PR TITLE
[#13918] Refactor loginAsInstructor to decouple from googleId

### DIFF
--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -244,10 +244,6 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         return logic.createOrGetAccount(Provider.TEAMMATES_DEV, subject, null, email);
     }
 
-    private Account ensureAccountExists(String subject, String email) {
-        return logic.createOrGetAccount(Provider.TEAMMATES_DEV, subject, null, email);
-    }
-
     /**
      * Logs the current user out of the test environment.
      */

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -188,9 +188,10 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * Logs in the user to the test environment as an instructor
      * (without admin rights or student rights).
      */
-    protected void loginAsInstructor(String userId) {
+    protected void loginAsInstructor(Instructor instructor) {
+        String instructorEmail = instructor.getAccount().getEmail();
         inTransaction(() -> {
-            Account account = ensureAccountExists(userId);
+            Account account = ensureAccountExists(instructorEmail);
             mockUserProvision.loginUser(account);
             mockUserProvision.setLogic(logic);
         });
@@ -356,7 +357,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         ______TS("Instructors cannot access");
         Instructor instructor = createTypicalInstructor(course, "inaccessibleforinstructors@teammates.tmt");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor);
         verifyCannotAccess(params);
 
     }
@@ -386,7 +387,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         Instructor instructor = createTypicalInstructor(course,
                 "inaccessiblewithoutmodifysessionprivilege@teammates.tmt");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor);
         verifyCannotAccess(submissionParams);
     }
 
@@ -396,7 +397,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         Instructor instructor = createTypicalInstructor(course,
                 "inaccessiblewithoutsubmitsessioninsectionsprivilege@teammates.tmt");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor);
         verifyCannotAccess(submissionParams);
     }
 
@@ -406,7 +407,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
 
         ______TS("without correct course privilege cannot access");
 
-        loginAsInstructor(instructor.getAccount().getGoogleId());
+        loginAsInstructor(instructor);
         verifyCannotAccess(submissionParams);
 
         ______TS("only instructor with correct course privilege should pass");
@@ -435,7 +436,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         Instructor instructorOtherCourse = createTypicalInstructor(courseOther,
                 "accessibleforinstructorsofthesamecourse-otherinstructor@teammates.tmt");
 
-        loginAsInstructor(instructorSameCourse.getAccount().getGoogleId());
+        loginAsInstructor(instructorSameCourse);
         verifyCanAccess(submissionParams);
 
         verifyCannotMasquerade(studentSameCourse.getAccountId(), submissionParams);
@@ -455,7 +456,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
         Instructor instructorOtherCourse = createTypicalInstructor(courseOther,
                 "accessibleforinstructorsofothercourse-otherinstructor@teammates.tmt");
 
-        loginAsInstructor(instructorOtherCourse.getAccount().getGoogleId());
+        loginAsInstructor(instructorOtherCourse);
         verifyCanAccess(submissionParams);
 
         verifyCannotMasquerade(studentSameCourse.getAccountId(), submissionParams);
@@ -487,7 +488,7 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
                 "inaccessibleforinstructorsofothercourses@teammates.tmt");
         assert !course.getId().equals(courseOther.getId());
 
-        loginAsInstructor(otherInstructor.getAccount().getGoogleId());
+        loginAsInstructor(otherInstructor);
         verifyCannotAccess(submissionParams);
     }
 

--- a/src/test/java/teammates/ui/webapi/BaseActionIT.java
+++ b/src/test/java/teammates/ui/webapi/BaseActionIT.java
@@ -189,9 +189,10 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
      * (without admin rights or student rights).
      */
     protected void loginAsInstructor(Instructor instructor) {
+        String instructorSubject = instructor.getAccount().getSubject();
         String instructorEmail = instructor.getAccount().getEmail();
         inTransaction(() -> {
-            Account account = ensureAccountExists(instructorEmail);
+            Account account = ensureAccountExists(instructorSubject, instructorEmail);
             mockUserProvision.loginUser(account);
             mockUserProvision.setLogic(logic);
         });
@@ -235,6 +236,10 @@ public abstract class BaseActionIT<T extends Action> extends BaseTestCaseWithDat
     private Account ensureAccountExists(String userId) {
         String email = userId.contains("@") ? userId : userId + "@example.com";
         String subject = userId;
+        return logic.createOrGetAccount(Provider.TEAMMATES_DEV, subject, null, email);
+    }
+
+    private Account ensureAccountExists(String subject, String email) {
         return logic.createOrGetAccount(Provider.TEAMMATES_DEV, subject, null, email);
     }
 

--- a/src/test/java/teammates/ui/webapi/CreateFeedbackQuestionActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateFeedbackQuestionActionIT.java
@@ -50,7 +50,7 @@ public class CreateFeedbackQuestionActionIT extends BaseActionIT<CreateFeedbackQ
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackSession session = typicalBundle.feedbackSessions.get("session1InCourse1");
 
-        loginAsInstructor(instructor1OfCourse1.getAccount().getGoogleId());
+        loginAsInstructor(instructor1OfCourse1);
 
         ______TS("Not enough parameters");
 
@@ -125,7 +125,7 @@ public class CreateFeedbackQuestionActionIT extends BaseActionIT<CreateFeedbackQ
                 Const.ParamsNames.FEEDBACK_SESSION_ID, "00000000-0000-4000-8000-000000000001",
         };
 
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1);
         verifyCannotAccess(submissionParams);
 
         ______TS("inaccessible without ModifySessionPrivilege");

--- a/src/test/java/teammates/ui/webapi/CreateInstructorActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateInstructorActionIT.java
@@ -51,7 +51,7 @@ public class CreateInstructorActionIT extends BaseActionIT<CreateInstructorActio
 
     @Test(groups = GroupNames.INTEGRATION)
     protected void testExecute_typicalCase_shouldPass() {
-        loginAsInstructor(typicalBundle.instructors.get("instructor1OfCourse1").getGoogleId());
+        loginAsInstructor(typicalBundle.instructors.get("instructor1OfCourse1"));
 
         Course course1 = typicalBundle.courses.get("course1");
 

--- a/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/CreateResponseInstructorCommentActionIT.java
@@ -43,7 +43,7 @@ public class CreateResponseInstructorCommentActionIT extends BaseActionIT<Create
         ______TS("Successful case: instructor result comment");
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackResponse fr = typicalBundle.feedbackResponses.get("response1ForQ1InSession2");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         String[] submissionParams = new String[] {
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, fr.getId().toString(),
         };
@@ -74,7 +74,7 @@ public class CreateResponseInstructorCommentActionIT extends BaseActionIT<Create
 
         ______TS("instructor access response to give result comments");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         verifyCanAccess(submissionParamsStudentToStudents);
     }
 

--- a/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/DeleteResponseInstructorCommentActionIT.java
@@ -63,14 +63,14 @@ public class DeleteResponseInstructorCommentActionIT extends BaseActionIT<Delete
         Instructor instructorWhoGiveComment = typicalBundle.instructors.get("instructor1OfCourse1");
 
         assertEquals(instructorWhoGiveComment, frc.getGiver());
-        loginAsInstructor(instructorWhoGiveComment.getGoogleId());
+        loginAsInstructor(instructorWhoGiveComment);
         verifyCanAccess(submissionParams);
 
         ______TS("Different instructor of same course cannot delete comment");
 
         Instructor differentInstructorInSameCourse = typicalBundle.instructors.get("instructor2OfCourse1");
         assertNotEquals(differentInstructorInSameCourse, frc.getGiver());
-        loginAsInstructor(differentInstructorInSameCourse.getGoogleId());
+        loginAsInstructor(differentInstructorInSameCourse);
         verifyCannotAccess(submissionParams);
     }
 

--- a/src/test/java/teammates/ui/webapi/EnrollStudentsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/EnrollStudentsActionIT.java
@@ -57,7 +57,7 @@ public class EnrollStudentsActionIT extends BaseActionIT<EnrollStudentsAction> {
                 "Test Student", "test@email.com", team.getName(),
                 team.getSection().getName(), "Test Comment");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         String[] params = new String[] {
                 Const.ParamsNames.COURSE_ID, courseId,

--- a/src/test/java/teammates/ui/webapi/GetCourseSessionResultsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetCourseSessionResultsActionIT.java
@@ -39,7 +39,7 @@ public class GetCourseSessionResultsActionIT extends BaseActionIT<GetCourseSessi
     @Test(groups = GroupNames.INTEGRATION)
     protected void testExecute() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         FeedbackSession feedbackSession = typicalBundle.feedbackSessions.get("session1InCourse1");
         String[] params = new String[] {

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionLogsActionIT.java
@@ -219,11 +219,11 @@ public class GetFeedbackSessionLogsActionIT extends BaseActionIT<GetFeedbackSess
         ______TS("Only instructors with modify student, session and instructor privilege can access");
         verifyCannotAccess(submissionParams);
 
-        loginAsInstructor(helper.getGoogleId());
+        loginAsInstructor(helper);
         verifyCannotAccess(submissionParams);
 
         ______TS("Only instructors of the same course can access");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         verifyCanAccess(submissionParams);
     }
 

--- a/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetFeedbackSessionSubmittedGiverSetActionIT.java
@@ -44,10 +44,9 @@ public class GetFeedbackSessionSubmittedGiverSetActionIT extends BaseActionIT<Ge
     @Override
     protected void testExecute() {
         Instructor instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
-        String instructorId = instructor1OfCourse1.getGoogleId();
         FeedbackSession fsa = typicalBundle.feedbackSessions.get("session1InCourse1");
 
-        loginAsInstructor(instructorId);
+        loginAsInstructor(instructor1OfCourse1);
 
         ______TS("Not enough parameters");
         verifyHttpParameterFailure();

--- a/src/test/java/teammates/ui/webapi/GetHasResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetHasResponsesActionIT.java
@@ -43,7 +43,7 @@ public class GetHasResponsesActionIT extends BaseActionIT<GetHasResponsesAction>
 
         FeedbackQuestion fq = typicalBundle.feedbackQuestions.get("qn1InSession1InCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         String[] params = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getId().toString(),

--- a/src/test/java/teammates/ui/webapi/GetInstructorPrivilegeActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetInstructorPrivilegeActionIT.java
@@ -46,7 +46,7 @@ public class GetInstructorPrivilegeActionIT extends BaseActionIT<GetInstructorPr
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         Instructor otherInstructor = typicalBundle.instructors.get("instructor2OfCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         ______TS("Typical Success Case fetching privilege of self");
         String[] params = new String[] {

--- a/src/test/java/teammates/ui/webapi/GetInstructorsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetInstructorsActionIT.java
@@ -44,7 +44,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     protected void testExecute() throws Exception {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         ______TS("Typical Success Case with FULL_DETAIL");
         String[] params = new String[] {
@@ -98,8 +98,8 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     @Test(groups = GroupNames.INTEGRATION)
     public void courseNotFound_loggedInAsInstructor_fullDetailIntent() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
-
+        loginAsInstructor(instructor);
+        
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "does-not-exist-id",
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
@@ -150,7 +150,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     @Test(groups = GroupNames.INTEGRATION)
     public void instructor_invalidIntent_shouldFailParameterCheck() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
@@ -163,7 +163,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     @Test(groups = GroupNames.INTEGRATION)
     public void instructor_fullDetailIntent_canAccessOwnCourse() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         String[] params = {
                 Const.ParamsNames.COURSE_ID, instructor.getCourseId(),

--- a/src/test/java/teammates/ui/webapi/GetInstructorsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetInstructorsActionIT.java
@@ -99,7 +99,7 @@ public class GetInstructorsActionIT extends BaseActionIT<GetInstructorsAction> {
     public void courseNotFound_loggedInAsInstructor_fullDetailIntent() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         loginAsInstructor(instructor);
-        
+
         String[] params = {
                 Const.ParamsNames.COURSE_ID, "does-not-exist-id",
                 Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),

--- a/src/test/java/teammates/ui/webapi/GetRegKeyValidityActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetRegKeyValidityActionIT.java
@@ -76,7 +76,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
 
         ______TS("Normal case: Wrong logged in user for a used regkey; should be valid/used/disallowed");
 
-        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1").getGoogleId());
+        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1"));
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, instructor1Key,
@@ -108,7 +108,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
         assertTrue(output.isUsed());
         assertTrue(output.isAllowedAccess());
 
-        loginAsInstructor(instructor1.getGoogleId());
+        loginAsInstructor(instructor1);
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, instructor1Key,
@@ -160,7 +160,7 @@ public class GetRegKeyValidityActionIT extends BaseActionIT<GetRegkeyValidityAct
 
         ______TS("Normal case: Any logged in user for an unused regkey; should be valid/unused/allowed");
 
-        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1").getGoogleId());
+        loginAsInstructor(typicalBundle.instructors.get("instructor2OfCourse1"));
 
         params = new String[] {
                 Const.ParamsNames.REGKEY, instructor1Key,

--- a/src/test/java/teammates/ui/webapi/GetSessionResponseStatsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetSessionResponseStatsActionIT.java
@@ -40,7 +40,7 @@ public class GetSessionResponseStatsActionIT extends BaseActionIT<GetSessionResp
     @Test(groups = GroupNames.INTEGRATION)
     protected void testExecute() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         ______TS("typical: instructor accesses feedback stats of his/her course");
 

--- a/src/test/java/teammates/ui/webapi/GetSessionSubmissionDataActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetSessionSubmissionDataActionIT.java
@@ -64,7 +64,7 @@ public class GetSessionSubmissionDataActionIT extends BaseActionIT<GetSessionSub
         assertTrue(output.getQuestions().stream().anyMatch(question -> !question.getResponses().isEmpty()));
 
         ______TS("Instructor submission data contains instructor questions and recipients");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         action = getAction(buildParams(session, Intent.INSTRUCTOR_SUBMISSION));
         output = getOutput(action);
 
@@ -120,7 +120,7 @@ public class GetSessionSubmissionDataActionIT extends BaseActionIT<GetSessionSub
         ______TS("Instructor submission access");
         String[] instructorSubmissionParams = buildParams(session, Intent.INSTRUCTOR_SUBMISSION);
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         verifyCanAccess(instructorSubmissionParams);
         verifyInaccessibleForInstructorsOfOtherCourses(course, instructorSubmissionParams);
     }

--- a/src/test/java/teammates/ui/webapi/GetStudentsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetStudentsActionIT.java
@@ -45,7 +45,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
         Student student = typicalBundle.students.get("student1InCourse1");
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         ______TS("Typical Success Case with only course id, logged in as instructor");
         String[] params = new String[] {
@@ -102,7 +102,7 @@ public class GetStudentsActionIT extends BaseActionIT<GetStudentsAction> {
                 Const.ParamsNames.COURSE_ID, course.getId(),
         };
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         verifyCanAccess(params);
 

--- a/src/test/java/teammates/ui/webapi/GetUserSessionResultsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetUserSessionResultsActionIT.java
@@ -44,7 +44,7 @@ public class GetUserSessionResultsActionIT extends BaseActionIT<GetUserSessionRe
     @Test(groups = GroupNames.INTEGRATION)
     protected void testExecute() {
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         FeedbackSession accessibleFeedbackSession = typicalBundle.feedbackSessions.get("session1InCourse1");
         String[] params = new String[] {

--- a/src/test/java/teammates/ui/webapi/SearchStudentsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SearchStudentsActionIT.java
@@ -128,7 +128,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
 
     @Test(groups = GroupNames.INTEGRATION)
     public void execute_instructorSearchGoogleId_matchOnlyStudentsInCourse() {
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1);
         String[] googleIdParams = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "student1",
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,
@@ -142,7 +142,7 @@ public class SearchStudentsActionIT extends BaseActionIT<SearchStudentsAction> {
 
     @Test(groups = GroupNames.INTEGRATION)
         public void execute_searchWithoutSearchService_shouldSucceed() {
-        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+        loginAsInstructor(instructor1OfCourse1);
         String[] params = new String[] {
                 Const.ParamsNames.SEARCH_KEY, "student1",
                 Const.ParamsNames.ENTITY_TYPE, Const.EntityType.INSTRUCTOR,

--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionIT.java
@@ -68,7 +68,7 @@ public class SubmitFeedbackResponsesActionIT extends BaseActionIT<SubmitFeedback
 
     private Instructor loginInstructor(String instructorId) {
         Instructor instructor = getInstructor(instructorId);
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         return instructor;
     }
 

--- a/src/test/java/teammates/ui/webapi/UpdateFeedbackQuestionActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateFeedbackQuestionActionIT.java
@@ -54,7 +54,7 @@ public class UpdateFeedbackQuestionActionIT extends BaseActionIT<UpdateFeedbackQ
         FeedbackQuestion typicalQuestion = inTransaction(() -> logic.getFeedbackQuestion(fq1.getId()));
         assertEquals(FeedbackQuestionType.TEXT, typicalQuestion.getQuestionType());
 
-        loginAsInstructor(instructor1ofCourse1.getGoogleId());
+        loginAsInstructor(instructor1ofCourse1);
 
         ______TS("Not enough parameters");
 
@@ -121,7 +121,7 @@ public class UpdateFeedbackQuestionActionIT extends BaseActionIT<UpdateFeedbackQ
 
         ______TS("non-existent feedback question");
 
-        loginAsInstructor(instructor1OfCourse1.getAccount().getGoogleId());
+        loginAsInstructor(instructor1OfCourse1);
 
         verifyCannotAccess(Const.ParamsNames.FEEDBACK_QUESTION_ID, "00000000-0000-0000-0000-000000000000");
 

--- a/src/test/java/teammates/ui/webapi/UpdateResponseInstructorCommentActionIT.java
+++ b/src/test/java/teammates/ui/webapi/UpdateResponseInstructorCommentActionIT.java
@@ -42,7 +42,7 @@ public class UpdateResponseInstructorCommentActionIT extends BaseActionIT<Update
         Instructor instructor = typicalBundle.instructors.get("instructor1OfCourse1");
         ResponseInstructorComment frc = typicalBundle.responseInstructorComments.get("comment1ToResponse1ForQ1");
         ______TS("Typical successful case for INSTRUCTOR_RESULT");
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
 
         String [] submissionParams = new String[] {
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, frc.getId().toString(),
@@ -70,7 +70,7 @@ public class UpdateResponseInstructorCommentActionIT extends BaseActionIT<Update
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, frc.getId().toString(),
         };
 
-        loginAsInstructor(instructor.getGoogleId());
+        loginAsInstructor(instructor);
         verifyCanAccess(submissionParams);
     }
 


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Refactor loginAsInstructor to take in Instructor entity and create account with subject and email instead of googleId.
