### PR TITLE
[#12547] Support empty weights for MCQ and MSQ questions

### DIFF
--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -1,5 +1,7 @@
 // PR checks for TEAMMATES contribution guidelines; used by .github/workflows/pr.yml.
 
+const BOT_COMMENT_MARKER = '<!-- teammates-pr-checker -->';
+
 const getOrphanLockfiles = (changedPaths) => {
   const dirOf = (filePath) => {
     const idx = filePath.lastIndexOf('/');
@@ -25,7 +27,43 @@ const getOrphanLockfiles = (changedPaths) => {
     .map((dir) => (dir === '' ? 'package-lock.json' : `${dir}/package-lock.json`));
 };
 
-const checkPr = async ({ github, context }) => {
+const findBotComment = async ({ github, context }) => {
+  let page = 1;
+  while (true) {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      per_page: 100,
+      page,
+    });
+    const botComment = comments.find((c) => c.body.includes(BOT_COMMENT_MARKER));
+    if (botComment) return botComment;
+    if (comments.length < 100) return null;
+    page += 1;
+  }
+};
+
+const upsertComment = async ({ github, context, body }) => {
+  const existingComment = await findBotComment({ github, context });
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingComment.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      issue_number: context.issue.number,
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      body,
+    });
+  }
+};
+
+const checkPr = async ({ github, context, core }) => {
   const pr = await github.rest.pulls.get({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -69,12 +107,26 @@ const checkPr = async ({ github, context }) => {
       issue_number: issueNumber,
     });
     isIssueOpen = issue.data.state === 'open';
-    if (isTitleValid && isDescriptionValid && isIssueOpen && isLockfileChangeValid) {
-      return;
-    }
   }
-  let body = `Hi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!
-              However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+
+  const hasViolations = !isTitleValid || !isDescriptionValid || (issueNumber && !isIssueOpen) || !isLockfileChangeValid;
+
+  if (!hasViolations) {
+    // All checks passed — update existing comment to reflect resolution, if one exists.
+    const existingComment = await findBotComment({ github, context });
+    if (existingComment) {
+      await github.rest.issues.updateComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: existingComment.id,
+        body: `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, all PR guideline checks have passed. Thank you for your contribution! :tada:`,
+      });
+    }
+    return;
+  }
+
+  let body = `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n`
+    + `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
   if (!isTitleValid) {
     body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
   }
@@ -89,12 +141,10 @@ const checkPr = async ({ github, context }) => {
     body += `- This PR contains changes to \`package-lock.json\` without corresponding \`package.json\` changes. Please revert the \`package-lock.json\` changes.\n`;
   }
   body += '\nPlease address the above before we proceed to review your PR.';
-  await github.rest.issues.createComment({
-    issue_number: context.issue.number,
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    body,
-  });
+
+  await upsertComment({ github, context, body });
+
+  core.setFailed('PR does not follow contribution guidelines. See the comment on the PR for details.');
 };
 
 module.exports = checkPr;

--- a/.github/scripts/check-pr.js
+++ b/.github/scripts/check-pr.js
@@ -125,8 +125,9 @@ const checkPr = async ({ github, context, core }) => {
     return;
   }
 
-  let body = `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n`
-    + `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
+  let body =
+    `${BOT_COMMENT_MARKER}\nHi @${pr.data.user.login}, thank you for your interest in contributing to TEAMMATES!\n` +
+    `However, your PR does not appear to follow our [contributing guidelines](https://teammates.github.io/teammates/contributing/guidelines.html):\n\n`;
   if (!isTitleValid) {
     body += '- Title must start with the issue number the PR is fixing in square brackets, e.g. `[#<issue-number>]`\n';
   }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
       - reopened
+      - edited
+      - synchronize
     branches:
       - master
 
@@ -18,4 +20,4 @@ jobs:
         with:
           script: |
             const script = require('./.github/scripts/check-pr.js')
-            await script({ github, context })
+            await script({ github, context, core })

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.html
@@ -21,7 +21,7 @@
         <div class="form-check form-check-inline">
           <label
             class="form-check-label ngb-tooltip-class fw-bold"
-            ngbTooltip="Assign weights to the choices for calculating statistics."
+            ngbTooltip="Assign weights to the choices for calculating statistics. Leave a weight field blank to indicate no numerical weight for that choice."
             container="body"
           >
             <input

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-question-edit-details-form.component.ts
@@ -53,7 +53,7 @@ export class McqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
       return;
     }
 
