### PR TITLE
[#14181] Open links in current tab by default

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
@@ -61,19 +61,19 @@ public class InstructorCourseDetailsPageE2ETest extends BaseE2ETestCase {
         InstructorCourseStudentDetailsViewPage studentDetailsViewPage =
                 detailsPage.clickViewStudent(studentToView.getEmail());
         studentDetailsViewPage.verifyIsCorrectPage(course.getId(), studentToView.getEmail());
-        studentDetailsViewPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentDetailsViewPage.goBack();
 
         ______TS("link: edit student details page");
         InstructorCourseStudentDetailsEditPage studentDetailsEditPage =
                 detailsPage.clickEditStudent(studentToView.getEmail());
         studentDetailsEditPage.verifyIsCorrectPage(course.getId(), studentToView.getEmail());
-        studentDetailsEditPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentDetailsEditPage.goBack();
 
         ______TS("link: view all records page");
         InstructorStudentRecordsPage studentRecordsPage =
                 detailsPage.clickViewAllRecords(studentToView.getEmail());
         studentRecordsPage.verifyIsCorrectPage(course.getId(), studentToView.getName());
-        studentRecordsPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentRecordsPage.goBack();
 
         ______TS("send invite");
         detailsPage.sendInvite(student3.getEmail());

--- a/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorFeedbackEditPageE2ETest.java
@@ -134,11 +134,11 @@ public class InstructorFeedbackEditPageE2ETest extends BaseE2ETestCase {
 
         ______TS("preview session as student");
         FeedbackSubmitPage previewPage = feedbackEditPage.previewAsStudent(testData.students.get("InstFEP.jose.tmms"));
-        previewPage.closeCurrentWindowAndSwitchToParentWindow();
+        previewPage.goBack();
 
         ______TS("preview session as instructor");
         previewPage = feedbackEditPage.previewAsInstructor(instructor);
-        previewPage.closeCurrentWindowAndSwitchToParentWindow();
+        previewPage.goBack();
 
         ______TS("copy session to other course");
         FeedbackSession copiedSession = EntityCopyUtil.copyFeedbackSession(feedbackSession);

--- a/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
@@ -76,21 +76,21 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
         InstructorCourseStudentDetailsViewPage studentDetailsViewPage =
                 searchPage.clickViewStudent(course1, studentEmail);
         studentDetailsViewPage.verifyIsCorrectPage(course1.getId(), studentEmail);
-        studentDetailsViewPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentDetailsViewPage.goBack();
 
         ______TS("link: edit student details page");
 
         InstructorCourseStudentDetailsEditPage studentDetailsEditPage =
                 searchPage.clickEditStudent(course1, studentEmail);
         studentDetailsEditPage.verifyIsCorrectPage(course1.getId(), studentEmail);
-        studentDetailsEditPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentDetailsEditPage.goBack();
 
         ______TS("link: view all records page");
 
         InstructorStudentRecordsPage studentRecordsPage =
                 searchPage.clickViewAllRecords(course1, studentEmail);
         studentRecordsPage.verifyIsCorrectPage(course1.getId(), studentToView.getName());
-        studentRecordsPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentRecordsPage.goBack();
 
         ______TS("action: delete student");
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorSearchPageE2ETest.java
@@ -77,6 +77,7 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
                 searchPage.clickViewStudent(course1, studentEmail);
         studentDetailsViewPage.verifyIsCorrectPage(course1.getId(), studentEmail);
         studentDetailsViewPage.goBack();
+        searchPage.search("student2");
 
         ______TS("link: edit student details page");
 
@@ -84,6 +85,7 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
                 searchPage.clickEditStudent(course1, studentEmail);
         studentDetailsEditPage.verifyIsCorrectPage(course1.getId(), studentEmail);
         studentDetailsEditPage.goBack();
+        searchPage.search("student2");
 
         ______TS("link: view all records page");
 
@@ -91,6 +93,7 @@ public class InstructorSearchPageE2ETest extends BaseE2ETestCase {
                 searchPage.clickViewAllRecords(course1, studentEmail);
         studentRecordsPage.verifyIsCorrectPage(course1.getId(), studentToView.getName());
         studentRecordsPage.goBack();
+        searchPage.search("student2");
 
         ______TS("action: delete student");
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
@@ -86,21 +86,21 @@ public class InstructorStudentListPageE2ETest extends BaseE2ETestCase {
         InstructorCourseStudentDetailsViewPage studentDetailsViewPage =
                 listPage.clickViewStudent(course3, studentEmail);
         studentDetailsViewPage.verifyIsCorrectPage(course3.getId(), studentEmail);
-        studentDetailsViewPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentDetailsViewPage.goBack();
 
         ______TS("link: edit student details page");
 
         InstructorCourseStudentDetailsEditPage studentDetailsEditPage =
                 listPage.clickEditStudent(course3, studentEmail);
         studentDetailsEditPage.verifyIsCorrectPage(course3.getId(), studentEmail);
-        studentDetailsEditPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentDetailsEditPage.goBack();
 
         ______TS("link: view all records page");
 
         InstructorStudentRecordsPage studentRecordsPage =
                 listPage.clickViewAllRecords(course3, studentEmail);
         studentRecordsPage.verifyIsCorrectPage(course3.getId(), studentToView.getName());
-        studentRecordsPage.closeCurrentWindowAndSwitchToParentWindow();
+        studentRecordsPage.goBack();
 
         ______TS("action: delete student");
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorStudentListPageE2ETest.java
@@ -87,6 +87,7 @@ public class InstructorStudentListPageE2ETest extends BaseE2ETestCase {
                 listPage.clickViewStudent(course3, studentEmail);
         studentDetailsViewPage.verifyIsCorrectPage(course3.getId(), studentEmail);
         studentDetailsViewPage.goBack();
+        listPage.clickCourseTabHeader(course3);
 
         ______TS("link: edit student details page");
 
@@ -94,6 +95,7 @@ public class InstructorStudentListPageE2ETest extends BaseE2ETestCase {
                 listPage.clickEditStudent(course3, studentEmail);
         studentDetailsEditPage.verifyIsCorrectPage(course3.getId(), studentEmail);
         studentDetailsEditPage.goBack();
+        listPage.clickCourseTabHeader(course3);
 
         ______TS("link: view all records page");
 
@@ -101,6 +103,7 @@ public class InstructorStudentListPageE2ETest extends BaseE2ETestCase {
                 listPage.clickViewAllRecords(course3, studentEmail);
         studentRecordsPage.verifyIsCorrectPage(course3.getId(), studentToView.getName());
         studentRecordsPage.goBack();
+        listPage.clickCourseTabHeader(course3);
 
         ______TS("action: delete student");
 

--- a/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/AppPage.java
@@ -846,6 +846,14 @@ public abstract class AppPage {
         browser.closeCurrentWindowAndSwitchToParentWindow();
     }
 
+    /**
+     * Navigates back to the previous page in the browser history.
+     */
+    public void goBack() {
+        browser.driver.navigate().back();
+        browser.waitForPageLoad(false);
+    }
+
     String getDisplayGiverName(QuestionGiverType type) {
         switch (type) {
         case SESSION_CREATOR:

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
@@ -14,7 +14,6 @@ import teammates.e2e.util.TestProperties;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
-import teammates.test.ThreadHelper;
 
 /**
  * Represents the instructor course details page of the website.

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCourseDetailsPage.java
@@ -158,8 +158,6 @@ public class InstructorCourseDetailsPage extends AppPage {
         WebElement studentRow = getStudentRow(studentEmailAddress);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-details-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorCourseStudentDetailsViewPage.class);
     }
 
@@ -167,8 +165,6 @@ public class InstructorCourseDetailsPage extends AppPage {
         WebElement studentRow = getStudentRow(studentEmailAddress);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-edit-details-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorCourseStudentDetailsEditPage.class);
     }
 
@@ -176,8 +172,6 @@ public class InstructorCourseDetailsPage extends AppPage {
         WebElement studentRow = getStudentRow(studentEmailAddress);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-records-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorStudentRecordsPage.class);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorFeedbackEditPage.java
@@ -283,8 +283,6 @@ public class InstructorFeedbackEditPage extends AppPage {
 
     public FeedbackSubmitPage previewAsStudent() {
         click(previewAsStudentButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(FeedbackSubmitPage.class);
     }
 
@@ -295,8 +293,6 @@ public class InstructorFeedbackEditPage extends AppPage {
 
     public FeedbackSubmitPage previewAsInstructor() {
         click(previewAsInstructorButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(FeedbackSubmitPage.class);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -135,8 +135,6 @@ public class InstructorSearchPage extends AppPage {
         WebElement studentRow = getStudentRow(course, studentEmail);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-details-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorCourseStudentDetailsViewPage.class);
     }
 
@@ -144,8 +142,6 @@ public class InstructorSearchPage extends AppPage {
         WebElement studentRow = getStudentRow(course, studentEmail);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-edit-details-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorCourseStudentDetailsEditPage.class);
     }
 
@@ -153,8 +149,6 @@ public class InstructorSearchPage extends AppPage {
         WebElement studentRow = getStudentRow(course, studentEmail);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-records-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorStudentRecordsPage.class);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorSearchPage.java
@@ -14,7 +14,6 @@ import org.openqa.selenium.support.FindBy;
 import teammates.common.util.StringHelper;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Student;
-import teammates.test.ThreadHelper;
 
 /**
  * Represents the instructor search page.

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
@@ -158,8 +158,6 @@ public class InstructorStudentListPage extends AppPage {
         WebElement studentRow = getStudentRow(course, studentEmail);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-details-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorCourseStudentDetailsViewPage.class);
     }
 
@@ -167,8 +165,6 @@ public class InstructorStudentListPage extends AppPage {
         WebElement studentRow = getStudentRow(course, studentEmail);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-edit-details-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorCourseStudentDetailsEditPage.class);
     }
 
@@ -176,8 +172,6 @@ public class InstructorStudentListPage extends AppPage {
         WebElement studentRow = getStudentRow(course, studentEmail);
         WebElement viewButton = studentRow.findElement(By.cssSelector("[id^='btn-view-records-']"));
         click(viewButton);
-        ThreadHelper.waitFor(2000);
-        switchToNewWindow();
         return changePageType(InstructorStudentRecordsPage.class);
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorStudentListPage.java
@@ -14,7 +14,6 @@ import org.openqa.selenium.WebElement;
 import teammates.e2e.util.TestProperties;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.Student;
-import teammates.test.ThreadHelper;
 
 /**
  * Page Object Model for instructor student list page.

--- a/src/web/app/components/preview-session-panel/preview-session-panel.component.html
+++ b/src/web/app/components/preview-session-panel/preview-session-panel.component.html
@@ -24,8 +24,6 @@
             <a
               [routerLink]="['/web/sessions', feedbackSessionId, 'submission']"
               [queryParams]="{ previewAs: userIdOfStudentToPreview }"
-              target="_blank"
-              rel="noopener noreferrer"
               [ngbTooltip]="
                 userIdOfStudentToPreview.length !== 0
                   ? 'View how this session would look like to a student who is submitting feedback.'
@@ -75,8 +73,6 @@
             <a
               [routerLink]="['/web/instructor/sessions', feedbackSessionId, 'submission']"
               [queryParams]="{ previewAs: userIdOfInstructorToPreview }"
-              target="_blank"
-              rel="noopener noreferrer"
               ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list."
             >
               <ng-container *ngTemplateOutlet="previewInstructorBtn"></ng-container>

--- a/src/web/app/components/preview-session-result-panel/preview-session-result-panel.component.html
+++ b/src/web/app/components/preview-session-result-panel/preview-session-result-panel.component.html
@@ -20,8 +20,6 @@
             <a
               [routerLink]="['/web/sessions', feedbackSessionId, 'result']"
               [queryParams]="{ previewAs: userIdOfStudentToPreview }"
-              target="_blank"
-              rel="noopener noreferrer"
               [ngbTooltip]="
                 userIdOfStudentToPreview.length !== 0
                   ? 'View how the session results would look like to a student.'
@@ -70,8 +68,6 @@
             <a
               [routerLink]="['/web/instructor/sessions', feedbackSessionId, 'result']"
               [queryParams]="{ previewAs: userIdOfInstructorToPreview }"
-              target="_blank"
-              rel="noopener noreferrer"
               ngbTooltip="View how the session results would look like to an instructor."
             >
               <ng-container *ngTemplateOutlet="previewInstructorBtn"></ng-container>

--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -369,8 +369,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-009/details"
                     id="btn-view-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -378,8 +376,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-009/edit"
                     id="btn-edit-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -399,8 +395,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-009/records"
                     id="btn-view-records--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -442,8 +436,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-010/details"
                     id="btn-view-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -451,8 +443,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-010/edit"
                     id="btn-edit-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -472,8 +462,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-010/records"
                     id="btn-view-records--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -515,8 +503,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-011/details"
                     id="btn-view-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -524,8 +510,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-011/edit"
                     id="btn-edit-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -539,8 +523,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-011/records"
                     id="btn-view-records--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -582,8 +564,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-012/details"
                     id="btn-view-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -591,8 +571,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-012/edit"
                     id="btn-edit-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -606,8 +584,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-012/records"
                     id="btn-view-records--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -820,8 +796,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-013/details"
                     id="btn-view-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -829,8 +803,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     href="/web/instructor/courses//students/student-013/edit"
                     id="btn-edit-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -850,8 +822,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     href="/web/instructor/students//student-013/records"
                     id="btn-view-records--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -893,8 +863,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-014/details"
                     id="btn-view-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -902,8 +870,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-014/edit"
                     id="btn-edit-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -917,8 +883,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-014/records"
                     id="btn-view-records--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -960,8 +924,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-015/details"
                     id="btn-view-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -969,8 +931,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-015/edit"
                     id="btn-edit-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -984,8 +944,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-015/records"
                     id="btn-view-records--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1027,8 +985,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-016/details"
                     id="btn-view-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1036,8 +992,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-016/edit"
                     id="btn-edit-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1051,8 +1005,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-016/records"
                     id="btn-view-records--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1265,8 +1217,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-001/details"
                     id="btn-view-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1274,8 +1224,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-001/edit"
                     id="btn-edit-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1289,8 +1237,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-001/records"
                     id="btn-view-records--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1332,8 +1278,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-002/details"
                     id="btn-view-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1341,8 +1285,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-002/edit"
                     id="btn-edit-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1356,8 +1298,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-002/records"
                     id="btn-view-records--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1399,8 +1339,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-003/details"
                     id="btn-view-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1408,8 +1346,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-003/edit"
                     id="btn-edit-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1423,8 +1359,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-003/records"
                     id="btn-view-records--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1466,8 +1400,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-004/details"
                     id="btn-view-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1475,8 +1407,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-004/edit"
                     id="btn-edit-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1490,8 +1420,6 @@ exports[`StudentListComponent > should snap with some student list data 1`] = `
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-004/records"
                     id="btn-view-records--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1704,8 +1632,6 @@ exports[`StudentListComponent > should snap with some student list data and some
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-018/details"
                     id="btn-view-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1713,8 +1639,6 @@ exports[`StudentListComponent > should snap with some student list data and some
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-018/edit"
                     id="btn-edit-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1728,8 +1652,6 @@ exports[`StudentListComponent > should snap with some student list data and some
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-018/records"
                     id="btn-view-records--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -1771,8 +1693,6 @@ exports[`StudentListComponent > should snap with some student list data and some
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-020/details"
                     id="btn-view-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -1780,8 +1700,6 @@ exports[`StudentListComponent > should snap with some student list data and some
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-020/edit"
                     id="btn-edit-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -1795,8 +1713,6 @@ exports[`StudentListComponent > should snap with some student list data and some
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-020/records"
                     id="btn-view-records--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -2009,8 +1925,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-005/details"
                     id="btn-view-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -2018,8 +1932,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     href="/web/instructor/courses//students/student-005/edit"
                     id="btn-edit-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -2033,8 +1945,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     href="/web/instructor/students//student-005/records"
                     id="btn-view-records--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -2076,8 +1986,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-006/details"
                     id="btn-view-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -2085,8 +1993,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     href="/web/instructor/courses//students/student-006/edit"
                     id="btn-edit-details--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -2100,8 +2006,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     href="/web/instructor/students//student-006/records"
                     id="btn-view-records--1"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -2143,8 +2047,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-007/details"
                     id="btn-view-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -2152,8 +2054,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-007/edit"
                     id="btn-edit-details--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -2167,8 +2067,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-007/records"
                     id="btn-view-records--2"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -2210,8 +2108,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-008/details"
                     id="btn-view-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -2219,8 +2115,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-008/edit"
                     id="btn-edit-details--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -2234,8 +2128,6 @@ exports[`StudentListComponent > should snap with some student list data when not
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-008/records"
                     id="btn-view-records--3"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>
@@ -2448,8 +2340,6 @@ exports[`StudentListComponent > should snap with some student list data with no 
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-021/details"
                     id="btn-view-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      View 
                   </a>
@@ -2457,8 +2347,6 @@ exports[`StudentListComponent > should snap with some student list data with no 
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/courses//students/student-021/edit"
                     id="btn-edit-details--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      Edit 
                   </a>
@@ -2472,8 +2360,6 @@ exports[`StudentListComponent > should snap with some student list data with no 
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     href="/web/instructor/students//student-021/records"
                     id="btn-view-records--0"
-                    rel="noopener noreferrer"
-                    target="_blank"
                   >
                      All Records 
                   </a>

--- a/src/web/app/components/student-list/cell-with-actions.component.html
+++ b/src/web/app/components/student-list/cell-with-actions.component.html
@@ -1,8 +1,6 @@
 <div class="text-center">
   <a
     class="btn btn-light btn-sm btn-margin-right custom-button"
-    target="_blank"
-    rel="noopener noreferrer"
     [id]="'btn-view-details-' + courseId + '-' + idx"
     [ngbTooltip]="'View the details of the student'"
     [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'details']"
@@ -11,8 +9,6 @@
   </a>
   <a
     class="btn btn-light btn-sm btn-margin-right custom-button"
-    target="_blank"
-    rel="noopener noreferrer"
     [id]="'btn-edit-details-' + courseId + '-' + idx"
     [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
     [ngbTooltip]="
@@ -62,8 +58,6 @@
   </button>
   <a
     class="btn btn-light btn-sm btn-margin-right custom-button"
-    target="_blank"
-    rel="noopener noreferrer"
     [id]="'btn-view-records-' + courseId + '-' + idx"
     [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
     [ngbTooltip]="

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -134,11 +134,11 @@
       <i class="fas fa-bolt"></i>&nbsp;<a routerLink="/web/front/home">TEAMMATES</a> V{{ version }}
     </div>
     <div class="col-sm-6 text-md-end">
-      <i class="far fa-comments"></i>&nbsp;Send <a routerLink="/web/front/contact" target="_blank">Feedback</a>
+      <i class="far fa-comments"></i>&nbsp;Send <a routerLink="/web/front/contact">Feedback</a>
     </div>
     <div class="col-sm-12">
       Sponsored by School of Computing, National University of Singapore.
-      <a routerLink="/web/front/contact" target="_blank">Become a sponsor</a>
+      <a routerLink="/web/front/contact">Become a sponsor</a>
     </div>
   </div>
 </footer>

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
@@ -171,7 +171,7 @@ export class AdminAccountsPageComponent implements OnInit {
   masqueradeAsUser(): void {
     this.masqueradeModeService.masqueradeAs(this.accountInfo.accountId);
     const url = this.linkService.generateInstructorHomePageLink();
-    globalThis.location.assign(url);
+    globalThis.open(url, '_blank');
   }
 
   private confirmAndUnlinkAccount(userId: string, name: string, courseId: string, onSuccess: () => void): void {

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.ts
@@ -172,6 +172,7 @@ export class AdminAccountsPageComponent implements OnInit {
     this.masqueradeModeService.masqueradeAs(this.accountInfo.accountId);
     const url = this.linkService.generateInstructorHomePageLink();
     globalThis.open(url, '_blank');
+    this.masqueradeModeService.clearMasquerade();
   }
 
   private confirmAndUnlinkAccount(userId: string, name: string, courseId: string, onSuccess: () => void): void {

--- a/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-instructor-search-table/admin-instructor-search-table.component.html
@@ -35,12 +35,7 @@
             <td [innerHtml]="instructor.institute | highlighter: searchString : true"></td>
             <td>
               @if (instructor.manageAccountLink) {
-                <a
-                  href="{{ instructor.manageAccountLink }}"
-                  (click)="$event.stopPropagation()"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a href="{{ instructor.manageAccountLink }}" (click)="$event.stopPropagation()">
                   <i class="fas fa-info-circle"></i> Manage this account
                 </a>
                 <br />

--- a/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.html
@@ -49,12 +49,7 @@
             <td [innerHtml]="student.comments | highlighter: searchString : true"></td>
             <td>
               @if (student.manageAccountLink) {
-                <a
-                  href="{{ student.manageAccountLink }}"
-                  (click)="$event.stopPropagation()"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a href="{{ student.manageAccountLink }}" (click)="$event.stopPropagation()">
                   <i class="fas fa-info-circle"></i> Manage this account
                 </a>
                 <br />

--- a/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.html
+++ b/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.html
@@ -196,12 +196,9 @@
                         <td>{{ session.endTimeString }}</td>
                         <td>
                           @if (session.ongoingSession.accountId) {
-                            <a
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              [routerLink]="'/web/admin/accounts/' + session.ongoingSession.accountId"
-                              >{{ session.ongoingSession.creatorEmail }}</a
-                            >
+                            <a [routerLink]="'/web/admin/accounts/' + session.ongoingSession.accountId">{{
+                              session.ongoingSession.creatorEmail
+                            }}</a>
                           } @else {
                             {{ session.ongoingSession.creatorEmail }}
                           }

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -570,8 +570,6 @@ exports[`InstructorCourseDetailsPageComponent > should snap with a course with o
                             class="btn btn-light btn-sm btn-margin-right custom-button"
                             href="/web/instructor/courses/CS101/students/student-jamie/details"
                             id="btn-view-details-CS101-0"
-                            rel="noopener noreferrer"
-                            target="_blank"
                           >
                              View 
                           </a>
@@ -579,8 +577,6 @@ exports[`InstructorCourseDetailsPageComponent > should snap with a course with o
                             class="btn btn-light btn-sm btn-margin-right custom-button"
                             href="/web/instructor/courses/CS101/students/student-jamie/edit"
                             id="btn-edit-details-CS101-0"
-                            rel="noopener noreferrer"
-                            target="_blank"
                           >
                              Edit 
                           </a>
@@ -600,8 +596,6 @@ exports[`InstructorCourseDetailsPageComponent > should snap with a course with o
                             class="btn btn-light btn-sm btn-margin-right custom-button"
                             href="/web/instructor/students/CS101/student-jamie/records"
                             id="btn-view-records-CS101-0"
-                            rel="noopener noreferrer"
-                            target="_blank"
                           >
                              All Records 
                           </a>

--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -293,8 +293,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-5/details"
                               id="btn-view-details-test-exa.demo-0"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                View 
                             </a>
@@ -302,8 +300,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-5/edit"
                               id="btn-edit-details-test-exa.demo-0"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                Edit 
                             </a>
@@ -317,8 +313,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/students/test-exa.demo/student-5/records"
                               id="btn-view-records-test-exa.demo-0"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                All Records 
                             </a>
@@ -360,8 +354,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-6/details"
                               id="btn-view-details-test-exa.demo-1"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                View 
                             </a>
@@ -369,8 +361,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-6/edit"
                               id="btn-edit-details-test-exa.demo-1"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                Edit 
                             </a>
@@ -384,8 +374,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/students/test-exa.demo/student-6/records"
                               id="btn-view-records-test-exa.demo-1"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                All Records 
                             </a>
@@ -427,8 +415,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-7/details"
                               id="btn-view-details-test-exa.demo-2"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                View 
                             </a>
@@ -436,8 +422,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-7/edit"
                               id="btn-edit-details-test-exa.demo-2"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                Edit 
                             </a>
@@ -451,8 +435,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/students/test-exa.demo/student-7/records"
                               id="btn-view-records-test-exa.demo-2"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                All Records 
                             </a>
@@ -494,8 +476,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-8/details"
                               id="btn-view-details-test-exa.demo-3"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                View 
                             </a>
@@ -503,8 +483,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/courses/test-exa.demo/students/student-8/edit"
                               id="btn-edit-details-test-exa.demo-3"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                Edit 
                             </a>
@@ -518,8 +496,6 @@ exports[`InstructorSearchPageComponent > should snap with a student table 1`] = 
                               class="btn btn-light btn-sm btn-margin-right custom-button"
                               href="/web/instructor/students/test-exa.demo/student-8/records"
                               id="btn-view-records-test-exa.demo-3"
-                              rel="noopener noreferrer"
-                              target="_blank"
                             >
                                All Records 
                             </a>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.html
@@ -71,8 +71,6 @@
                     @if (!isDisplayOnly) {
                       <a
                         [routerLink]="['/web/sessions', session.feedbackSessionId, 'submission']"
-                        rel="noopener noreferrer"
-                        target="_blank"
                         [queryParams]="{ moderatedPerson: noResponseStudent.userId }"
                         class="btn btn-light btn-sm button"
                       >

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.html
@@ -10,8 +10,6 @@
   }"
   class="btn btn-sm"
   [ngClass]="btnStyle === 'PRIMARY' ? 'btn-primary' : 'btn-light'"
-  target="_blank"
-  rel="noopener noreferrer"
 >
   Moderate response
 </a>


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14181

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

In line with best practices, open links in current tab by default. This gives users the option to open it in a new tab using browser native controls if required.

The exceptions to this:
1. Masquerade mode opens in a new tab
2. External pages
3. Help pages are treated as external page and opened in a new tab