### PR TITLE
[#14353] Remove unauthenticated instructor access

### DIFF
--- a/src/main/java/teammates/common/datatransfer/AuthContext.java
+++ b/src/main/java/teammates/common/datatransfer/AuthContext.java
@@ -3,7 +3,7 @@ package teammates.common.datatransfer;
 import jakarta.annotation.Nullable;
 
 import teammates.storage.entity.Account;
-import teammates.storage.entity.User;
+import teammates.storage.entity.Student;
 import teammates.ui.webapi.AuthType;
 
 /**
@@ -16,14 +16,14 @@ import teammates.ui.webapi.AuthType;
  * @param authType     The authentication type.
  * @param account      The user's account. If masquerading, this is the account
  *                     of the user being masqueraded as.
- * @param regKeyUser   The user associated with the registration key.
- * @param isAdmin      Indicates whether the user has admin privilege.
- * @param isMaintainer Indicates whether the user has maintainer privilege.
+ * @param regKeyStudent The student associated with the registration key.
+ * @param isAdmin       Indicates whether the user has admin privilege.
+ * @param isMaintainer  Indicates whether the user has maintainer privilege.
  */
 public record AuthContext(
         AuthType authType,
         @Nullable Account account,
-        @Nullable User regKeyUser,
+        @Nullable Student regKeyStudent,
         boolean isAdmin,
         boolean isMaintainer) {
 }

--- a/src/main/java/teammates/common/datatransfer/RequestContext.java
+++ b/src/main/java/teammates/common/datatransfer/RequestContext.java
@@ -7,7 +7,6 @@ import java.util.function.BiFunction;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
-import teammates.storage.entity.User;
 import teammates.ui.webapi.AuthType;
 
 /**
@@ -43,8 +42,8 @@ public class RequestContext {
         return authContext.account();
     }
 
-    public User getRegKeyUser() {
-        return authContext.regKeyUser();
+    public Student getRegKeyUser() {
+        return authContext.regKeyStudent();
     }
 
     /**

--- a/src/main/java/teammates/common/util/LinksUtil.java
+++ b/src/main/java/teammates/common/util/LinksUtil.java
@@ -28,11 +28,9 @@ public final class LinksUtil {
     /**
      * Returns the absolute URL for an instructor to submit responses for the given feedback session.
      */
-    public static String getInstructorSessionSubmitUrl(UUID feedbackSessionId, String regKey) {
-        return Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_SUBMISSION_PAGE)
+    public static String getInstructorSessionSubmitUrl(UUID feedbackSessionId) {
+        return Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_SUBMISSION_PAGE)
                 .withFeedbackSessionId(feedbackSessionId)
-                .withRegistrationKey(regKey)
-                .withEntityType(Const.EntityType.INSTRUCTOR)
                 .toAbsoluteString();
     }
 
