### PR TITLE
[#13918] Remove googleId getter and setter in User entity

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseStudentDetailsEditPageE2ETest.java
@@ -59,7 +59,7 @@ public class InstructorCourseStudentDetailsEditPageE2ETest extends BaseE2ETestCa
         ______TS("edit email and resend links");
         String newEmail = "new.email@gmail.tmt";
         student.setEmail(newEmail);
-        student.setGoogleId(null);
+        student.setAccount(null);
         editPage.editStudentEmailAndResendLinks(newEmail);
 
         editPage.verifyStatusMessage("Student has been updated and email sent");

--- a/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
+++ b/src/e2e/java/teammates/e2e/util/TestDataValidityTest.java
@@ -38,7 +38,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * <p>
  * For the above reason, the following fields are checked:
  * <ul>
- * <li>Account Google ID</li>
  * <li>Course ID</li>
  * <li>Student email</li>
  * <li>Instructor email</li>
@@ -76,11 +75,6 @@ public class TestDataValidityTest extends BaseTestCase {
                 DataBundle dataBundle = JsonUtils.fromJson(jsonString, DataBundle.class);
 
                 dataBundle.accounts.forEach((id, account) -> {
-                    if (!isValidTestGoogleId(account.getGoogleId(), testPage)) {
-                        errors.computeIfAbsent(pathString, k -> new ArrayList<>())
-                                .add("Invalid account google ID: " + account.getGoogleId());
-                    }
-
                     if (!isValidTestEmail(account.getEmail())) {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid account email: " + account.getEmail());
@@ -105,11 +99,6 @@ public class TestDataValidityTest extends BaseTestCase {
                 });
 
                 dataBundle.students.forEach((id, student) -> {
-                    if (!isValidTestGoogleId(student.getGoogleId(), testPage)) {
-                        errors.computeIfAbsent(pathString, k -> new ArrayList<>())
-                                .add("Invalid student google ID: " + student.getGoogleId());
-                    }
-
                     if (!isValidTestEmail(student.getEmail())) {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid student email: " + student.getEmail());
@@ -117,11 +106,6 @@ public class TestDataValidityTest extends BaseTestCase {
                 });
 
                 dataBundle.instructors.forEach((id, instructor) -> {
-                    if (!isValidTestGoogleId(instructor.getGoogleId(), testPage)) {
-                        errors.computeIfAbsent(pathString, k -> new ArrayList<>())
-                                .add("Invalid instructor google ID: " + instructor.getGoogleId());
-                    }
-
                     if (!isValidTestEmail(instructor.getEmail())) {
                         errors.computeIfAbsent(pathString, k -> new ArrayList<>())
                                 .add("Invalid instructor email: " + instructor.getEmail());
@@ -194,16 +178,6 @@ public class TestDataValidityTest extends BaseTestCase {
 
         return (courseId.matches(constructIdRegex(testPage))
                 || courseId.startsWith("tm.e2e.")) && courseId.length() < 64;
-    }
-
-    private boolean isValidTestGoogleId(String googleId, String testPage) {
-        if (googleId == null || "".equals(googleId)) {
-            // Empty google ID is always acceptable
-            return true;
-        }
-
-        return (googleId.matches(constructIdRegex(testPage)) || googleId.startsWith("tm.e2e."))
-                && googleId.length() < 64;
     }
 
     private String extractTestPage(String fileName) {

--- a/src/main/java/teammates/storage/entity/User.java
+++ b/src/main/java/teammates/storage/entity/User.java
@@ -198,15 +198,6 @@ public abstract class User extends BaseEntity {
         return null;
     }
 
-    /**
-     * Sets google id of account if account and googleId provided is not null.
-     */
-    public void setGoogleId(String googleId) {
-        if (googleId != null && getAccount() != null) {
-            getAccount().setGoogleId(googleId);
-        }
-    }
-
     public boolean isRegistered() {
         return this.account != null || this.accountId != null;
     }

--- a/src/main/java/teammates/storage/entity/User.java
+++ b/src/main/java/teammates/storage/entity/User.java
@@ -187,17 +187,6 @@ public abstract class User extends BaseEntity {
         return StringHelper.encrypt(uniqueId + "%" + prng.nextInt());
     }
 
-    /**
-     * Returns google id of the user if account is not null.
-     */
-    public String getGoogleId() {
-        if (getAccount() != null) {
-            return getAccount().getGoogleId();
-        }
-
-        return null;
-    }
-
     public boolean isRegistered() {
         return this.account != null || this.accountId != null;
     }

--- a/src/test/java/teammates/logic/core/AccountsLogicIT.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicIT.java
@@ -2,8 +2,6 @@ package teammates.logic.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.UUID;
-
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -61,10 +59,9 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: student joins course");
 
-        UUID loggedInAccountId = loggedInAccount.getId();
         inTransaction(() -> accountsLogic.joinCourse(student2YetToJoinCourse.getRegKey(), loggedInAccount));
 
-        assertEquals(loggedInAccountId, inTransaction(() -> usersLogic.getStudentForEmail(
+        assertEquals(loggedInAccount.getId(), inTransaction(() -> usersLogic.getStudentForEmail(
                 student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getAccountId()));
 
         ______TS("success: student joined but account already exists");
@@ -108,12 +105,11 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: instructor joins course");
 
-        UUID loggedInAccountId = loggedInAccount.getId();
         inTransaction(() -> accountsLogic.joinCourse(key[0], loggedInAccount));
 
         Instructor joinedInstructor = inTransaction(() -> usersLogic.getInstructorForEmail(
                         instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail()));
-        assertEquals(loggedInAccountId, joinedInstructor.getAccountId());
+        assertEquals(loggedInAccount.getId(), joinedInstructor.getAccountId());
 
         ______TS("success: instructor joined but account already exists");
 

--- a/src/test/java/teammates/logic/core/AccountsLogicIT.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicIT.java
@@ -2,6 +2,8 @@ package teammates.logic.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.UUID;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -39,9 +41,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
         Student student3YetToJoinCourse = typicalDataBundle.students.get("student3YetToJoinCourse4");
         Student studentInCourse = typicalDataBundle.students.get("student1InCourse1");
 
-        String loggedInGoogleId = "AccLogicT.student.id";
         Account loggedInAccount = getTypicalAccount();
-        loggedInAccount.setGoogleId(loggedInGoogleId);
         loggedInAccount.setEmail("acct.student@teammates.tmt");
         inTransaction(() -> accountsDb.persistAccount(loggedInAccount));
 
@@ -62,22 +62,23 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: student joins course");
 
+        UUID loggedInAccountId = loggedInAccount.getId();
         inTransaction(() -> accountsLogic.joinCourse(student2YetToJoinCourse.getRegKey(), loggedInAccount));
 
-        assertEquals(loggedInGoogleId, inTransaction(() -> usersLogic.getStudentForEmail(
-                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getGoogleId()));
+        assertEquals(loggedInAccountId, inTransaction(() -> usersLogic.getStudentForEmail(
+                student2YetToJoinCourse.getCourseId(), student2YetToJoinCourse.getEmail()).getAccountId()));
 
         ______TS("success: student joined but account already exists");
 
         Account existingAccount = getTypicalAccount();
-        existingAccount.setGoogleId("existingAccountId");
+        UUID existingAccountId = existingAccount.getId();
         existingAccount.setEmail(student3YetToJoinCourse.getEmail());
         inTransaction(() -> accountsDb.persistAccount(existingAccount));
 
         inTransaction(() -> accountsLogic.joinCourse(student3YetToJoinCourse.getRegKey(), existingAccount));
 
-        assertEquals("existingAccountId", inTransaction(() -> usersLogic.getStudentForEmail(
-                student3YetToJoinCourse.getCourseId(), student3YetToJoinCourse.getEmail()).getGoogleId()));
+        assertEquals(existingAccountId, inTransaction(() -> usersLogic.getStudentForEmail(
+                student3YetToJoinCourse.getCourseId(), student3YetToJoinCourse.getEmail()).getAccountId()));
 
         ______TS("failure: already joined");
 
@@ -91,9 +92,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
         Instructor instructor2YetToJoinCourse = typicalDataBundle.instructors.get("instructor2YetToJoinCourse4");
         Instructor instructor3YetToJoinCourse = typicalDataBundle.instructors.get("instructor3YetToJoinCourse4");
 
-        String loggedInGoogleId = "AccLogicT.instr.id";
         Account loggedInAccount = getTypicalAccount();
-        loggedInAccount.setGoogleId(loggedInGoogleId);
         loggedInAccount.setEmail("acct.instr@teammates.tmt");
         inTransaction(() -> accountsDb.persistAccount(loggedInAccount));
 
@@ -113,17 +112,17 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: instructor joins course");
 
+        UUID loggedInAccountId = loggedInAccount.getId();
         inTransaction(() -> accountsLogic.joinCourse(key[0], loggedInAccount));
 
         Instructor joinedInstructor = inTransaction(() -> usersLogic.getInstructorForEmail(
                         instructor2YetToJoinCourse.getCourseId(), instructor2YetToJoinCourse.getEmail()));
-        assertEquals(loggedInGoogleId, joinedInstructor.getGoogleId());
+        assertEquals(loggedInAccountId, joinedInstructor.getAccountId());
 
         ______TS("success: instructor joined but account already exists");
 
-        String existingAccountId = "existingAccountId";
         Account existingAccount = getTypicalAccount();
-        existingAccount.setGoogleId(existingAccountId);
+        UUID existingAccountId = existingAccount.getId();
         existingAccount.setEmail(instructor3YetToJoinCourse.getEmail());
         inTransaction(() -> accountsDb.persistAccount(existingAccount));
 
@@ -131,7 +130,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         joinedInstructor = inTransaction(() -> usersLogic.getInstructorForEmail(
                         instructor3YetToJoinCourse.getCourseId(), existingAccount.getEmail()));
-        assertEquals("existingAccountId", joinedInstructor.getGoogleId());
+        assertEquals(existingAccountId, joinedInstructor.getAccountId());
 
         ______TS("failure: instructor already joined");
 

--- a/src/test/java/teammates/logic/core/AccountsLogicIT.java
+++ b/src/test/java/teammates/logic/core/AccountsLogicIT.java
@@ -41,8 +41,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
         Student student3YetToJoinCourse = typicalDataBundle.students.get("student3YetToJoinCourse4");
         Student studentInCourse = typicalDataBundle.students.get("student1InCourse1");
 
-        Account loggedInAccount = getTypicalAccount();
-        loggedInAccount.setEmail("acct.student@teammates.tmt");
+        Account loggedInAccount = getTypicalAccountForEmail("acct.student@teammates.tmt");
         inTransaction(() -> accountsDb.persistAccount(loggedInAccount));
 
         ______TS("failure: wrong key");
@@ -52,7 +51,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
                 () -> accountsLogic.joinCourse(wrongKey, loggedInAccount));
         assertEquals("No user with given registration key: " + wrongKey, ednee.getMessage());
 
-        ______TS("failure: googleID belongs to an existing student in the course");
+        ______TS("failure: account belongs to an existing student in the course");
 
         Account studentInCourseAccount = inTransaction(() -> accountsLogic.getAccount(studentInCourse.getAccountId()));
         EntityAlreadyExistsException eaee = assertThrowsInTransaction(EntityAlreadyExistsException.class,
@@ -70,14 +69,12 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: student joined but account already exists");
 
-        Account existingAccount = getTypicalAccount();
-        UUID existingAccountId = existingAccount.getId();
-        existingAccount.setEmail(student3YetToJoinCourse.getEmail());
+        Account existingAccount = getTypicalAccountForEmail(student3YetToJoinCourse.getEmail());
         inTransaction(() -> accountsDb.persistAccount(existingAccount));
 
         inTransaction(() -> accountsLogic.joinCourse(student3YetToJoinCourse.getRegKey(), existingAccount));
 
-        assertEquals(existingAccountId, inTransaction(() -> usersLogic.getStudentForEmail(
+        assertEquals(existingAccount.getId(), inTransaction(() -> usersLogic.getStudentForEmail(
                 student3YetToJoinCourse.getCourseId(), student3YetToJoinCourse.getEmail()).getAccountId()));
 
         ______TS("failure: already joined");
@@ -92,8 +89,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
         Instructor instructor2YetToJoinCourse = typicalDataBundle.instructors.get("instructor2YetToJoinCourse4");
         Instructor instructor3YetToJoinCourse = typicalDataBundle.instructors.get("instructor3YetToJoinCourse4");
 
-        Account loggedInAccount = getTypicalAccount();
-        loggedInAccount.setEmail("acct.instr@teammates.tmt");
+        Account loggedInAccount = getTypicalAccountForEmail("acct.instr@teammates.tmt");
         inTransaction(() -> accountsDb.persistAccount(loggedInAccount));
 
         String[] key = new String[] {
@@ -101,7 +97,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
                 getRegKeyForInstructor(instructor2YetToJoinCourse.getCourseId(), instructor3YetToJoinCourse.getEmail()),
         };
 
-        ______TS("failure: googleID belongs to an existing instructor in the course");
+        ______TS("failure: account belongs to an existing instructor in the course");
 
         Account instructor1Account = inTransaction(() -> accountsLogic.getAccount(
                 typicalDataBundle.accounts.get("instructor1").getId()));
@@ -121,16 +117,14 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("success: instructor joined but account already exists");
 
-        Account existingAccount = getTypicalAccount();
-        UUID existingAccountId = existingAccount.getId();
-        existingAccount.setEmail(instructor3YetToJoinCourse.getEmail());
+        Account existingAccount = getTypicalAccountForEmail(instructor3YetToJoinCourse.getEmail());
         inTransaction(() -> accountsDb.persistAccount(existingAccount));
 
         inTransaction(() -> accountsLogic.joinCourse(key[1], existingAccount));
 
         joinedInstructor = inTransaction(() -> usersLogic.getInstructorForEmail(
                         instructor3YetToJoinCourse.getCourseId(), existingAccount.getEmail()));
-        assertEquals(existingAccountId, joinedInstructor.getAccountId());
+        assertEquals(existingAccount.getId(), joinedInstructor.getAccountId());
 
         ______TS("failure: instructor already joined");
 
@@ -140,9 +134,7 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
         ______TS("failure: key belongs to a different user");
 
-        Account otherAccount = getTypicalAccount();
-        otherAccount.setGoogleId("otherUserId");
-        otherAccount.setEmail("other@teammates.tmt");
+        Account otherAccount = getTypicalAccountForEmail("other@teammates.tmt");
         inTransaction(() -> accountsDb.persistAccount(otherAccount));
 
         eaee = assertThrowsInTransaction(EntityAlreadyExistsException.class,
@@ -161,5 +153,12 @@ public class AccountsLogicIT extends BaseTestCaseWithDatabaseAccess {
 
     private String getRegKeyForInstructor(String courseId, String email) {
         return inTransaction(() -> usersLogic.getInstructorForEmail(courseId, email).getRegKey());
+    }
+
+    private Account getTypicalAccountForEmail(String email) {
+        Account account = getTypicalAccount();
+        account.setEmail(email);
+        account.setGoogleId(email);
+        return account;
     }
 }


### PR DESCRIPTION
Part of #13918

**Outline of Solution**

* Remove `setGoogleId` and `getGoogleId` in `User` entity.
* Replace the method instances in remaining test classes.
