### PR TITLE
[#14352] Remove total unregistered column from instructor courses page

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCoursesPageE2ETest.java
@@ -221,7 +221,6 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
         int numSections = 0;
         int numTeams = 0;
         int numStudents = 0;
-        int numUnregistered = 0;
         Set<String> sections = new HashSet<>();
         Set<String> teams = new HashSet<>();
 
@@ -237,12 +236,9 @@ public class InstructorCoursesPageE2ETest extends BaseE2ETestCase {
                 teams.add(student.getTeamName());
                 numTeams++;
             }
-            if (!student.isRegistered()) {
-                numUnregistered++;
-            }
             numStudents++;
         }
         coursesPage.verifyActiveCourseStatistics(course, Integer.toString(numSections), Integer.toString(numTeams),
-                Integer.toString(numStudents), Integer.toString(numUnregistered));
+                Integer.toString(numStudents));
     }
 }

--- a/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/InstructorCoursesPage.java
@@ -65,11 +65,11 @@ public class InstructorCoursesPage extends AppPage {
     }
 
     public void verifyActiveCourseStatistics(Course course, String numSections, String numTeams,
-                                             String numStudents, String numUnregistered) {
+                                             String numStudents) {
         showStatistics(course.getId());
         String[] courseDetail = { course.getId(), course.getName(),
                 getDateString(course.getCreatedAt()),
-                numSections, numTeams, numStudents, numUnregistered };
+                numSections, numTeams, numStudents };
         verifyTableRowValues(getActiveTableRow(course.getId()), courseDetail);
     }
 

--- a/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-courses-page/__snapshots__/instructor-courses-page.component.spec.ts.snap
@@ -6566,9 +6566,6 @@ exports[`InstructorCoursesPageComponent > should snap when it is undeletable and
                   <th>
                     Total Students
                   </th>
-                  <th>
-                    Total Unregistered
-                  </th>
                   <th
                     class="text-center"
                   >
@@ -6595,11 +6592,6 @@ exports[`InstructorCoursesPageComponent > should snap when it is undeletable and
                       container="body"
                     >
                        5 Nov 2018 
-                    </span>
-                  </td>
-                  <td>
-                    <span>
-                       1 
                     </span>
                   </td>
                   <td>
@@ -6696,11 +6688,6 @@ exports[`InstructorCoursesPageComponent > should snap when it is undeletable and
                       container="body"
                     >
                        2 Feb 2019 
-                    </span>
-                  </td>
-                  <td>
-                    <span>
-                       2 
                     </span>
                   </td>
                   <td>
@@ -13574,9 +13561,6 @@ exports[`InstructorCoursesPageComponent > should snap with all courses in course
                   <th>
                     Total Students
                   </th>
-                  <th>
-                    Total Unregistered
-                  </th>
                   <th
                     class="text-center"
                   >
@@ -13603,11 +13587,6 @@ exports[`InstructorCoursesPageComponent > should snap with all courses in course
                       container="body"
                     >
                        5 Nov 2018 
-                    </span>
-                  </td>
-                  <td>
-                    <span>
-                       1 
                     </span>
                   </td>
                   <td>
@@ -13704,11 +13683,6 @@ exports[`InstructorCoursesPageComponent > should snap with all courses in course
                       container="body"
                     >
                        2 Feb 2019 
-                    </span>
-                  </td>
-                  <td>
-                    <span>
-                       2 
                     </span>
                   </td>
                   <td>
@@ -20599,9 +20573,6 @@ exports[`InstructorCoursesPageComponent > should snap with no courses in course 
                   <th>
                     Total Students
                   </th>
-                  <th>
-                    Total Unregistered
-                  </th>
                   <th
                     class="text-center"
                   >
@@ -20646,15 +20617,6 @@ exports[`InstructorCoursesPageComponent > should snap with no courses in course 
                         id="show-statistics-0"
                       >
                          Show 
-                      </button>
-                    </span>
-                  </td>
-                  <td>
-                    <span>
-                      <button
-                        class="link-button"
-                      >
-                        Show
                       </button>
                     </span>
                   </td>
@@ -20764,15 +20726,6 @@ exports[`InstructorCoursesPageComponent > should snap with no courses in course 
                         id="show-statistics-1"
                       >
                          Show 
-                      </button>
-                    </span>
-                  </td>
-                  <td>
-                    <span>
-                      <button
-                        class="link-button"
-                      >
-                        Show
                       </button>
                     </span>
                   </td>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.html
@@ -111,7 +111,6 @@
                   <th>Sections</th>
                   <th>Teams</th>
                   <th>Total Students</th>
-                  <th>Total Unregistered</th>
                   <th class="text-center">Action(s)</th>
                 </tr>
               </thead>
@@ -179,22 +178,6 @@
                       @if (courseStats[course.course.courseId]) {
                         <span>
                           {{ courseStats[course.course.courseId]['students'] }}
-                        </span>
-                      }
-                    </td>
-                    <td>
-                      @if (!courseStats[course.course.courseId]) {
-                        <span>
-                          @if (!course.isLoadingCourseStats) {
-                            <button (click)="getCourseStats(i)" class="link-button">Show</button>
-                          } @else {
-                            <tm-ajax-loading [useBlueSpinner]="true"></tm-ajax-loading>
-                          }
-                        </span>
-                      }
-                      @if (courseStats[course.course.courseId]) {
-                        <span>
-                          {{ courseStats[course.course.courseId]['unregistered'] }}
                         </span>
                       }
                     </td>

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -105,13 +105,11 @@ describe('InstructorCoursesPageComponent', () => {
       sections: 1,
       teams: 1,
       students: 1,
-      unregistered: 1,
     },
     CS3282: {
       sections: 2,
       teams: 2,
       students: 2,
-      unregistered: 2,
     },
   };
 
@@ -389,7 +387,6 @@ describe('InstructorCoursesPageComponent', () => {
     expect(component.courseStats['CS1231']['sections']).toEqual(2);
     expect(component.courseStats['CS1231']['teams']).toEqual(3);
     expect(component.courseStats['CS1231']['students']).toEqual(8);
-    expect(component.courseStats['CS1231']['unregistered']).toEqual(1);
   });
 
   it('should restore a soft deleted course', () => {

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -26,7 +26,6 @@ import {
   FeedbackSessionView,
   FeedbackSessions,
   AuthInfo,
-  JoinState,
   MessageOutput,
   ResponseVisibleSetting,
   SessionVisibleSetting,
@@ -269,7 +268,6 @@ export class InstructorCoursesPageComponent implements OnInit {
             sections: new Set(students.students.map((value: Student) => value.sectionName)).size,
             teams: new Set(students.students.map((value: Student) => value.teamName)).size,
             students: students.students.length,
-            unregistered: students.students.filter((value: Student) => value.joinState === JoinState.NOT_JOINED).length,
           };
         },
         error: (resp: ErrorMessageOutput) => {


### PR DESCRIPTION
Fixes #14352 

**Outline of Solution**

Removed the table data and column heading for 'total unregistered' and also updated the `getCourseStats(idx: number)` method to no longer return unregistered users. 
Created a new snapshot for testing and updated the E2E test cases to reflect the new UI changes on the frontend.

<img width="1235" height="357" alt="image" src="https://github.com/user-attachments/assets/bc1783f8-8c0b-4643-9596-4df7236f4a50" />