### PR TITLE
[#13471] Notifications page: add batch mark unread notifications as read

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -1,5 +1,7 @@
 // PR checks for TEAMMATES contribution guidelines; used by .github/workflows/pr.yml.
 
+const BOT_COMMENT_MARKER = '<!-- teammates-pr-checker -->';
+
 const getOrphanLockfiles = (changedPaths) => {
   const dirOf = (filePath) => {
     const idx = filePath.lastIndexOf('/');
@@ -25,7 +27,43 @@ const getOrphanLockfiles = (changedPaths) => {
     .map((dir) => (dir === '' ? 'package-lock.json' : `${dir}/package-lock.json`));
 };
 
-const checkPr = async ({ github, context }) => {
+const findBotComment = async ({ github, context }) => {
+  let page = 1;
+  while (true) {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      per_page: 100,
+      page,
+    });
+    const botComment = comments.find((c) => c.body.includes(BOT_COMMENT_MARKER));
+    if (botComment) return botComment;
+    if (comments.length < 100) return null;
+    page += 1;
+  }
+};
+
+const upsertComment = async ({ github, context, body }) => {
+  const existingComment = await findBotComment({ github, context });
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingComment.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body,
+    });
+  }
+};
+
+const checkPr = async ({ github, context, core }) => {
   const pr = await github.rest.pulls.get({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -69,12 +107,26 @@ const checkPr = async ({ github, context }) => {
       issue_number: issueNumber,
     });
     isIssueOpen = issue.data.state === 'open';
-    if (isTitleValid && isDescriptionValid && isIssueOpen && isLockfileChangeValid) {
-      return;
-    }
   }
-  let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
-              However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+
+  const hasViolations = !isTitleValid || !isDescriptionValid || (issueNumber && !isIssueOpen) || !isLockfileChangeValid;
+
+  if (!hasViolations) {
+    // All checks passed — update existing comment to reflect resolution, if one exists.
+    const existingComment = await findBotComment({ github, context });
+    if (existingComment) {
+      await github.rest.issues.updateComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: existingComment.id,
+        body: `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, all PR guideline checks have passed. Thank you for your contribution! :tada:`,
+      });
+    }
+    return;
+  }
+
+  let body = `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n`
+    + `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
   if (!isTitleValid) {
     body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
   }
@@ -89,12 +141,10 @@ const checkPr = async ({ github, context }) => {
     body += `- This PR contains changes to \`package-lock.json\` without corresponding \`package.json\` changes. Please revert the \`package-lock.json\` changes.\n`;
   }
   body += '\nPlease address the above before we proceed to review your PR.';
-  await github.rest.issues.createComment({
-    issue_number: context.issue.number,
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    body,
-  });
+
+  await upsertComment({ github, context, body });
+
+  core.setFailed('PR does not follow contribution guidelines. See the comment on the PR for details.');
 };
 
 module.exports = checkPr;

--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -125,8 +125,9 @@ const checkPr = async ({ github, context, core }) => {
     return;
   }
 
-  let body = `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n`
-    + `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+  let body =
+    `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n` +
+    `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
   if (!isTitleValid) {
     body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
   }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
       - reopened
+      - edited
+      - synchronize
     branches:
       - master
 
@@ -18,4 +20,4 @@ jobs:
         with:
           script: |
             const script = require('./.github/scripts/check-pr.js')
-            await script({ github, context })
+            await script({ github, context, core })

--- a/src/main/java/teammates/ui/request/MarkNotificationAsReadRequest.java
+++ b/src/main/java/teammates/ui/request/MarkNotificationAsReadRequest.java
@@ -1,6 +1,8 @@
 package teammates.ui.request;
 
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import teammates.ui.exception.InvalidHttpRequestBodyException;
 
