### PR TITLE
[#13918] Replace getGoogleId usages in E2E pages

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
@@ -237,7 +237,7 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
                 teams.add(student.getTeamName());
                 numTeams++;
             }
-            if (student.getGoogleId() == null || student.getGoogleId().isEmpty()) {
+            if (!student.isRegistered()) {
                 numUnregistered++;
             }
             numStudents++;

--- a/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
@@ -2,6 +2,7 @@ package teammates.e2e.cases;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.Test;
@@ -48,8 +49,9 @@ public class StudentHomePageE2ETest extends BaseE2ETestCase {
     private List<String> getAllVisibleCourseIds() {
         List<String> courseIds = new ArrayList<>();
 
+        UUID studentIdWithVisibleCourses = testData.students.get("SHome.student").getId();
         for (Student student : testData.students.values()) {
-            if ("tm.e2e.SHome.student".equals(student.getGoogleId())) {
+            if (studentIdWithVisibleCourses.equals(student.getId())) {
                 courseIds.add(student.getCourseId());
             }
         }

--- a/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/StudentHomePageE2ETest.java
@@ -49,9 +49,9 @@ public class StudentHomePageE2ETest extends BaseE2ETestCase {
     private List<String> getAllVisibleCourseIds() {
         List<String> courseIds = new ArrayList<>();
 
-        UUID studentIdWithVisibleCourses = testData.students.get("SHome.student").getId();
+        UUID studentAccountIdWithVisibleCourses = testData.accounts.get("SHome.student").getId();
         for (Student student : testData.students.values()) {
-            if (studentIdWithVisibleCourses.equals(student.getId())) {
+            if (studentAccountIdWithVisibleCourses.equals(student.getAccountId())) {
                 courseIds.add(student.getCourseId());
             }
         }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
@@ -115,7 +115,7 @@ public class InstructorCourseDetailsPage extends AppPage {
             expected[i][0] = student.getSectionName();
             expected[i][1] = student.getTeamName();
             expected[i][2] = student.getName();
-            expected[i][3] = (student.getGoogleId() == null || student.getGoogleId().isEmpty()) ? "Yet to Join" : "Joined";
+            expected[i][3] = (student.isRegistered()) ? "Joined" : "Yet to Join";
             expected[i][4] = student.getEmail();
         }
         return expected;

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -99,7 +99,7 @@ public class InstructorSearchPage extends AppPage {
             expected[i][0] = student.getSectionName();
             expected[i][1] = student.getTeamName();
             expected[i][2] = student.getName();
-            expected[i][3] = (student.getGoogleId() == null || student.getGoogleId().isEmpty()) ? "Yet to Join" : "Joined";
+            expected[i][3] = (student.isRegistered()) ? "Joined" : "Yet to Join";
             expected[i][4] = student.getEmail();
         }
         return expected;

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
@@ -124,7 +124,7 @@ public class InstructorStudentListPage extends AppPage {
             expected[i][0] = student.getSectionName();
             expected[i][1] = student.getTeamName();
             expected[i][2] = student.getName();
-            expected[i][3] = (student.getGoogleId() == null || student.getGoogleId().isEmpty()) ? "Yet to Join" : "Joined";
+            expected[i][3] = (student.isRegistered()) ? "Joined" : "Yet to Join";
             expected[i][4] = student.getEmail();
         }
         return expected;


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Replaces instances of `getGoogleId` in E2E pages and test.
