### PR TITLE
[#12552] Session Copy Modal: Validate against copying with same name in same course

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -1,5 +1,7 @@
 // PR checks for TEAMMATES contribution guidelines; used by .github/workflows/pr.yml.
 
+const BOT_COMMENT_MARKER = '<!-- teammates-pr-checker -->';
+
 const getOrphanLockfiles = (changedPaths) => {
   const dirOf = (filePath) => {
     const idx = filePath.lastIndexOf('/');
@@ -25,7 +27,43 @@ const getOrphanLockfiles = (changedPaths) => {
     .map((dir) => (dir === '' ? 'package-lock.json' : `${dir}/package-lock.json`));
 };
 
-const checkPr = async ({ github, context }) => {
+const findBotComment = async ({ github, context }) => {
+  let page = 1;
+  while (true) {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      per_page: 100,
+      page,
+    });
+    const botComment = comments.find((c) => c.body.includes(BOT_COMMENT_MARKER));
+    if (botComment) return botComment;
+    if (comments.length < 100) return null;
+    page += 1;
+  }
+};
+
+const upsertComment = async ({ github, context, body }) => {
+  const existingComment = await findBotComment({ github, context });
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingComment.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body,
+    });
+  }
+};
+
+const checkPr = async ({ github, context, core }) => {
   const pr = await github.rest.pulls.get({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -69,12 +107,26 @@ const checkPr = async ({ github, context }) => {
       issue_number: issueNumber,
     });
     isIssueOpen = issue.data.state === 'open';
-    if (isTitleValid && isDescriptionValid && isIssueOpen && isLockfileChangeValid) {
-      return;
-    }
   }
-  let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
-              However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+
+  const hasViolations = !isTitleValid || !isDescriptionValid || (issueNumber && !isIssueOpen) || !isLockfileChangeValid;
+
+  if (!hasViolations) {
+    // All checks passed — update existing comment to reflect resolution, if one exists.
+    const existingComment = await findBotComment({ github, context });
+    if (existingComment) {
+      await github.rest.issues.updateComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: existingComment.id,
+        body: `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, all PR guideline checks have passed. Thank you for your contribution! :tada:`,
+      });
+    }
+    return;
+  }
+
+  let body = `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n`
+    + `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
   if (!isTitleValid) {
     body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
   }
@@ -89,12 +141,10 @@ const checkPr = async ({ github, context }) => {
     body += `- This PR contains changes to \`package-lock.json\` without corresponding \`package.json\` changes. Please revert the \`package-lock.json\` changes.\n`;
   }
   body += '\nPlease address the above before we proceed to review your PR.';
-  await github.rest.issues.createComment({
-    issue_number: context.issue.number,
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    body,
-  });
+
+  await upsertComment({ github, context, body });
+
+  core.setFailed('PR does not follow contribution guidelines. See the comment on the PR for details.');
 };
 
 module.exports = checkPr;

--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -125,8 +125,9 @@ const checkPr = async ({ github, context, core }) => {
     return;
   }
 
-  let body = `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n`
-    + `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+  let body =
+    `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n` +
+    `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
   if (!isTitleValid) {
     body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
   }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
       - reopened
+      - edited
+      - synchronize
     branches:
       - master
 
@@ -18,4 +20,4 @@ jobs:
         with:
           script: |
             const script = require('./.github/scripts/check-pr.js')
-            await script({ github, context })
+            await script({ github, context, core })

--- a/src/web/app/components/copy-session-modal/__snapshots__/copy-session-modal.component.spec.ts.snap
+++ b/src/web/app/components/copy-session-modal/__snapshots__/copy-session-modal.component.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`CopySessionModalComponent > should snap with default fields 1`] = `
   courseCandidates={[Function Array]}
   newFeedbackSessionName=""
   sessionToCopyCourseId=""
+  sessionToCopyName=""
 >
   <div
     class="modal-header"
@@ -64,6 +65,16 @@ exports[`CopySessionModalComponent > should snap with default fields 1`] = `
             />
              The field "Name for copied session" should not be empty. 
           </div>
+          <div
+            class="invalid-field"
+            hidden=""
+          >
+            <i
+              aria-hidden="true"
+              class="fa fa-exclamation-circle"
+            />
+             The session name must be different if you are copying to the same course. 
+          </div>
           <span>
             64 characters left
           </span>
