### PR TITLE
[#13721] Remove section filtering when fetching results

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -136,9 +136,6 @@ public final class Const {
 
         public static final String FEEDBACK_RESPONSE_COMMENT_ID = "responsecommentid";
 
-        public static final String FEEDBACK_RESULTS_GROUPBYSECTION = "frgroupbysection";
-        public static final String IS_NO_SPECIFIC_SECTION = "isnospecificsection";
-
         public static final String PREVIEWAS = "previewas";
 
         public static final String USER_ID = "userid";

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1370,14 +1370,11 @@ public class Logic {
      * @param feedbackSession the feedback session
      * @param instructor the instructor requesting for the session result
      * @param questionId if not null, will only return partial bundle for the question
-     * @param sectionId if not null, will only return partial bundle for the section
      * @return the session result bundle
      */
     public SessionResultsBundle getSessionResults(
-            FeedbackSession feedbackSession, Instructor instructor,
-            @Nullable UUID questionId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
-        return feedbackResponsesLogic.getSessionResults(
-                feedbackSession, instructor, questionId, sectionId, isNoSpecificSection);
+            FeedbackSession feedbackSession, Instructor instructor, @Nullable UUID questionId) {
+        return feedbackResponsesLogic.getSessionResults(feedbackSession, instructor, questionId);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -580,7 +580,7 @@ public final class FeedbackResponsesLogic {
     }
 
     private SessionResultsBundle buildResultsBundle(
-            boolean isCourseWide, UUID sectionId, boolean isNoSpecificSection, User user,
+            boolean isCourseWide, User user,
             CourseRoster roster, List<FeedbackQuestion> relatedQuestions,
             List<FeedbackResponse> allResponses, boolean isPreviewResults) {
         List<FeedbackResponse> relatedResponses = new ArrayList<>();
@@ -684,7 +684,7 @@ public final class FeedbackResponsesLogic {
         if (isCourseWide && user instanceof Instructor instructor) {
             missingResponses = buildMissingResponses(
                     instructor, responseGiverVisibilityTable, responseRecipientVisibilityTable, relatedQuestions,
-                    existingResponses, roster, sectionId, isNoSpecificSection);
+                    existingResponses, roster);
         }
         RequestTracer.checkRemainingTime();
 
@@ -700,13 +700,10 @@ public final class FeedbackResponsesLogic {
      * @param feedbackSession the feedback session
      * @param instructor the instructor viewing the feedback session
      * @param questionId if not null, will only return partial bundle for the question
-     * @param sectionId if not null, will only return partial bundle for the section
-     * @param isNoSpecificSection true if the section is the default section
      * @return the session result bundle
      */
     public SessionResultsBundle getSessionResults(
-            FeedbackSession feedbackSession, Instructor instructor,
-            @Nullable UUID questionId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
+            FeedbackSession feedbackSession, Instructor instructor, @Nullable UUID questionId) {
 
         String courseId = feedbackSession.getCourseId();
         CourseRoster roster = new CourseRoster(
@@ -719,18 +716,15 @@ public final class FeedbackResponsesLogic {
 
         // load response(s)
         List<FeedbackResponse> allResponses;
-        // load all response for instructors and passively filter them later
         if (questionId == null) {
-            allResponses = getFeedbackResponsesForSessionInSection(
-                    feedbackSession, courseId, sectionId, isNoSpecificSection);
+            allResponses = frDb.getFeedbackResponsesForSession(feedbackSession, courseId);
         } else {
-            allResponses = getFeedbackResponsesForQuestionInSection(questionId, sectionId, isNoSpecificSection);
+            allResponses = frDb.getResponsesForQuestion(questionId);
         }
 
         RequestTracer.checkRemainingTime();
 
-        return buildResultsBundle(true, sectionId, isNoSpecificSection,
-                instructor, roster, allQuestions, allResponses, false);
+        return buildResultsBundle(true, instructor, roster, allQuestions, allResponses, false);
     }
 
     /**
@@ -769,7 +763,7 @@ public final class FeedbackResponsesLogic {
             allResponses.addAll(viewableResponses);
         }
 
-        return buildResultsBundle(false, null, false, user, roster, allQuestions, allResponses, isPreviewResults);
+        return buildResultsBundle(false, user, roster, allQuestions, allResponses, isPreviewResults);
     }
 
     /**
@@ -806,14 +800,12 @@ public final class FeedbackResponsesLogic {
      * @param relatedQuestions the relevant questions
      * @param existingResponses existing responses
      * @param courseRoster the course roster
-     * @param sectionId if not null, will only build missing responses for the section
      * @return a list of missing responses for the session.
      */
     private List<FeedbackMissingResponse> buildMissingResponses(
             Instructor instructor, Map<UUID, Boolean> responseGiverVisibilityTable,
             Map<UUID, Boolean> responseRecipientVisibilityTable, List<FeedbackQuestion> relatedQuestions,
-            List<FeedbackResponse> existingResponses, CourseRoster courseRoster, @Nullable UUID sectionId,
-            boolean isNoSpecificSection) {
+            List<FeedbackResponse> existingResponses, CourseRoster courseRoster) {
 
         // get all possible giver recipient pairs
         Map<FeedbackQuestion, Map<ResponseGiver, Set<ResponseRecipient>>> questionCompleteGiverRecipientMap =
@@ -849,21 +841,6 @@ public final class FeedbackResponsesLogic {
                 ResponseGiver giver = giverRecipientEntry.getKey();
 
                 for (ResponseRecipient recipient : giverRecipientEntry.getValue()) {
-                    UUID giverSectionId = giver.getSectionId();
-                    UUID recipientSectionId = recipient.getSectionId();
-                    if (isNoSpecificSection && giverSectionId != null && recipientSectionId != null) {
-                        // if isNoSpecificSection is true, either giver or recipient needs
-                        // to not have a section
-                        continue;
-                    }
-
-                    if (sectionId != null
-                            && !sectionId.equals(giverSectionId)
-                            && !sectionId.equals(recipientSectionId)) {
-                        // if sectionId is specified, either giver or recipient needs to be in the section
-                        continue;
-                    }
-
                     // recipient
                     FeedbackMissingResponse missingResponse = new FeedbackMissingResponse(
                             correspondingQuestion,
@@ -1061,75 +1038,6 @@ public final class FeedbackResponsesLogic {
     List<FeedbackResponse> getFeedbackResponsesForSession(
             FeedbackSession feedbackSession, String courseId) {
         return frDb.getFeedbackResponsesForSession(feedbackSession, courseId);
-    }
-
-    /**
-     * Gets all responses given to/from a section in a feedback session in a course.
-     *
-     * @param feedbackSession the session
-     * @param courseId the course ID of the session
-     * @param sectionId if null, will retrieve all responses in the session
-     * @param isNoSpecificSection true if filtering for no specific section
-     * @return a list of responses
-     */
-    public List<FeedbackResponse> getFeedbackResponsesForSessionInSection(
-            FeedbackSession feedbackSession, String courseId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
-        List<FeedbackResponse> responses = frDb.getFeedbackResponsesForSession(feedbackSession, courseId);
-        if (sectionId == null && !isNoSpecificSection) {
-            return responses;
-        } else {
-            return filterResponsesBySection(responses, sectionId, isNoSpecificSection);
-        }
-    }
-
-    /**
-     * Gets all responses given to/from a section for a question.
-     *
-     * @param feedbackQuestionId the question UUID
-     * @param sectionId if null, will retrieve all responses for the question
-     * @param isNoSpecificSection true if filtering for no specific section
-     * @return a list of responses
-     */
-    public List<FeedbackResponse> getFeedbackResponsesForQuestionInSection(
-            UUID feedbackQuestionId, @Nullable UUID sectionId, boolean isNoSpecificSection) {
-        List<FeedbackResponse> responses = frDb.getResponsesForQuestion(feedbackQuestionId);
-        if (sectionId == null && !isNoSpecificSection) {
-            return responses;
-        } else {
-            return filterResponsesBySection(responses, sectionId, isNoSpecificSection);
-        }
-    }
-
-    private List<FeedbackResponse> filterResponsesBySection(List<FeedbackResponse> responses,
-            UUID sectionId, boolean isNoSpecificSection) {
-        List<FeedbackResponse> filteredResponses = new ArrayList<>();
-        for (FeedbackResponse response : responses) {
-            ResponseGiver giver = response.getGiver();
-            ResponseRecipient recipient = response.getRecipient();
-
-            UUID giverSectionId = giver.getSectionId();
-            UUID recipientSectionId = recipient.getSectionId();
-
-            boolean isGiverInSection;
-            if (isNoSpecificSection) {
-                isGiverInSection = giverSectionId == null;
-            } else {
-                isGiverInSection = giverSectionId != null && giverSectionId.equals(sectionId);
-            }
-
-            boolean isRecipientInSection;
-            if (isNoSpecificSection) {
-                isRecipientInSection = recipientSectionId == null;
-            } else {
-                isRecipientInSection = recipientSectionId != null && recipientSectionId.equals(sectionId);
-            }
-
-            if (isGiverInSection || isRecipientInSection) {
-                filteredResponses.add(response);
-            }
-        }
-
-        return filteredResponses;
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/GetCourseSessionResultsAction.java
@@ -1,6 +1,5 @@
 package teammates.ui.webapi;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import teammates.common.datatransfer.SessionResultsBundle;
@@ -26,9 +25,6 @@ public class GetCourseSessionResultsAction extends LoggedInAction {
         UUID feedbackSessionId = getUuidRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ID);
 
         UUID questionId = getNullableUuidRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        UUID selectedSection = getNullableUuidRequestParamValue(Const.ParamsNames.FEEDBACK_RESULTS_GROUPBYSECTION);
-        Optional<Boolean> isNoSpecificSection =
-                getNullableBooleanRequestParamValue(Const.ParamsNames.IS_NO_SPECIFIC_SECTION);
 
         FeedbackSession feedbackSession = logic.getFeedbackSession(feedbackSessionId);
         if (feedbackSession == null) {
@@ -36,8 +32,7 @@ public class GetCourseSessionResultsAction extends LoggedInAction {
         }
 
         Instructor instructor = getInstructorFromRequest(feedbackSession.getCourseId());
-        SessionResultsBundle bundle = logic.getSessionResults(feedbackSession, instructor,
-                questionId, selectedSection, isNoSpecificSection.orElse(false));
+        SessionResultsBundle bundle = logic.getSessionResults(feedbackSession, instructor, questionId);
 
         return new JsonResult(SessionResultsData.init(bundle));
     }

--- a/src/test/java/teammates/ui/webapi/GetCourseSessionResultsActionIT.java
+++ b/src/test/java/teammates/ui/webapi/GetCourseSessionResultsActionIT.java
@@ -51,7 +51,7 @@ public class GetCourseSessionResultsActionIT extends BaseActionIT<GetCourseSessi
         SessionResultsData output = (SessionResultsData) result.getOutput();
 
         SessionResultsData expected = inTransaction(() -> SessionResultsData.init(logic.getSessionResults(
-                feedbackSession, instructor, null, null, false)));
+                feedbackSession, instructor, null)));
 
         assertEquals(expected.getQuestions().size(), output.getQuestions().size());
     }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -402,17 +402,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
             return;
           }
           const responses: QuestionOutput = resp.questions[0];
-          const missingRespMap: Map<string, ResponseOutput> = new Map();
-          const tmpMap: Map<string, ResponseOutput> = new Map();
-          responses.allResponses.forEach((response: ResponseOutput) =>
-            response.isMissingResponse
-              ? missingRespMap.set(response.responseId, response)
-              : tmpMap.set(response.responseId, response),
-          );
-          tmpMap.forEach((response: ResponseOutput) => this.questionsModel[questionId].responses.push(response));
-          missingRespMap.forEach((response: ResponseOutput) =>
-            this.questionsModel[questionId].responses.push(response),
-          );
+          this.questionsModel[questionId].responses.push(...responses.allResponses);
           this.questionsModel[questionId].statistics = responses.questionStatistics;
           this.preprocessComments(responses.allResponses, responses.feedbackQuestion.showResponsesTo);
           this.questionsModel[questionId].errorMessage = '';

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit, ViewChild, inject } from '@angular/core';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 import { of } from 'rxjs';
-import { concatMap, finalize } from 'rxjs/operators';
+import { finalize } from 'rxjs/operators';
 import { InstructorSessionNoResponsePanelComponent } from './instructor-session-no-response-panel.component';
 import { InstructorSessionResultGqrViewComponent } from './instructor-session-result-gqr-view.component';
 import { InstructorSessionResultGrqViewComponent } from './instructor-session-result-grq-view.component';
@@ -19,6 +19,7 @@ import {
 } from './instructor-session-tab.model';
 import { CourseService } from '../../../services/course.service';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
+import { FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { FeedbackSessionActionsService } from '../../../services/feedback-session-actions.service';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { FileSaveService } from '../../../services/file-save.service';
@@ -30,8 +31,6 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
-  ContributionStatistics,
-  ContributionStatisticsEntry,
   FeedbackQuestions,
   FeedbackSession,
   FeedbackSessionView,
@@ -93,6 +92,7 @@ export class InstructorSessionResultPageComponent implements OnInit {
   private readonly feedbackSessionsService = inject(FeedbackSessionsService);
   private readonly feedbackSessionActionsService = inject(FeedbackSessionActionsService);
   private readonly feedbackQuestionsService = inject(FeedbackQuestionsService);
+  private readonly feedbackResponsesService = inject(FeedbackResponsesService);
   private readonly courseService = inject(CourseService);
   private readonly fileSaveService = inject(FileSaveService);
   private readonly studentService = inject(StudentService);
@@ -389,47 +389,32 @@ export class InstructorSessionResultPageComponent implements OnInit {
       return;
     }
 
-    const missingRespMap: Map<string, ResponseOutput> = new Map();
-    const tmpMap: Map<string, ResponseOutput> = new Map();
-
-    if (this.hasSectionsLoadingFailed) {
-      // the page would not render properly
-      return;
-    }
-    of(...Object.keys(this.sectionsModel))
-      .pipe(
-        concatMap((sectionId: string) => {
-          return this.feedbackSessionsService.getCourseSessionResults({
-            questionId,
-            feedbackSessionId: this.session.feedbackSessionId,
-            groupBySection: this.isNoSpecificSection(sectionId) ? undefined : sectionId,
-            isNoSpecificSection: this.isNoSpecificSection(sectionId),
-          });
-        }),
-      )
+    this.feedbackSessionsService
+      .getCourseSessionResults({
+        questionId,
+        feedbackSessionId: this.session.feedbackSessionId,
+      })
       .subscribe({
         next: (resp: SessionResults) => {
           if (!resp.questions.length) {
+            this.questionsModel[questionId].errorMessage = '';
+            this.questionsModel[questionId].hasPopulated = true;
             return;
           }
           const responses: QuestionOutput = resp.questions[0];
+          const missingRespMap: Map<string, ResponseOutput> = new Map();
+          const tmpMap: Map<string, ResponseOutput> = new Map();
           responses.allResponses.forEach((response: ResponseOutput) =>
             response.isMissingResponse
               ? missingRespMap.set(response.responseId, response)
               : tmpMap.set(response.responseId, response),
           );
-          this.questionsModel[questionId].statistics = this.mergeStatistics(
-            this.questionsModel[questionId].statistics,
-            responses.questionStatistics,
-          );
-
-          this.preprocessComments(responses.allResponses, responses.feedbackQuestion.showResponsesTo);
-        },
-        complete: () => {
           tmpMap.forEach((response: ResponseOutput) => this.questionsModel[questionId].responses.push(response));
           missingRespMap.forEach((response: ResponseOutput) =>
             this.questionsModel[questionId].responses.push(response),
           );
+          this.questionsModel[questionId].statistics = responses.questionStatistics;
+          this.preprocessComments(responses.allResponses, responses.feedbackQuestion.showResponsesTo);
           this.questionsModel[questionId].errorMessage = '';
           this.questionsModel[questionId].hasPopulated = true;
         },
@@ -461,21 +446,25 @@ export class InstructorSessionResultPageComponent implements OnInit {
     this.feedbackSessionsService
       .getCourseSessionResults({
         feedbackSessionId: this.session.feedbackSessionId,
-        groupBySection: this.isNoSpecificSection(sectionId) ? undefined : sectionId,
-        isNoSpecificSection: this.isNoSpecificSection(sectionId),
       })
       .subscribe({
         next: (resp: SessionResults) => {
-          this.sectionsModel[sectionId].questions = resp.questions;
-
           // sort questions by question number
           resp.questions.sort(
             (a: QuestionOutput, b: QuestionOutput) =>
               a.feedbackQuestion.questionNumber - b.feedbackQuestion.questionNumber,
           );
           resp.questions.forEach((question: QuestionOutput) => {
+            question.allResponses = question.allResponses.filter((response: ResponseOutput) =>
+              this.feedbackResponsesService.isFeedbackResponsesDisplayedOnSection(
+                response,
+                sectionId,
+                InstructorSessionResultSectionType.EITHER,
+              ),
+            );
             this.preprocessComments(question.allResponses, question.feedbackQuestion.showResponsesTo);
           });
+          this.sectionsModel[sectionId].questions = resp.questions;
         },
         complete: () => {
           this.sectionsModel[sectionId].hasPopulated = true;
@@ -494,10 +483,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
 
   private getSectionName(sectionId: string): string {
     return this.sectionsModel[sectionId]?.section.sectionName ?? sectionId;
-  }
-
-  private isNoSpecificSection(sectionId: string): boolean {
-    return sectionId === NO_SPECIFIC_SECTION_ID;
   }
 
   /**
@@ -743,37 +728,6 @@ export class InstructorSessionResultPageComponent implements OnInit {
           this.statusMessageService.showErrorToast(resp.error.message);
         },
       });
-  }
-
-  /**
-   * Merges the existing statistics with the new statistics.
-   *
-   * Since only statistics for contribution question is calculated on the backend,
-   * the merging logic is based on contribution question statistics only.
-   */
-  private mergeStatistics(prevStats: string, newStats: string): string {
-    if (prevStats === '') {
-      return newStats;
-    }
-    if (newStats === '') {
-      return prevStats;
-    }
-
-    // Only statistics for contribution question is calculated on the backend.
-    const prevStatsJSON: ContributionStatistics = JSON.parse(prevStats);
-    const newStatsJSON: ContributionStatistics = JSON.parse(newStats);
-    for (const email of Object.keys(newStatsJSON.results)) {
-      const newStatsEntryForEmail: ContributionStatisticsEntry = newStatsJSON.results[email];
-      const { claimed }: { claimed: number } = newStatsEntryForEmail;
-      const { perceived }: { perceived: number } = newStatsEntryForEmail;
-      if (claimed < 0 && perceived < 0) {
-        continue;
-      }
-      // If new entry has submitted stats, overwrite the old data
-      prevStatsJSON.results[email] = newStatsEntryForEmail;
-    }
-
-    return JSON.stringify(prevStatsJSON);
   }
 
   navigateToIndividualSessionResultPage(): void {

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, inject } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
-import { combineLatest, Observable } from 'rxjs';
+import { forkJoin, Observable } from 'rxjs';
 import { finalize, map, mergeMap, tap } from 'rxjs/operators';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorCommentEventData, InstructorCommentService } from '../../../services/instructor-comment.service';
@@ -50,11 +50,11 @@ interface SessionTab {
   providers: [CommentsToCommentTableModelPipe],
 })
 export class InstructorStudentRecordsPageComponent implements OnInit {
-  private feedbackSessionsService = inject(FeedbackSessionsService);
-  private studentService = inject(StudentService);
-  private tableComparatorService = inject(TableComparatorService);
-  private statusMessageService = inject(StatusMessageService);
-  private commentService = inject(InstructorCommentService);
+  private readonly feedbackSessionsService = inject(FeedbackSessionsService);
+  private readonly studentService = inject(StudentService);
+  private readonly tableComparatorService = inject(TableComparatorService);
+  private readonly statusMessageService = inject(StatusMessageService);
+  private readonly commentService = inject(InstructorCommentService);
 
   @Input({ required: true }) courseId!: string;
   @Input({ required: true }) userId!: string;
@@ -81,20 +81,20 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
     this.hasStudentResultsLoadingFailed = false;
     this.isStudentResultsLoading = true;
 
-    combineLatest({
+    forkJoin({
       feedbackSession: this.getFeedbackSessions(courseId),
       student: this.loadStudentRecords(studentId),
     })
       .pipe(
-        mergeMap(({ feedbackSession, student }: { feedbackSession: FeedbackSession; student: Student }) => {
-          return this.getFeedbackSessionResults(feedbackSession, student.sectionId);
+        mergeMap(({ feedbackSession }) => {
+          return this.getFeedbackSessionResults(feedbackSession);
         }),
         finalize(() => {
           this.isStudentResultsLoading = false;
         }),
       )
       .subscribe({
-        next: ({ feedbackSession, results }: { results: SessionResults; feedbackSession: FeedbackSession }) => {
+        next: ({ feedbackSession, results }) => {
           this.sessionTabs.push(this.createSessionTab(feedbackSession, results));
           results.questions.forEach((questions: QuestionOutput) => {
             return this.preprocessComments(
@@ -139,17 +139,14 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
   }
 
   /**
-   * Fetches the full detail result of the given feedback session in the current course
-   * grouped by the student's section ID.
+   * Fetches the full detail result of the given feedback session in the current course.
    */
   private getFeedbackSessionResults(
     feedbackSession: FeedbackSession,
-    groupBySectionId: string,
   ): Observable<{ results: SessionResults; feedbackSession: FeedbackSession }> {
     return this.feedbackSessionsService
       .getCourseSessionResults({
         feedbackSessionId: feedbackSession.feedbackSessionId,
-        groupBySection: groupBySectionId,
       })
       .pipe(
         map((results: SessionResults) => {

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, inject } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
-import { forkJoin, Observable } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { finalize, map, mergeMap, tap } from 'rxjs/operators';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { InstructorCommentEventData, InstructorCommentService } from '../../../services/instructor-comment.service';
@@ -81,7 +81,7 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
     this.hasStudentResultsLoadingFailed = false;
     this.isStudentResultsLoading = true;
 
-    forkJoin({
+    combineLatest({
       feedbackSession: this.getFeedbackSessions(courseId),
       student: this.loadStudentRecords(studentId),
     })

--- a/src/web/services/feedback-sessions.service.spec.ts
+++ b/src/web/services/feedback-sessions.service.spec.ts
@@ -116,19 +116,6 @@ describe('FeedbackSessionsService', () => {
     expect(spyHttpRequestService.get).toHaveBeenCalledWith(ResourceEndpoints.COURSE_SESSION_RESULTS, paramMap);
   });
 
-  it('should call get with section ID when grouping course feedback session results by section', () => {
-    const paramMap: Record<string, string> = {
-      fsid: '248b1915-5f52-4730-b5b2-3ec25a2caabc',
-      frgroupbysection: '1b5d916f-f81d-4bc9-a6bf-6f9f6f81f102',
-    };
-
-    service.getCourseSessionResults({
-      feedbackSessionId: paramMap['fsid'],
-      groupBySection: paramMap['frgroupbysection'],
-    });
-    expect(spyHttpRequestService.get).toHaveBeenCalledWith(ResourceEndpoints.COURSE_SESSION_RESULTS, paramMap);
-  });
-
   it('should call get when retrieving user feedback session results', () => {
     const paramMap: Record<string, string> = {
       fsid: '248b1915-5f52-4730-b5b2-3ec25a2caabc',

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -33,7 +33,6 @@ import {
   FeedbackSessionUpdateRequest,
   Intent,
 } from '../types/api-request';
-import { NO_SPECIFIC_SECTION_ID } from '../app/pages-instructor/instructor-session-result-page/instructor-session-tab.model';
 
 /**
  * Handles sessions related logic provision.
@@ -360,8 +359,6 @@ export class FeedbackSessionsService {
 
   /**
    * Download session results.
-   *
-   * <p>When provided, {@code groupBySection} should be a section ID (UUID), not section name.
    */
   downloadSessionResults(
     feedbackSessionId: string,
@@ -374,16 +371,9 @@ export class FeedbackSessionsService {
       sectionNameForCsv?: string;
     },
   ): Observable<string> {
-    const isNoSpecificSection = sectionOptions?.groupBySectionId
-      ? sectionOptions.groupBySectionId === NO_SPECIFIC_SECTION_ID
-      : undefined;
-    const groupBySectionId =
-      sectionOptions?.groupBySectionId === NO_SPECIFIC_SECTION_ID ? undefined : sectionOptions?.groupBySectionId;
     return this.getCourseSessionResults({
       feedbackSessionId,
       questionId,
-      groupBySection: groupBySectionId,
-      isNoSpecificSection: isNoSpecificSection,
     }).pipe(
       map((results: SessionResults) =>
         this.sessionResultCsvService.getCsvForSessionResult(
@@ -400,29 +390,14 @@ export class FeedbackSessionsService {
 
   /**
    * Retrieves course-wide results for a feedback session.
-   *
-   * <p>When provided, {@code groupBySection} should be a section ID (UUID), not section name.
    */
-  getCourseSessionResults(queryParams: {
-    feedbackSessionId: string;
-    questionId?: string;
-    groupBySection?: string;
-    isNoSpecificSection?: boolean;
-  }): Observable<SessionResults> {
+  getCourseSessionResults(queryParams: { feedbackSessionId: string; questionId?: string }): Observable<SessionResults> {
     const paramMap: Record<string, string> = {
       fsid: queryParams.feedbackSessionId,
     };
 
     if (queryParams.questionId) {
       paramMap['questionid'] = queryParams.questionId;
-    }
-
-    if (queryParams.groupBySection) {
-      paramMap['frgroupbysection'] = queryParams.groupBySection;
-    }
-
-    if (queryParams.isNoSpecificSection !== undefined) {
-      paramMap['isnospecificsection'] = queryParams.isNoSpecificSection.toString();
     }
 
     return this.httpRequestService.get(ResourceEndpoints.COURSE_SESSION_RESULTS, paramMap);


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #13721

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Findings from load testing showed that the bottlenecks were
1. multiple concurrent http requests (up to 200)
2. page rendering thousands of rows

The actual fetching of data was more performant when not filtered by section.

This also simplifies implementation significantly. While there is still a need to find a solution to performance problems for large courses (>1000 students), the solution would involve redesigning the page to support viewing such large courses rather than backend optimisations.