-    const newWeights: number[] = this.model.mcqWeights.slice();
+    const newWeights: (number | null)[] = this.model.mcqWeights.slice();
     const newOptions: string[] = this.model.mcqChoices.slice();
     moveItemInArray(newOptions, event.previousIndex, event.currentIndex);
     moveItemInArray(newWeights, event.previousIndex, event.currentIndex);
@@ -72,7 +72,7 @@ export class McqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
     newOptions.push('');
     fieldsToUpdate['mcqChoices'] = newOptions;
     if (this.model.hasAssignedWeights) {
-      const newWeights: number[] = this.model.mcqWeights.slice();
+      const newWeights: (number | null)[] = this.model.mcqWeights.slice();
       newWeights.push(0);
       fieldsToUpdate['mcqWeights'] = newWeights;
     }
@@ -88,7 +88,7 @@ export class McqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
     newOptions.splice(event, 1);
     fieldsToUpdate['mcqChoices'] = newOptions;
     if (this.model.hasAssignedWeights) {
-      const newWeights: number[] = this.model.mcqWeights.slice();
+      const newWeights: (number | null)[] = this.model.mcqWeights.slice();
       newWeights.splice(event, 1);
       fieldsToUpdate['mcqWeights'] = newWeights;
     }
@@ -107,8 +107,8 @@ export class McqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
   /**
    * Displays new Mcq weight at specified index.
    */
-  onMcqWeightEntered(event: number, index: number): void {
-    const newWeights: number[] = this.model.mcqWeights.slice();
+  onMcqWeightEntered(event: number | null, index: number): void {
+    const newWeights: (number | null)[] = this.model.mcqWeights.slice();
     newWeights[index] = event;
     this.triggerModelChange('mcqWeights', newWeights);
   }

--- a/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.html
@@ -5,7 +5,7 @@
         <div class="form-check form-check-inline">
           <label
             class="form-check-label ngb-tooltip-class fw-bold"
-            ngbTooltip="Assign weights to the choices for calculating statistics."
+            ngbTooltip="Assign weights to the choices for calculating statistics. Leave a weight field blank to indicate no numerical weight for that choice."
             container="body"
           >
             <input

--- a/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/msq-question-edit-details-form.component.ts
@@ -56,7 +56,7 @@ export class MsqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
       return;
     }
 
-    const newWeights: number[] = this.model.msqWeights.slice();
+    const newWeights: (number | null)[] = this.model.msqWeights.slice();
     const newOptions: string[] = this.model.msqChoices.slice();
     moveItemInArray(newOptions, event.previousIndex, event.currentIndex);
     moveItemInArray(newWeights, event.previousIndex, event.currentIndex);
@@ -69,8 +69,8 @@ export class MsqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
   /**
    * Displays new Msq weight at specified index.
    */
