### PR TITLE
[#14246] Rephrase Google ID and sign-in terminology for email templates

### DIFF
--- a/src/main/resources/instructorEmailFragment-registrationKeyReset.html
+++ b/src/main/resources/instructorEmailFragment-registrationKeyReset.html
@@ -3,8 +3,7 @@
   <a href="${joinUrl}">${joinUrl}</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/main/resources/instructorEmailTemplate-courseJoin.html
+++ b/src/main/resources/instructorEmailTemplate-courseJoin.html
@@ -10,8 +10,7 @@
   <a href="${joinUrl}">${joinUrl}</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.
@@ -20,7 +19,7 @@
 </p>
 
 <p>
-  Note that if you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
   However, you need to join the course in order to access features such as creating/editing feedback sessions or creating your own courses.
 </p>

--- a/src/main/resources/ownerEmailTemplate-feedbackSessionOpeningSoonNotJoined.html
+++ b/src/main/resources/ownerEmailTemplate-feedbackSessionOpeningSoonNotJoined.html
@@ -71,8 +71,7 @@
 </p>
 <ul>
   <li>
-    If prompted to log in when joining the course, use your Google account to log in.
-    If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+    If you are asked to sign in, choose any of the available sign-in options and continue.
   </li>
   <li>
     The above link to join the course is unique to you. Please do not share it with others.

--- a/src/main/resources/studentEmailFragment-courseJoin.html
+++ b/src/main/resources/studentEmailFragment-courseJoin.html
@@ -6,8 +6,7 @@
   <a href="${joinUrl}">${joinUrl}</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with your classmates.
@@ -16,9 +15,9 @@
 </p>
 
 <p>
-  Note that If you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
-  However, we recommend joining the course using your Google account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
+  However, we recommend joining the course using your account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
 </p>
 
 <p>

--- a/src/main/resources/studentEmailFragment-registrationKeyReset.html
+++ b/src/main/resources/studentEmailFragment-registrationKeyReset.html
@@ -3,8 +3,7 @@
   <a href="${joinUrl}">${joinUrl}</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with your classmates.
@@ -19,9 +18,9 @@
 </p>
 
 <p>
-  Note that If you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
-  However, we recommend joining the course using your Google account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
+  However, we recommend joining the course using your account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
 </p>
 
 <p>

--- a/src/main/resources/studentEmailTemplate-courseJoin.html
+++ b/src/main/resources/studentEmailTemplate-courseJoin.html
@@ -8,8 +8,7 @@
   <a href="${joinUrl}">${joinUrl}</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with your classmates.
@@ -18,9 +17,9 @@
 </p>
 
 <p>
-  Note that If you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
-  However, we recommend joining the course using your Google account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
+  However, we recommend joining the course using your account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
 </p>
 
 <p>

--- a/src/test/resources/emails/feedbackSessionSummaryEmailForUpdatedStudent.html
+++ b/src/test/resources/emails/feedbackSessionSummaryEmailForUpdatedStudent.html
@@ -13,8 +13,7 @@
   <a href="${app.url}/web/join?key=${regkey.enc}&entityType=student">${app.url}/web/join?key=${regkey.enc}&entityType=student</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with your classmates.
@@ -23,9 +22,9 @@
 </p>
 
 <p>
-  Note that If you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
-  However, we recommend joining the course using your Google account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
+  However, we recommend joining the course using your account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
 </p>
 
 <p>

--- a/src/test/resources/emails/instructorCourseJoinEmail.html
+++ b/src/test/resources/emails/instructorCourseJoinEmail.html
@@ -10,7 +10,7 @@
   <a href="${app.url}/web/join?key=${regkey.enc}&entityType=instructor">${app.url}/web/join?key=${regkey.enc}&entityType=instructor</a>
   <ul>
     <li>
-     If you are asked to sign in, choose any of the available sign-in options and continue.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/instructorCourseJoinEmail.html
+++ b/src/test/resources/emails/instructorCourseJoinEmail.html
@@ -10,8 +10,7 @@
   <a href="${app.url}/web/join?key=${regkey.enc}&entityType=instructor">${app.url}/web/join?key=${regkey.enc}&entityType=instructor</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+     If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.
@@ -20,7 +19,7 @@
 </p>
 
 <p>
-  Note that if you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
   However, you need to join the course in order to access features such as creating/editing feedback sessions or creating your own courses.
 </p>

--- a/src/test/resources/emails/sessionOpeningSoonEmailForCoOwnerNotJoined.html
+++ b/src/test/resources/emails/sessionOpeningSoonEmailForCoOwnerNotJoined.html
@@ -71,8 +71,7 @@
 </p>
 <ul>
   <li>
-    If prompted to log in when joining the course, use your Google account to log in.
-    If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+    If you are asked to sign in, choose any of the available sign-in options and continue.
   </li>
   <li>
     The above link to join the course is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/studentCourseJoinEmail.html
+++ b/src/test/resources/emails/studentCourseJoinEmail.html
@@ -8,8 +8,7 @@
   <a href="${app.url}/web/join?key=${regkey.enc}&entityType=student">${app.url}/web/join?key=${regkey.enc}&entityType=student</a>
   <ul>
     <li>
-      If prompted to log in, use your Google account to log in.
-      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+      If you are asked to sign in, choose any of the available sign-in options and continue.
     </li>
     <li>
       The above link is unique to you. Please do not share it with your classmates.
@@ -18,9 +17,9 @@
 </p>
 
 <p>
-  Note that If you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  Note that if you wish to access TEAMMATES without using your account, you do not need to ‘join’ the course as instructed above.
   You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
-  However, we recommend joining the course using your Google account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
+  However, we recommend joining the course using your account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
 </p>
 
 <p>


### PR DESCRIPTION
Fixes #14246

**Outline of Solution**

* As per title.