@@ -9,18 +11,27 @@ import teammates.ui.exception.InvalidHttpRequestBodyException;
  */
 public class MarkNotificationAsReadRequest extends BasicRequest {
     private String notificationId;
+    private List<String> notificationIds;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public MarkNotificationAsReadRequest(String notificationId) {
+    public MarkNotificationAsReadRequest(
+            @JsonProperty("notificationId") String notificationId,
+            @JsonProperty("notificationIds") List<String> notificationIds) {
         this.notificationId = notificationId;
+        this.notificationIds = notificationIds;
     }
 
     public String getNotificationId() {
         return this.notificationId;
     }
 
+    public List<String> getNotificationIds() {
+        return this.notificationIds;
+    }
+
     @Override
     public void validate() throws InvalidHttpRequestBodyException {
-        validateTrue(notificationId != null, "Notification id should not be null.");
+        validateTrue(notificationId != null || (notificationIds != null && !notificationIds.isEmpty()),
+                "Either notificationId or notificationIds should be provided.");
     }
 }

--- a/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
+++ b/src/main/java/teammates/ui/webapi/MarkNotificationAsReadAction.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import teammates.common.exception.EntityDoesNotExistException;
@@ -11,6 +13,7 @@ import teammates.ui.exception.InvalidOperationException;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.exception.UnexpectedServerException;
 import teammates.ui.output.ReadNotificationData;
+import teammates.ui.output.ReadNotificationsData;
 import teammates.ui.request.MarkNotificationAsReadRequest;
 
 /**
@@ -26,21 +29,36 @@ public class MarkNotificationAsReadAction extends LoggedInAction {
     public JsonResult execute() throws InvalidHttpRequestBodyException, InvalidOperationException {
         MarkNotificationAsReadRequest readNotificationCreateRequest =
                 getAndValidateRequestBody(MarkNotificationAsReadRequest.class);
-        UUID notificationId = UUID.fromString(readNotificationCreateRequest.getNotificationId());
 
         Account account = logic.getAccountForGoogleId(getCurrentUserGoogleId());
         if (account == null) {
             // This should not happen as the user is authenticated
             throw new UnexpectedServerException("Account not found");
         }
-        ReadNotification readNotification;
-        try {
-            readNotification = logic.createReadNotification(account.getId(), notificationId);
-        } catch (EntityDoesNotExistException e) {
-            throw new EntityNotFoundException(e);
-        }
-        ReadNotificationData output = new ReadNotificationData(readNotification);
 
-        return new JsonResult(output);
+        if (readNotificationCreateRequest.getNotificationIds() != null) {
+            List<ReadNotification> readNotifications = new ArrayList<>();
+            try {
+                for (String idStr : readNotificationCreateRequest.getNotificationIds()) {
+                    UUID notificationId = UUID.fromString(idStr);
+                    readNotifications.add(logic.createReadNotification(account.getId(), notificationId));
+                }
+            } catch (EntityDoesNotExistException e) {
+                throw new EntityNotFoundException(e);
+            }
+            List<UUID> readNotificationIds = readNotifications.stream()
+                    .map(rn -> rn.getNotification().getId())
+                    .toList();
+            return new JsonResult(new ReadNotificationsData(readNotificationIds));
+        } else {
+            UUID notificationId = UUID.fromString(readNotificationCreateRequest.getNotificationId());
+            ReadNotification readNotification;
+            try {
+                readNotification = logic.createReadNotification(account.getId(), notificationId);
+            } catch (EntityDoesNotExistException e) {
+                throw new EntityNotFoundException(e);
+            }
+            return new JsonResult(new ReadNotificationData(readNotification));
+        }
     }
 }

--- a/src/web/app/components/notification-banner/notification-banner.component.spec.ts
+++ b/src/web/app/components/notification-banner/notification-banner.component.spec.ts
@@ -111,7 +111,7 @@ describe('NotificationBannerComponent', () => {
       .mockImplementation((request: MarkNotificationAsReadRequest) => {
         expect(request.notificationId).toEqual(testNotificationOne.notificationId);
         return of({
-          readNotifications: [request.notificationId],
+          readNotifications: [request.notificationId!],
         });
       });
     const messageSpy = vi.spyOn(statusMessageService, 'showSuccessToast').mockImplementation((args: string) => {
@@ -135,7 +135,7 @@ describe('NotificationBannerComponent', () => {
       .mockImplementation((request: MarkNotificationAsReadRequest) => {
         expect(request.notificationId).toEqual(testNotificationOne.notificationId);
         return of({
-          readNotifications: [request.notificationId],
+          readNotifications: [request.notificationId!],
         });
       });
     const messageSpy = vi.spyOn(statusMessageService, 'showSuccessToast').mockImplementation((args: string) => {

--- a/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
+++ b/src/web/app/components/user-notifications-list/__snapshots__/user-notifications-list.component.spec.ts.snap
@@ -23,10 +23,14 @@ exports[`UserNotificationsListComponent > should snap when all loaded notificati
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-3"
+    class="row mb-3 align-items-center"
   >
     <div
-      class="col-12"
+      class="col-6"
+    >
+    </div>
+    <div
+      class="col-6"
     >
       <div
         class="float-end"
@@ -232,10 +236,20 @@ exports[`UserNotificationsListComponent > should snap when it loads the provided
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-3"
+    class="row mb-3 align-items-center"
   >
     <div
-      class="col-12"
+      class="col-6"
+    >
+      <button
+        class="btn btn-primary"
+        id="mark-all-read-btn"
+      >
+         Mark All as Read 
+      </button>
+    </div>
+    <div
+      class="col-6"
     >
       <div
         class="float-end"
@@ -413,10 +427,20 @@ exports[`UserNotificationsListComponent > should snap when it sorts the notifica
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-3"
+    class="row mb-3 align-items-center"
   >
     <div
-      class="col-12"
+      class="col-6"
+    >
+      <button
+        class="btn btn-primary"
+        id="mark-all-read-btn"
+      >
+         Mark All as Read 
+      </button>
+    </div>
+    <div
+      class="col-6"
     >
       <div
         class="float-end"
@@ -595,10 +619,20 @@ exports[`UserNotificationsListComponent > should snap when it sorts the notifica
       All dates are displayed in UTC time.
     </p>
   </div><div
-    class="row mb-3"
+    class="row mb-3 align-items-center"
   >
     <div
-      class="col-12"
+      class="col-6"
+    >
+      <button
+        class="btn btn-primary"
+        id="mark-all-read-btn"
+      >
+         Mark All as Read 
+      </button>
+    </div>
+    <div
+      class="col-6"
     >
       <div
         class="float-end"

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.html
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.html
@@ -2,8 +2,19 @@
   <p>All dates are displayed in {{ timezone }} time.</p>
 </div>
 @if (notificationTabs.length > 0) {
-  <div class="row mb-3">
-    <div class="col-12">
+  <div class="row mb-3 align-items-center">
+    <div class="col-6">
+      @if (hasUnreadNotifications) {
+        <button
+          id="mark-all-read-btn"
+          class="btn btn-primary"
+          (click)="markAllNotificationsAsRead()"
+        >
+          Mark All as Read
+        </button>
+      }
+    </div>
+    <div class="col-6">
       <div class="float-end">
         <strong class="d-inline"> Sort By: </strong>
         <div class="btn-group" data-toggle="buttons">

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.spec.ts
@@ -126,7 +126,7 @@ describe('UserNotificationsListComponent', () => {
       .mockImplementation((request: MarkNotificationAsReadRequest) => {
         expect(request.notificationId).toEqual(testNotificationOne.notificationId);
         return of({
-          readNotifications: [request.notificationId],
+          readNotifications: [request.notificationId!],
         });
       });
     const messageSpy = vi.spyOn(statusMessageService, 'showSuccessToast').mockImplementation((args: string) => {
@@ -141,6 +141,32 @@ describe('UserNotificationsListComponent', () => {
     expect(messageSpy).toHaveBeenCalledTimes(1);
     // check that it is no longer expanded
     expect(component.notificationTabs[0].hasTabExpanded).toBeFalsy();
+  });
+
+  it('should mark all notifications as read when mark all as read button is clicked', () => {
+    const apiSpy = vi
+      .spyOn(notificationService, 'markNotificationAsRead')
+      .mockImplementation((request: MarkNotificationAsReadRequest) => {
+        expect(request.notificationIds).toEqual([testNotificationOne.notificationId, testNotificationTwo.notificationId]);
+        return of({
+          readNotifications: request.notificationIds!,
+        });
+      });
+    const messageSpy = vi.spyOn(statusMessageService, 'showSuccessToast').mockImplementation((args: string) => {
+      expect(args).toEqual('All notifications marked as read.');
+    });
+
+    component.notificationTabs = getNotificationTabs([testNotificationOne, testNotificationTwo]);
+    fixture.detectChanges();
+
+    const markAllReadBtn = fixture.debugElement.query(By.css('#mark-all-read-btn')).nativeElement;
+    expect(markAllReadBtn).toBeTruthy();
+
+    markAllReadBtn.click();
+    expect(apiSpy).toHaveBeenCalledTimes(1);
+    expect(messageSpy).toHaveBeenCalledTimes(1);
+    expect(component.notificationTabs[0].isRead).toBeTruthy();
+    expect(component.notificationTabs[1].isRead).toBeTruthy();
   });
 
   it('should collapse an expanded tab when the header is clicked', () => {

--- a/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
+++ b/src/web/app/components/user-notifications-list/user-notifications-list.component.ts
@@ -71,6 +71,35 @@ export class UserNotificationsListComponent implements OnInit {
     this.loadNotifications();
   }
 
+  get hasUnreadNotifications(): boolean {
+    return this.notificationTabs.some((tab) => !tab.isRead);
+  }
+
+  markAllNotificationsAsRead(): void {
+    const unreadTabs = this.notificationTabs.filter((tab) => !tab.isRead);
+    if (unreadTabs.length === 0) {
+      return;
+    }
+    const notificationIds = unreadTabs.map((tab) => tab.notification.notificationId);
+
+    this.notificationService
+      .markNotificationAsRead({
+        notificationIds,
+      })
+      .subscribe({
+        next: () => {
+          unreadTabs.forEach((tab) => {
+            tab.isRead = true;
+            tab.hasTabExpanded = false;
+          });
+          this.statusMessageService.showSuccessToast('All notifications marked as read.');
+        },
+        error: (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorToast(resp.error.message);
+        },
+      });
+  }
+
   loadNotifications(): void {
     this.hasLoadingFailed = false;
     this.isLoadingNotifications = true;

--- a/src/web/types/api-request.ts
+++ b/src/web/types/api-request.ts
@@ -212,7 +212,8 @@ export interface InstructorUpdateRequest extends BasicRequest {
 }
 
 export interface MarkNotificationAsReadRequest extends BasicRequest {
-  notificationId: string;
+  notificationId?: string;
+  notificationIds?: string[];
 }
 
 export interface NotificationBasicRequest extends BasicRequest {


### PR DESCRIPTION
This PR adds support for marking a batch of unread notifications as read in a single API call (instead of sequential individual API calls on the client side). It includes both backend updates to accept list of IDs and frontend implementation for the 'Mark All as Read' button.