-  onMsqWeightEntered(event: number, index: number): void {
-    const newWeights: number[] = this.model.msqWeights.slice();
+  onMsqWeightEntered(event: number | null, index: number): void {
+    const newWeights: (number | null)[] = this.model.msqWeights.slice();
     newWeights[index] = event;
     this.triggerModelChange('msqWeights', newWeights);
   }
@@ -83,7 +83,7 @@ export class MsqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
     newOptions.push('');
     const fieldsToUpdate: Partial<FeedbackMsqQuestionDetails> = { msqChoices: newOptions };
     if (this.model.hasAssignedWeights) {
-      const newWeights: number[] = this.model.msqWeights.slice();
+      const newWeights: (number | null)[] = this.model.msqWeights.slice();
       newWeights.push(0);
       fieldsToUpdate.msqWeights = newWeights;
     }
@@ -98,7 +98,7 @@ export class MsqQuestionEditDetailsFormComponent extends QuestionEditDetailsForm
     newOptions.splice(event, 1);
     const fieldsToUpdate: Partial<FeedbackMsqQuestionDetails> = { msqChoices: newOptions };
     if (this.model.hasAssignedWeights) {
-      const newWeights: number[] = this.model.msqWeights.slice();
+      const newWeights: (number | null)[] = this.model.msqWeights.slice();
       newWeights.splice(event, 1);
       fieldsToUpdate.msqWeights = newWeights;
     }

--- a/src/web/app/components/question-types/question-edit-details-form/weight-field/weight-field.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/weight-field/weight-field.component.ts
@@ -14,15 +14,15 @@ export class WeightFieldComponent {
   isEditable = false;
 
   @Input()
-  weight = 1;
+  weight: number | null = null;
 
   @Output()
-  weightEntered: EventEmitter<number> = new EventEmitter();
+  weightEntered: EventEmitter<number | null> = new EventEmitter();
 
   /**
    * Emit the weight entered to the parent component.
    */
-  onWeightEntered(weight: number): void {
+  onWeightEntered(weight: number | null): void {
     this.weightEntered.emit(weight);
   }
 }

--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -43,6 +43,10 @@ export class McqQuestionStatisticsComponent implements OnChanges {
     this.getTableData(stats);
   }
 
+  private getDisplayWeight(weight: number | null | undefined): string {
+    return weight === null || weight === undefined ? '-' : String(weight);
+  }
+
   private getTableData(stats: McqQuestionStatistics): void {
     this.summaryColumnsData = [
       { header: 'Choice', sortBy: SortBy.MCQ_CHOICE },
@@ -55,10 +59,10 @@ export class McqQuestionStatisticsComponent implements OnChanges {
     this.summaryRowsData = Object.keys(stats.answerFrequency).map((key: string) => {
       return [
         { value: key },
-        { value: stats.weightPerOption[key] === 0 ? 0 : stats.weightPerOption[key] || '-' },
+        { value: stats.weightPerOption[key] === 0 ? 0 : stats.weightPerOption[key] ?? '-' },
         { value: stats.answerFrequency[key] },
         { value: stats.percentagePerOption[key] },
-        { value: stats.weightedPercentagePerOption[key] === 0 ? 0 : stats.weightedPercentagePerOption[key] || '-' },
+        { value: stats.weightedPercentagePerOption[key] === 0 ? 0 : stats.weightedPercentagePerOption[key] ?? '-' },
       ];
     });
 
@@ -67,7 +71,7 @@ export class McqQuestionStatisticsComponent implements OnChanges {
       { header: 'Recipient Name', sortBy: SortBy.MCQ_RECIPIENT_NAME },
       ...Object.keys(stats.weightPerOption).map((key: string) => {
         return {
-          header: `${key}[${stats.weightPerOption[key].toFixed(2)}]`,
+          header: `${key} [${this.getDisplayWeight(stats.weightPerOption[key])}]`,
           sortBy: SortBy.MCQ_OPTION_SELECTED_TIMES,
         };
       }),
@@ -87,8 +91,8 @@ export class McqQuestionStatisticsComponent implements OnChanges {
             value: stats.perRecipientResponses[key].responses[option],
           };
         }),
-        { value: stats.perRecipientResponses[key].total.toFixed(2) },
-        { value: stats.perRecipientResponses[key].average.toFixed(2) },
+        { value: this.getDisplayWeight(stats.perRecipientResponses[key].total) },
+        { value: this.getDisplayWeight(stats.perRecipientResponses[key].average) },
       ];
     });
   }

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -45,6 +45,10 @@ export class MsqQuestionStatisticsComponent implements OnChanges {
     this.hasAnswers = stats.hasAnswers;
   }
 