@@ -99,6 +110,7 @@ exports[`CopySessionModalComponent > should snap with some session and courses c
   courseCandidates={[Function Array]}
   newFeedbackSessionName={[Function String]}
   sessionToCopyCourseId={[Function String]}
+  sessionToCopyName=""
 >
   <div
     class="modal-header"
@@ -154,6 +166,16 @@ exports[`CopySessionModalComponent > should snap with some session and courses c
               class="fa fa-exclamation-circle"
             />
              The field "Name for copied session" should not be empty. 
+          </div>
+          <div
+            class="invalid-field"
+            hidden=""
+          >
+            <i
+              aria-hidden="true"
+              class="fa fa-exclamation-circle"
+            />
+             The session name must be different if you are copying to the same course. 
           </div>
           <span>
             52 characters left

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.html
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.html
@@ -29,6 +29,13 @@
           <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
           The field "Name for copied session" should not be empty.
         </div>
+        <div
+          [hidden]="!isNewFeedbackSessionNameSameAsSource"
+          class="invalid-field"
+        >
+          <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+          The session name must be different if you are copying to the same course.
+        </div>
         <span>{{ FEEDBACK_SESSION_NAME_MAX_LENGTH - newFeedbackSessionName.length }} characters left</span>
       </div>
       @for (course of courseCandidates; track course) {
@@ -61,7 +68,7 @@
     type="button"
     class="btn btn-primary"
     (click)="copy()"
-    [disabled]="!isNewFeedbackSessionNameValid || copyToCourseSet.size < 1"
+    [disabled]="!isNewFeedbackSessionNameValid || copyToCourseSet.size < 1 || isNewFeedbackSessionNameSameAsSource"
   >
     Copy
   </button>

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.spec.ts
@@ -144,4 +144,13 @@ describe('CopySessionModalComponent', () => {
     component.select(courseId);
     expect(component.copyToCourseSet.has(courseId)).toBe(false);
   });
+
+  it('should detect when new session name is identical to source session name while copying to same course', () => {
+    component.newFeedbackSessionName = feedbackSessionToCopy.feedbackSessionName;
+    component.sessionToCopyName = feedbackSessionToCopy.feedbackSessionName;
+    component.sessionToCopyCourseId = courseSessionIn.courseId;
+    component.copyToCourseSet.add(courseSessionIn.courseId);
+
+    expect(component.isNewFeedbackSessionNameSameAsSource).toBe(true);
+  });
 });

--- a/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
+++ b/src/web/app/components/copy-session-modal/copy-session-modal.component.ts
@@ -26,6 +26,9 @@ export class CopySessionModalComponent {
   @Input()
   sessionToCopyCourseId = '';
 
+  @Input()
+  sessionToCopyName = '';
+
   newFeedbackSessionName = '';
   copyToCourseSet: Set<string> = new Set<string>();
 
@@ -38,6 +41,14 @@ export class CopySessionModalComponent {
    */
   get isNewFeedbackSessionNameValid(): boolean {
     return this.newFeedbackSessionName.trim().length > 0;
+  }
+
+  /**
+   * Whether the new session name is identical to the source session name when copying to the same course.
+   */
+  get isNewFeedbackSessionNameSameAsSource(): boolean {
+    return this.copyToCourseSet.has(this.sessionToCopyCourseId) &&
+      this.newFeedbackSessionName.trim().toLowerCase() === this.sessionToCopyName.trim().toLowerCase();
   }
 
   /**

--- a/src/web/app/components/sessions-table/sessions-table.component.ts
+++ b/src/web/app/components/sessions-table/sessions-table.component.ts
@@ -387,6 +387,7 @@ export class SessionsTableComponent implements OnInit {
     const modalRef: NgbModalRef = this.ngbModal.open(CopySessionModalComponent);
     const model: SessionsTableRowModel = this.sessionsTableRowModelsVar[rowIndex];
     modalRef.componentInstance.newFeedbackSessionName = model.feedbackSession.feedbackSessionName;
+    modalRef.componentInstance.sessionToCopyName = model.feedbackSession.feedbackSessionName;
     modalRef.componentInstance.courseCandidates = this.courseCandidates;
     modalRef.componentInstance.sessionToCopyCourseId = model.feedbackSession.courseId;
 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -250,6 +250,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
             this.modifiedSession = {};
             const modalRef: NgbModalRef = this.ngbModal.open(CopySessionModalComponent);
             modalRef.componentInstance.newFeedbackSessionName = this.feedbackSessionName;
+            modalRef.componentInstance.sessionToCopyName = this.feedbackSessionName;
             modalRef.componentInstance.courseCandidates = courses.courses.map(
               (courseView: CourseView) => courseView.course,
             );


### PR DESCRIPTION
Fixes #12552. Prevents users from attempting to copy a session to the same course with the same name, displaying a helpful validation message inside the modal instead of failing and showing a server-side error toast.