@@ -49,11 +47,9 @@ public final class LinksUtil {
     /**
      * Returns the absolute URL for an instructor to view results for the given feedback session.
      */
-    public static String getInstructorSessionResultsUrl(UUID feedbackSessionId, String regKey) {
-        return Config.getFrontEndAppUrl(Const.WebPageURIs.SESSION_RESULTS_PAGE)
+    public static String getInstructorSessionResultsUrl(UUID feedbackSessionId) {
+        return Config.getFrontEndAppUrl(Const.WebPageURIs.INSTRUCTOR_SESSION_RESULTS_PAGE)
                 .withFeedbackSessionId(feedbackSessionId)
-                .withRegistrationKey(regKey)
-                .withEntityType(Const.EntityType.INSTRUCTOR)
                 .toAbsoluteString();
     }
 

--- a/src/main/java/teammates/logic/api/UserProvision.java
+++ b/src/main/java/teammates/logic/api/UserProvision.java
@@ -16,7 +16,7 @@ import teammates.logic.core.AccountVerificationsLogic;
 import teammates.logic.core.AccountsLogic;
 import teammates.logic.core.UsersLogic;
 import teammates.storage.entity.Account;
-import teammates.storage.entity.User;
+import teammates.storage.entity.Student;
 import teammates.ui.exception.UnauthorizedAccessException;
 import teammates.ui.webapi.AuthType;
 
@@ -208,7 +208,7 @@ public class UserProvision {
             throws UnauthorizedAccessException {
         AuthType authType = AuthType.LOGGED_IN;
         Account effectiveAccount = account;
-        User validRegKeyUser = null;
+        Student validRegKeyUser = null;
 
         if (isMasqueradeRequest(req)) {
             authType = AuthType.MASQUERADE;
@@ -226,15 +226,16 @@ public class UserProvision {
         }
 
         // If the request contains a registration key, include it in the auth context if
-        // 1. The registration key is valid, and
-        // 2. The user associated with the registration key is not already associated with another account
+        // 1. The registration key is valid and belongs to a student, and
+        // 2. The student associated with the registration key is not already associated with another account
         if (isRegKeyRequest(req)) {
             String regKey = req.getParameter(Const.ParamsNames.REGKEY);
-            User regKeyUser = usersLogic.getUserByRegistrationKey(regKey);
+            Student regKeyStudent = usersLogic.getStudentByRegistrationKey(regKey);
 
-            if (regKeyUser != null
-                    && (regKeyUser.getAccount() == null || Objects.equals(effectiveAccount, regKeyUser.getAccount()))) {
-                validRegKeyUser = regKeyUser;
+            if (regKeyStudent != null
+                    && (regKeyStudent.getAccount() == null
+                            || Objects.equals(effectiveAccount, regKeyStudent.getAccount()))) {
+                validRegKeyUser = regKeyStudent;
             }
         }
 
@@ -260,20 +261,20 @@ public class UserProvision {
 
     private AuthContext handleRegkeyUser(HttpServletRequest req) throws UnauthorizedAccessException {
         String regKey = req.getParameter(Const.ParamsNames.REGKEY);
-        User regKeyUser = usersLogic.getUserByRegistrationKey(regKey);
+        Student regKeyStudent = usersLogic.getStudentByRegistrationKey(regKey);
 
-        if (regKeyUser == null) {
+        if (regKeyStudent == null) {
             throw new UnauthorizedAccessException("Invalid registration key: no user found for regkey");
         }
 
-        if (regKeyUser.getAccount() != null) {
+        if (regKeyStudent.getAccount() != null) {
             throw new UnauthorizedAccessException("Login is required to access this resource");
         }
 
         return new AuthContext(
                 AuthType.REG_KEY,
                 null,
-                regKeyUser,
+                regKeyStudent,
                 false,
                 false);
     }

--- a/src/main/java/teammates/logic/core/AuthLogic.java
+++ b/src/main/java/teammates/logic/core/AuthLogic.java
@@ -36,8 +36,8 @@ public final class AuthLogic {
      * and course ID.
      */
     public Student getStudentFromAuthContext(AuthContext authContext, String courseId) {
-        if (authContext.regKeyUser() instanceof Student student) {
-            return student;
+        if (authContext.regKeyStudent() != null) {
+            return authContext.regKeyStudent();
         }
 
         Account account = authContext.account();
@@ -53,16 +53,10 @@ public final class AuthLogic {
      * course ID.
      *
      * <p>
-     * If a valid registration key is present, it returns the unregistered instructor
-     * from the authentication context. Otherwise, it retrieves the instructor from
-     * the database linked to the account
-     * and course ID.
+     * Retrieves the instructor from the database linked to the account and course ID.
+     * Instructors cannot authenticate via registration key.
      */
     public Instructor getInstructorFromAuthContext(AuthContext authContext, String courseId) {
-        if (authContext.regKeyUser() instanceof Instructor instructor) {
-            return instructor;
-        }
-
         Account account = authContext.account();
         if (account == null) {
             return null;

--- a/src/main/java/teammates/logic/core/DeadlineExtensionsLogic.java
+++ b/src/main/java/teammates/logic/core/DeadlineExtensionsLogic.java
@@ -292,8 +292,8 @@ public final class DeadlineExtensionsLogic {
     private String getSubmitUrl(FeedbackSession feedbackSession, User user) {
         return switch (user) {
         case Student student -> LinksUtil.getStudentSessionSubmitUrl(feedbackSession.getId(), student.getRegKey());
-        case Instructor instructor -> LinksUtil.getInstructorSessionSubmitUrl(feedbackSession.getId(),
-                instructor.getRegKey());
+        case @SuppressWarnings("unused") Instructor instructor ->
+                LinksUtil.getInstructorSessionSubmitUrl(feedbackSession.getId());
         default -> throw new AssertionError("User must be either an instructor or a student: " + user);
         };
     }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -723,14 +723,14 @@ public final class FeedbackSessionsLogic {
     private String getSubmissionUrl(UserType userType, UUID feedbackSessionId, String regKey) {
         return switch (userType) {
         case STUDENT -> LinksUtil.getStudentSessionSubmitUrl(feedbackSessionId, regKey);
-        case INSTRUCTOR -> LinksUtil.getInstructorSessionSubmitUrl(feedbackSessionId, regKey);
+        case INSTRUCTOR -> LinksUtil.getInstructorSessionSubmitUrl(feedbackSessionId);
         };
     }
 
     private String getResultUrl(UserType userType, UUID feedbackSessionId, String regKey) {
         return switch (userType) {
         case STUDENT -> LinksUtil.getStudentSessionResultsUrl(feedbackSessionId, regKey);
-        case INSTRUCTOR -> LinksUtil.getInstructorSessionResultsUrl(feedbackSessionId, regKey);
+        case INSTRUCTOR -> LinksUtil.getInstructorSessionResultsUrl(feedbackSessionId);
         };
     }
 

--- a/src/main/java/teammates/ui/webapi/GetOwnInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/GetOwnInstructorAction.java
@@ -8,7 +8,7 @@ import teammates.ui.output.InstructorData;
 /**
  * Get the information of the instructor associated with the request.
  */
-public class GetOwnInstructorAction extends RegKeyAction {
+public class GetOwnInstructorAction extends LoggedInAction {
     @Override
     void checkSpecificAccessControl() {
         // No specific access control required.

--- a/src/test/java/teammates/common/util/LinksUtilTest.java
+++ b/src/test/java/teammates/common/util/LinksUtilTest.java
@@ -49,10 +49,9 @@ public class LinksUtilTest extends BaseTestCase {
     }
 
     @Test
-    public void getInstructorSessionSubmitUrl_instructorUser_returnsAbsoluteUrlWithInstructorEntityType() {
-        String expected = TEST_BASE_URL + "/web/sessions/" + SAMPLE_SESSION_ID + "/submission"
-                + "?key=" + SAMPLE_REG_KEY + "&entityType=instructor";
-        assertEquals(expected, LinksUtil.getInstructorSessionSubmitUrl(SAMPLE_SESSION_ID, SAMPLE_REG_KEY));
+    public void getInstructorSessionSubmitUrl_instructorUser_returnsAbsoluteUrlOnInstructorPath() {
+        String expected = TEST_BASE_URL + "/web/instructor/sessions/" + SAMPLE_SESSION_ID + "/submission";
+        assertEquals(expected, LinksUtil.getInstructorSessionSubmitUrl(SAMPLE_SESSION_ID));
     }
 
     @Test
@@ -63,10 +62,9 @@ public class LinksUtilTest extends BaseTestCase {
     }
 
     @Test
-    public void getInstructorSessionResultsUrl_instructorUser_returnsAbsoluteUrlWithInstructorEntityType() {
-        String expected = TEST_BASE_URL + "/web/sessions/" + SAMPLE_SESSION_ID + "/result"
-                + "?key=" + SAMPLE_REG_KEY + "&entityType=instructor";
-        assertEquals(expected, LinksUtil.getInstructorSessionResultsUrl(SAMPLE_SESSION_ID, SAMPLE_REG_KEY));
+    public void getInstructorSessionResultsUrl_instructorUser_returnsAbsoluteUrlOnInstructorPath() {
+        String expected = TEST_BASE_URL + "/web/instructor/sessions/" + SAMPLE_SESSION_ID + "/result";
+        assertEquals(expected, LinksUtil.getInstructorSessionResultsUrl(SAMPLE_SESSION_ID));
     }
 
     @Test

--- a/src/test/java/teammates/logic/api/UserProvisionTest.java
+++ b/src/test/java/teammates/logic/api/UserProvisionTest.java
@@ -116,7 +116,7 @@ public class UserProvisionTest extends BaseTestCase {
 
         assertEquals(AuthType.LOGGED_IN, authContext.authType());
         assertEquals(account, authContext.account());
-        assertNull(authContext.regKeyUser());
+        assertNull(authContext.regKeyStudent());
     }
 
     @Test

--- a/src/test/java/teammates/logic/core/AuthLogicTest.java
+++ b/src/test/java/teammates/logic/core/AuthLogicTest.java
@@ -9,7 +9,6 @@ import teammates.common.datatransfer.AuthContext;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.Instructor;
 import teammates.storage.entity.Student;
-import teammates.storage.entity.User;
 import teammates.test.GroupNames;
 import teammates.ui.webapi.AuthType;
 
@@ -62,17 +61,17 @@ public class AuthLogicTest extends BaseLogicTest {
     }
 
     @Test(groups = GroupNames.LOGIC)
-    public void getInstructorFromAuthContext_regKeyAuthContext_returnsUnregisteredInstructor() {
+    public void getInstructorFromAuthContext_regKeyAuthContext_returnsNull() {
         var course = given.course("course");
-        var expectedInstructor = given.instructor("instructor", s -> s.course(course.alias()));
+        var expectedStudent = given.student("student", s -> s.course(course.alias()));
         persistGivenData(given);
 
         Instructor actualInstructor = inTransaction(() -> {
-            AuthContext authContext = buildRegKeyAuthContext(getEntity(Instructor.class, expectedInstructor.id()));
+            AuthContext authContext = buildRegKeyAuthContext(getEntity(Student.class, expectedStudent.id()));
             return authLogic.getInstructorFromAuthContext(authContext, course.id());
         });
 
-        assertEquals(expectedInstructor.id(), actualInstructor.getId());
+        assertNull(actualInstructor);
     }
 
     @Test(groups = GroupNames.LOGIC)
@@ -104,8 +103,8 @@ public class AuthLogicTest extends BaseLogicTest {
         assertNull(actualInstructor);
     }
 
-    private AuthContext buildRegKeyAuthContext(User user) {
-        return new AuthContext(AuthType.REG_KEY, null, user, false, false);
+    private AuthContext buildRegKeyAuthContext(Student student) {
+        return new AuthContext(AuthType.REG_KEY, null, student, false, false);
     }
 
     private AuthContext buildAccountAuthContext(Account account) {

--- a/src/test/java/teammates/logic/email/EmailRendererTest.java
+++ b/src/test/java/teammates/logic/email/EmailRendererTest.java
@@ -127,7 +127,7 @@ public class EmailRendererTest extends BaseTestCase {
                         Instant.parse("2027-04-30T21:59:00Z"),
                         false,
                         "Please please fill in the following questions.",
-                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID),
                         true,
                         buildCourseContext().coOwnerContacts()));
 
@@ -189,7 +189,7 @@ public class EmailRendererTest extends BaseTestCase {
                         Instant.parse("2027-04-30T21:59:00Z"),
                         false,
                         "Please please fill in the following questions.",
-                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID),
                         true,
                         buildCourseContext().coOwnerContacts()));
 
@@ -252,7 +252,7 @@ public class EmailRendererTest extends BaseTestCase {
                         Instant.parse("2027-04-30T21:59:00Z"),
                         false,
                         "Please please fill in the following questions.",
-                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID),
                         true,
                         buildCourseContext().coOwnerContacts()));
 
@@ -307,7 +307,7 @@ public class EmailRendererTest extends BaseTestCase {
                         "idOfTypicalCourse1",
                         "Typical Course 1 with 2 Evals",
                         "First feedback session",
-                        LinksUtil.getInstructorSessionResultsUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionResultsUrl(FEEDBACK_SESSION_ID),
                         true,
                         buildCourseContext().coOwnerContacts()));
 
@@ -722,7 +722,7 @@ public class EmailRendererTest extends BaseTestCase {
                         "instructor2@course1.tmt",
                         "Instructor2 Course1",
                         true,
-                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID),
                         Instant.parse("2027-04-30T21:59:00Z"),
                         Instant.parse("2027-04-30T23:00:00Z"),
                         EmailType.DEADLINE_EXTENSION_GRANTED));
@@ -736,7 +736,7 @@ public class EmailRendererTest extends BaseTestCase {
                         "instructor2@course1.tmt",
                         "Instructor2 Course1",
                         true,
-                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID),
                         Instant.parse("2027-04-30T21:59:00Z"),
                         Instant.parse("2027-04-30T23:00:00Z"),
                         EmailType.DEADLINE_EXTENSION_UPDATED));
@@ -750,7 +750,7 @@ public class EmailRendererTest extends BaseTestCase {
                         "instructor2@course1.tmt",
                         "Instructor2 Course1",
                         true,
-                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID, REG_KEY),
+                        LinksUtil.getInstructorSessionSubmitUrl(FEEDBACK_SESSION_ID),
                         Instant.parse("2027-04-30T23:00:00Z"),
                         Instant.parse("2027-04-30T21:59:00Z"),
                         EmailType.DEADLINE_EXTENSION_REVOKED));

--- a/src/test/java/teammates/ui/webapi/GetOwnInstructorActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetOwnInstructorActionTest.java
@@ -32,22 +32,6 @@ public class GetOwnInstructorActionTest extends BaseActionTest<GetOwnInstructorA
     }
 
     @Test(groups = GroupNames.ACTION)
-    public void getOwnInstructorAction_byRegKey_returnsInstructorData() {
-        var course = given.course("course");
-        var instructor = given.instructor("instructor", i -> i.course(course.alias()));
-        persistGivenData(given);
-
-        RequestContext request = new RequestContext()
-                .withParam(Const.ParamsNames.COURSE_ID, course.id())
-                .withRegKey(instructor.regKey());
-
-        InstructorData result = execute(request);
-
-        assertEquals(instructor.id(), result.getUserId());
-        assertEquals(course.id(), result.getCourseId());
-    }
-
-    @Test(groups = GroupNames.ACTION)
     public void getOwnInstructorAction_requestWithoutInstructor_throwsEntityNotFoundException() {
         var account = given.account("account");
         var course = given.course("course");

--- a/src/test/java/teammates/ui/webapi/GetSessionLinksActionTest.java
+++ b/src/test/java/teammates/ui/webapi/GetSessionLinksActionTest.java
@@ -72,12 +72,10 @@ public class GetSessionLinksActionTest extends BaseActionTest<GetSessionLinksAct
         assertEquals(LinksUtil.getInstructorCourseJoinUrl(instructor.regKey()), result.getCourseJoinLink());
         assertTrue(result.getSubmissionLinks().stream().anyMatch(
                 link -> openSession.id().equals(link.feedbackSessionId())
-                        && LinksUtil.getInstructorSessionSubmitUrl(openSession.id(),
-                                instructor.regKey()).equals(link.url())));
+                        && LinksUtil.getInstructorSessionSubmitUrl(openSession.id()).equals(link.url())));
         assertTrue(result.getResultsLinks().stream().anyMatch(
                 link -> publishedSession.id().equals(link.feedbackSessionId())
-                        && LinksUtil.getInstructorSessionResultsUrl(publishedSession.id(), instructor.regKey())
-                                .equals(link.url())));
+                        && LinksUtil.getInstructorSessionResultsUrl(publishedSession.id()).equals(link.url())));
     }
 
     @Test(groups = GroupNames.ACTION)

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor">${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/submission">${app.url}/web/instructor/sessions/${fsid}/submission</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor">${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/submission">${app.url}/web/instructor/sessions/${fsid}/submission</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor">${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/submission">${app.url}/web/instructor/sessions/${fsid}/submission</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/sessionClosingSoonEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingSoonEmailForInstructor.html
@@ -53,7 +53,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor">${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/submission">${app.url}/web/instructor/sessions/${fsid}/submission</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/sessionOpenedEmailForInstructor.html
+++ b/src/test/resources/emails/sessionOpenedEmailForInstructor.html
@@ -52,7 +52,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor">${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/submission">${app.url}/web/instructor/sessions/${fsid}/submission</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/sessionPublishedEmailForInstructor.html
+++ b/src/test/resources/emails/sessionPublishedEmailForInstructor.html
@@ -30,7 +30,7 @@
   <ul>
     <li>
       <strong>To view the responses for this session, please go to this Web address: </strong>
-      <a href="http://localhost:4200/web/sessions/${fsid}/result?key=${regkey.enc}&entityType=instructor">http://localhost:4200/web/sessions/${fsid}/result?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/result">${app.url}/web/instructor/sessions/${fsid}/result</a>
     </li>
     <li>The above link is unique to you. Please do not share it with others.</li>
   </ul>

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -53,7 +53,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor">${app.url}/web/sessions/${fsid}/submission?key=${regkey.enc}&entityType=instructor</a>
+      <a href="${app.url}/web/instructor/sessions/${fsid}/submission">${app.url}/web/instructor/sessions/${fsid}/submission</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -135,7 +135,7 @@ export class SessionResultPageComponent implements OnInit {
           this.navigationService.navigateWithErrorMessage('/web/front', 'You are not authorized to view this page.');
           return;
         }
-        if (this.key) {
+        if (this.key && this.entityType !== 'instructor') {
           this.authService.getAuthRegkeyValidity(this.key, this.intent).subscribe({
             next: (resp: RegkeyValidity) => {
               if (resp.isAllowedAccess) {
@@ -228,7 +228,7 @@ export class SessionResultPageComponent implements OnInit {
     } else if (this.previewAs) {
       return this.instructorService.getInstructor({ userId: this.previewAs });
     } else {
-      return this.instructorService.getOwnInstructor({ courseId: this.courseId, key: this.key });
+      return this.instructorService.getOwnInstructor({ courseId: this.courseId });
     }
   }
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -176,7 +176,7 @@ export class SessionSubmissionPageComponent implements OnInit {
         if (auth.user) {
           this.accountEmail = auth.user.accountEmail;
         }
-        if (this.key && !isPreviewOrModeration) {
+        if (this.key && !isPreviewOrModeration && this.entityType !== 'instructor') {
           this.authService.getAuthRegkeyValidity(this.key, this.intent).subscribe({
             next: (resp: RegkeyValidity) => {
               if (resp.isAllowedAccess) {
@@ -294,7 +294,6 @@ export class SessionSubmissionPageComponent implements OnInit {
         return this.instructorService
           .getOwnInstructor({
             courseId: this.courseId,
-            key: this.key,
           })
           .pipe(
             tap((instructor: Instructor) => {

--- a/src/web/services/instructor.service.ts
+++ b/src/web/services/instructor.service.ts
@@ -58,13 +58,10 @@ export class InstructorService {
   /**
    * Get the instructor associated with the current request in a course by calling API.
    */
-  getOwnInstructor(queryParams: { courseId: string; key?: string }): Observable<Instructor> {
+  getOwnInstructor(queryParams: { courseId: string }): Observable<Instructor> {
     const paramMap: Record<string, string> = {
       courseid: queryParams.courseId,
     };
-    if (queryParams.key) {
-      paramMap['key'] = queryParams.key;
-    }
 
     return this.httpRequestService.get(ResourceEndpoints.OWN_INSTRUCTOR, paramMap);
   }


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14353

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

The first part of this series of PRs modifies access control to prevent instructor access via regkey. Instead, instructors will have to sign in first. 

Emails have been updated with the new links. Note that while the links are not unique at the moment, we will be updating them to be unique in a future PR (storing the context so that we can display appropriate messages on the frontend if the wrong account is used).