+  private getDisplayWeight(weight: number | null | undefined): string {
+    return weight === null || weight === undefined ? '-' : String(weight);
+  }
+
   private getTableData(stats: MsqQuestionStatistics): void {
     this.summaryColumnsData = [
       { header: 'Choice', sortBy: SortBy.MSQ_CHOICE },
@@ -57,10 +61,10 @@ export class MsqQuestionStatisticsComponent implements OnChanges {
     this.summaryRowsData = Object.keys(stats.answerFrequency).map((key: string) => {
       return [
         { value: key },
-        { value: stats.weightPerOption[key] === 0 ? 0 : stats.weightPerOption[key] || '-' },
+        { value: stats.weightPerOption[key] === 0 ? 0 : stats.weightPerOption[key] ?? '-' },
         { value: stats.answerFrequency[key] },
         { value: stats.percentagePerOption[key] },
-        { value: stats.weightedPercentagePerOption[key] === 0 ? 0 : stats.weightedPercentagePerOption[key] || '-' },
+        { value: stats.weightedPercentagePerOption[key] === 0 ? 0 : stats.weightedPercentagePerOption[key] ?? '-' },
       ];
     });
 
@@ -69,7 +73,7 @@ export class MsqQuestionStatisticsComponent implements OnChanges {
       { header: 'Recipient Name', sortBy: SortBy.MSQ_RECIPIENT_NAME },
       ...Object.keys(stats.weightPerOption).map((key: string) => {
         return {
-          header: `${key} [${stats.weightPerOption[key].toFixed(2)}]`,
+          header: `${key} [${this.getDisplayWeight(stats.weightPerOption[key])}]`,
           sortBy: SortBy.MSQ_OPTION_SELECTED_TIMES,
         };
       }),
@@ -89,9 +93,10 @@ export class MsqQuestionStatisticsComponent implements OnChanges {
             value: stats.perRecipientResponses[key].responses[option],
           };
         }),
-        { value: stats.perRecipientResponses[key].total.toFixed(2) },
-        { value: stats.perRecipientResponses[key].average.toFixed(2) },
+        { value: this.getDisplayWeight(stats.perRecipientResponses[key].total) },
+        { value: this.getDisplayWeight(stats.perRecipientResponses[key].average) },
       ];
     });
   }
 }
+

--- a/src/web/app/utils/question-statistics.util.ts
+++ b/src/web/app/utils/question-statistics.util.ts
@@ -225,7 +225,7 @@ export function calculateMcqQuestionStatistics(
   if (question.hasAssignedWeights) {
     for (let i = 0; i < question.mcqChoices.length; i += 1) {
       const option: string = question.mcqChoices[i];
-      const weight: number = question.mcqWeights[i];
+      const weight: number | null = question.mcqWeights[i];
       stats.weightPerOption[option] = weight;
     }
     if (question.otherEnabled) {
@@ -234,13 +234,19 @@ export function calculateMcqQuestionStatistics(
 
     let totalWeightedResponseCount = 0;
     for (const answer of Object.keys(stats.answerFrequency)) {
-      const weight: number = stats.weightPerOption[answer];
-      const weightedAnswer: number = weight * stats.answerFrequency[answer];
-      totalWeightedResponseCount += weightedAnswer;
+      const weight: number | null = stats.weightPerOption[answer];
+      if (weight === null || weight === undefined) {
+        continue;
+      }
+      totalWeightedResponseCount += weight * stats.answerFrequency[answer];
     }
 
     for (const answer of Object.keys(stats.weightPerOption)) {
-      const weight: number = stats.weightPerOption[answer];
+      const weight: number | null = stats.weightPerOption[answer];
+      if (weight === null || weight === undefined) {
+        stats.weightedPercentagePerOption[answer] = null;
+        continue;
+      }
       const frequency: number = stats.answerFrequency[answer];
       const weightedPercentage: number =
         totalWeightedResponseCount === 0 ? 0 : 100 * ((frequency * weight) / totalWeightedResponseCount);
@@ -282,19 +288,23 @@ export function calculateMcqQuestionStatistics(
       const responses: Record<string, number> = perRecipientResponse[recipient];
       let total = 0;
       let numOfResponsesForRecipient = 0;
+      let hasAnyWeight = false;
       for (const answer of Object.keys(responses)) {
-        const responseCount: number = responses[answer];
-        const weight: number = stats.weightPerOption[answer];
-        total += responseCount * weight;
-        numOfResponsesForRecipient += responseCount;
+        const weight: number | null = stats.weightPerOption[answer];
+        if (weight === null || weight === undefined) {
+          continue;
+        }
+        hasAnyWeight = true;
+        total += responses[answer] * weight;
+        numOfResponsesForRecipient += responses[answer];
       }
       const average = numOfResponsesForRecipient ? total / numOfResponsesForRecipient : 0;
 
       stats.perRecipientResponses[recipient] = {
         recipient,
         recipientEmail: recipientEmails[recipient],
-        total: +total.toFixed(5),
-        average: +average.toFixed(2),
+        total: hasAnyWeight ? +total.toFixed(5) : null,
+        average: hasAnyWeight && numOfResponsesForRecipient ? +average.toFixed(2) : null,
         recipientTeam: recipientToTeam[recipient],
         responses: perRecipientResponse[recipient],
       };
@@ -338,7 +348,7 @@ export function calculateMsqQuestionStatistics(
   if (question.hasAssignedWeights) {
     for (let i = 0; i < question.msqChoices.length; i += 1) {
       const option: string = question.msqChoices[i];
-      const weight: number = question.msqWeights[i];
+      const weight: number | null = question.msqWeights[i];
       stats.weightPerOption[option] = weight;
     }
     if (question.otherEnabled) {
@@ -347,13 +357,19 @@ export function calculateMsqQuestionStatistics(
 
     let totalWeightedResponseCount = 0;
     for (const answer of Object.keys(stats.answerFrequency)) {
-      const weight: number = stats.weightPerOption[answer];
-      const weightedAnswer: number = weight * stats.answerFrequency[answer];
-      totalWeightedResponseCount += weightedAnswer;
+      const weight: number | null = stats.weightPerOption[answer];
+      if (weight === null || weight === undefined) {
+        continue;
+      }
+      totalWeightedResponseCount += weight * stats.answerFrequency[answer];
     }
 
     for (const answer of Object.keys(stats.weightPerOption)) {
-      const weight: number = stats.weightPerOption[answer];
+      const weight: number | null = stats.weightPerOption[answer];
+      if (weight === null || weight === undefined) {
+        stats.weightedPercentagePerOption[answer] = null;
+        continue;
+      }
       const frequency: number = stats.answerFrequency[answer];
       const weightedPercentage: number =
         totalWeightedResponseCount === 0 ? 0 : 100 * ((frequency * weight) / totalWeightedResponseCount);
@@ -403,19 +419,23 @@ export function calculateMsqQuestionStatistics(
     const responses: Record<string, number> = perRecipientResponse[recipient];
     let total = 0;
     let numOfResponsesForRecipient = 0;
+    let hasAnyWeight = false;
     for (const answer of Object.keys(responses)) {
-      const responseCount: number = responses[answer];
-      const weight: number = stats.weightPerOption[answer];
-      total += responseCount * weight;
-      numOfResponsesForRecipient += responseCount;
+      const weight: number | null = stats.weightPerOption[answer];
+      if (weight === null || weight === undefined) {
+        continue;
+      }
+      hasAnyWeight = true;
+      total += responses[answer] * weight;
+      numOfResponsesForRecipient += responses[answer];
     }
     const average = numOfResponsesForRecipient ? total / numOfResponsesForRecipient : 0;
 
     stats.perRecipientResponses[recipient] = {
       recipient: recipientNames[recipient],
       recipientEmail: recipientEmails[recipient],
-      total: +total.toFixed(5),
-      average: +average.toFixed(2),
+      total: hasAnyWeight ? +total.toFixed(5) : null,
+      average: hasAnyWeight && numOfResponsesForRecipient ? +average.toFixed(2) : null,
       recipientTeam: recipientToTeam[recipient],
       responses: perRecipientResponse[recipient],
     };

--- a/src/web/types/api-output.ts
+++ b/src/web/types/api-output.ts
@@ -141,8 +141,8 @@ export interface FeedbackContributionResponseDetails extends FeedbackResponseDet
 
 export interface FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
   hasAssignedWeights: boolean;
-  mcqWeights: number[];
-  mcqOtherWeight: number;
+  mcqWeights: (number | null)[];
+  mcqOtherWeight: number | null;
   mcqChoices: string[];
   otherEnabled: boolean;
   questionDropdownEnabled: boolean;
@@ -159,8 +159,8 @@ export interface FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
   msqChoices: string[];
   otherEnabled: boolean;
   hasAssignedWeights: boolean;
-  msqWeights: number[];
-  msqOtherWeight: number;
+  msqWeights: (number | null)[];
+  msqOtherWeight: number | null;
   generateOptionsFor: QuestionRecipientType;
   maxSelectableChoices: number;
   minSelectableChoices: number;

--- a/src/web/types/question-details-impl/abstract-feedback-mcq-msq-question-details.ts
+++ b/src/web/types/question-details-impl/abstract-feedback-mcq-msq-question-details.ts
@@ -5,6 +5,10 @@ import { AbstractFeedbackQuestionDetails } from './abstract-feedback-question-de
  * Abstract class for MCQ/MSQ question detail.
  */
 export abstract class AbstractFeedbackMcqMsqQuestionDetails extends AbstractFeedbackQuestionDetails {
+  private getDisplayValue(val: number | null | undefined): string {
+    return val === null || val === undefined ? '-' : String(val);
+  }
+
   protected getQuestionCsvStatsFrom(
     statsCalculation: McqMsqQuestionStatistics,
     hasAssignedWeights: boolean,
@@ -23,10 +27,10 @@ export abstract class AbstractFeedbackMcqMsqQuestionDetails extends AbstractFeed
         if (hasAssignedWeights) {
           statsRows.push([
             answer,
-            String(statsCalculation.weightPerOption[answer]),
+            this.getDisplayValue(statsCalculation.weightPerOption[answer]),
             String(statsCalculation.answerFrequency[answer]),
             String(statsCalculation.percentagePerOption[answer]),
-            String(statsCalculation.weightedPercentagePerOption[answer]),
+            this.getDisplayValue(statsCalculation.weightedPercentagePerOption[answer]),
           ]);
         } else {
           statsRows.push([
@@ -48,7 +52,7 @@ export abstract class AbstractFeedbackMcqMsqQuestionDetails extends AbstractFeed
       'Team',
       'Recipient Name',
       ...Object.keys(statsCalculation.weightPerOption).map(
-        (choice: string) => `${choice} [${statsCalculation.weightPerOption[choice]}]`,
+        (choice: string) => `${choice} [${this.getDisplayValue(statsCalculation.weightPerOption[choice])}]`,
       ),
       'Total',
       'Average',
@@ -64,11 +68,12 @@ export abstract class AbstractFeedbackMcqMsqQuestionDetails extends AbstractFeed
           ...Object.keys(statsCalculation.weightPerOption).map((choice: string) =>
             String(recipientResponses.responses[choice]),
           ),
-          String(recipientResponses.total),
-          String(recipientResponses.average),
+          this.getDisplayValue(recipientResponses.total),
+          this.getDisplayValue(recipientResponses.average),
         ]);
       });
 
     return statsRows;
   }
 }
+

--- a/src/web/types/question-details-impl/feedback-mcq-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-mcq-question-details.impl.ts
@@ -17,8 +17,8 @@ export class FeedbackMcqQuestionDetailsImpl
   implements FeedbackMcqQuestionDetails
 {
   hasAssignedWeights = false;
-  mcqWeights: number[] = [];
-  mcqOtherWeight = 0;
+  mcqWeights: (number | null)[] = [];
+  mcqOtherWeight: number | null = null;
   mcqChoices: string[] = [];
   otherEnabled = false;
   questionDropdownEnabled = false;

--- a/src/web/types/question-details-impl/feedback-msq-question-details.impl.ts
+++ b/src/web/types/question-details-impl/feedback-msq-question-details.impl.ts
@@ -23,8 +23,8 @@ export class FeedbackMsqQuestionDetailsImpl
   maxSelectableChoices: number = NO_VALUE;
   minSelectableChoices: number = NO_VALUE;
   hasAssignedWeights = false;
-  msqWeights: number[] = [];
-  msqOtherWeight = 0;
+  msqWeights: (number | null)[] = [];
+  msqOtherWeight: number | null = null;
   questionText = '';
   questionType: FeedbackQuestionType = FeedbackQuestionType.MSQ;
 

--- a/src/web/types/question-statistics.model.ts
+++ b/src/web/types/question-statistics.model.ts
@@ -50,8 +50,8 @@ export interface ContributionQuestionStatistics {
 export interface McqMsqPerRecipientStatistics {
   recipient: string;
   recipientEmail?: string;
-  total: number;
-  average: number;
+  total: number | null;
+  average: number | null;
   recipientTeam: string;
   responses: Record<string, number>;
 }
@@ -59,8 +59,8 @@ export interface McqMsqPerRecipientStatistics {
 export interface McqMsqQuestionStatistics {
   answerFrequency: Record<string, number>;
   percentagePerOption: Record<string, number>;
-  weightPerOption: Record<string, number>;
-  weightedPercentagePerOption: Record<string, number>;
+  weightPerOption: Record<string, number | null>;
+  weightedPercentagePerOption: Record<string, number | null>;
   perRecipientResponses: Record<string, McqMsqPerRecipientStatistics>;
 }
 


### PR DESCRIPTION
Fixes #12547

## What changed

MCQ and MSQ questions with assigned weights now allow individual choices to have no weight — leaving the field blank is equivalent to the 'Not enough information to evaluate' case described in the issue.

Blank weights are stored as `null`, shown as `-` in the statistics tables and CSV export, and skipped when computing weighted totals/averages. If every option for a recipient has a null weight, their total and average also show `-`.

### Changes

**Types**
- `api-output.ts`: widen `mcqWeights`, `mcqOtherWeight`, `msqWeights`, `msqOtherWeight` to `(number | null)`
- `question-statistics.model.ts`: widen `weightPerOption`, `weightedPercentagePerOption`, `total`, and `average` to `(number | null)`

**Statistics calculation** (`question-statistics.util.ts`)
- Skip null-weight choices when computing weighted response counts
- Set `weightedPercentagePerOption` to `null` for null-weight choices
- Set `total`/`average` to `null` when no weighted responses exist for a recipient

**UI / display**
- `weight-field.component.ts`: accept and emit `null` so a cleared input propagates correctly
- `mcq/msq-question-edit-details-form.component.ts`: update local weight array types
- `mcq/msq-question-statistics.component.ts`: add `getDisplayWeight` (same pattern as the existing rubric stats component) and fix `.toFixed()` crash on null
- `abstract-feedback-mcq-msq-question-details.ts`: use `getDisplayValue` in CSV rows so null prints as `-`
- Tooltip text on the weights checkbox updated to mention the empty-weight option

### Demo

**Before** — saving with a blank weight field was blocked by frontend validation; attempting to do so showed an error.

**After** — clearing a weight field is accepted. In the statistics panel, that choice's Weight column shows `-`, its Weighted Percentage shows `-`, and the per-recipient Total/Average show `-` if all of the recipient's selected options have no weight (mirrors the rubric question behaviour from #12544/#12545).