### PR TITLE
[#14353] Remove intent from submission and results pages

### DIFF
--- a/src/web/app/app.routes.ts
+++ b/src/web/app/app.routes.ts
@@ -3,7 +3,6 @@ import { AdminPageComponent } from './pages-admin/admin-page.component';
 import { InstructorPageComponent } from './pages-instructor/instructor-page.component';
 import { MaintainerPageComponent } from './pages-maintainer/maintainer-page.component';
 import { StaticPageComponent } from './pages-static/static-page.component';
-import { Intent } from '../types/api-request';
 import { StudentPageComponent } from './pages-student/student-page.component';
 import { RoleGuard, UserRole } from '../route-guards/role.guard';
 import { PageComponent } from './page.component';
@@ -39,9 +38,6 @@ const routes: Routes = [
               import('./pages-session/session-result-page/session-result-page.component').then(
                 (m) => m.SessionResultPageComponent,
               ),
-            data: {
-              intent: Intent.STUDENT_RESULT,
-            },
           },
           {
             path: ':feedbackSessionId/submission',
@@ -49,9 +45,6 @@ const routes: Routes = [
               import('./pages-session/session-submission-page/session-submission-page.component').then(
                 (m) => m.SessionSubmissionPageComponent,
               ),
-            data: {
-              intent: Intent.STUDENT_SUBMISSION,
-            },
           },
         ],
       },

--- a/src/web/app/app.routes.ts
+++ b/src/web/app/app.routes.ts
@@ -38,6 +38,9 @@ const routes: Routes = [
               import('./pages-session/session-result-page/session-result-page.component').then(
                 (m) => m.SessionResultPageComponent,
               ),
+            data: {
+              entityType: 'student',
+            },
           },
           {
             path: ':feedbackSessionId/submission',
@@ -45,6 +48,9 @@ const routes: Routes = [
               import('./pages-session/session-submission-page/session-submission-page.component').then(
                 (m) => m.SessionSubmissionPageComponent,
               ),
+            data: {
+              entityType: 'student',
+            },
           },
         ],
       },

--- a/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
+++ b/src/web/app/components/question-response-panel/__snapshots__/question-response-panel.component.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`QuestionResponsePanelComponent > should snap with feedback session with questions 1`] = `
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
-  intent={[Function String]}
+  entityType={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
   regKey=""
@@ -410,7 +410,7 @@ exports[`QuestionResponsePanelComponent > should snap with feedback session with
 exports[`QuestionResponsePanelComponent > should snap with feedback session with questions of anonymous responses 1`] = `
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
-  intent={[Function String]}
+  entityType={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
   regKey=""
@@ -701,7 +701,7 @@ exports[`QuestionResponsePanelComponent > should snap with feedback session with
 exports[`QuestionResponsePanelComponent > should snap with questions and responses when previewing results 1`] = `
 <tm-question-response-panel
   RESPONSE_HIDDEN_QUESTIONS={[Function Array]}
-  intent={[Function String]}
+  entityType={[Function String]}
   previewAsPerson=""
   questions={[Function Array]}
   regKey=""

--- a/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
@@ -572,8 +572,9 @@ describe('QuestionResponsePanelComponent', () => {
     expect(canSee).toBe(true);
   });
 
-  it('canUserSeeResponses: should return false when entityType does not allow seeing responses', () => {
+  it('canUserSeeResponses: should return false when no responses are visible to instructors', () => {
     component.entityType = 'instructor';
+    // Empty showResponsesTo should make the instructor branch return false.
     testFeedbackQuestionModel.feedbackQuestion.showResponsesTo = [];
     const canSee = component.canUserSeeResponses(testFeedbackQuestionModel);
 

--- a/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.spec.ts
@@ -24,7 +24,6 @@ import {
   ResponseVisibleSetting,
   SessionVisibleSetting,
 } from '../../../types/api-output';
-import { Intent } from '../../../types/api-request';
 import { FeedbackQuestionModel } from '../../pages-session/session-result-page/feedback-question.model';
 
 describe('QuestionResponsePanelComponent', () => {
@@ -565,23 +564,24 @@ describe('QuestionResponsePanelComponent', () => {
     expect(fixture).toMatchSnapshot();
   });
 
-  it('canUserSeeResponses: should allow instructors to see responses when intent is INSTRUCTOR_RESULT', () => {
-    component.intent = Intent.INSTRUCTOR_RESULT;
+  it('canUserSeeResponses: should allow instructors to see responses when entityType is instructor', () => {
+    component.entityType = 'instructor';
     testFeedbackQuestionModel.feedbackQuestion.showResponsesTo = [FeedbackVisibilityType.INSTRUCTORS];
     const canSee = component.canUserSeeResponses(testFeedbackQuestionModel);
 
     expect(canSee).toBe(true);
   });
 
-  it('canUserSeeResponses: should return false when intent does not allow seeing responses', () => {
-    component.intent = Intent.FULL_DETAIL;
+  it('canUserSeeResponses: should return false when entityType does not allow seeing responses', () => {
+    component.entityType = 'instructor';
+    testFeedbackQuestionModel.feedbackQuestion.showResponsesTo = [];
     const canSee = component.canUserSeeResponses(testFeedbackQuestionModel);
 
     expect(canSee).toBe(false);
   });
 
-  it('canUserSeeResponses: should allow students when responses are visible to recipients and instructors', () => {
-    component.intent = Intent.STUDENT_RESULT;
+  it('canUserSeeResponses: should allow students when entityType is student and responses are visible to recipients and instructors', () => {
+    component.entityType = 'student';
     testFeedbackQuestionModel.feedbackQuestion.showResponsesTo = [
       FeedbackVisibilityType.RECIPIENT,
       FeedbackVisibilityType.INSTRUCTORS,

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -7,7 +7,7 @@ import {
   ResponseVisibleSetting,
   SessionVisibleSetting,
 } from '../../../types/api-output';
-import { FeedbackVisibilityType, Intent } from '../../../types/api-request';
+import { FeedbackVisibilityType } from '../../../types/api-request';
 import { FeedbackQuestionModel } from '../../pages-session/session-result-page/feedback-question.model';
 import { SingleStatisticsComponent } from '../question-responses/single-statistics/single-statistics.component';
 import { StudentViewResponsesComponent } from '../question-responses/student-view-responses/student-view-responses.component';
@@ -47,8 +47,7 @@ export class QuestionResponsePanelComponent {
     createdAtTimestamp: 0,
   };
 
-  @Input()
-  intent: Intent = Intent.STUDENT_RESULT;
+  @Input() entityType: 'student' | 'instructor' = 'student';
 
   @Input()
   regKey = '';
@@ -58,7 +57,7 @@ export class QuestionResponsePanelComponent {
 
   canUserSeeResponses(question: FeedbackQuestionModel): boolean {
     const showResponsesTo: FeedbackVisibilityType[] = question.feedbackQuestion.showResponsesTo;
-    if (this.intent === Intent.STUDENT_RESULT) {
+    if (this.entityType === 'student') {
       return (
         showResponsesTo.includes(FeedbackVisibilityType.RECIPIENT) ||
         showResponsesTo.includes(FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS) ||
@@ -66,7 +65,7 @@ export class QuestionResponsePanelComponent {
         showResponsesTo.includes(FeedbackVisibilityType.STUDENTS)
       );
     }
-    if (this.intent === Intent.INSTRUCTOR_RESULT) {
+    if (this.entityType === 'instructor') {
       return showResponsesTo.includes(FeedbackVisibilityType.INSTRUCTORS);
     }
     return false;

--- a/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
+++ b/src/web/app/components/sessions-table/__snapshots__/sessions-table.component.spec.ts.snap
@@ -407,7 +407,7 @@ exports[`SessionsTableComponent > should snap like in home page with 2 sessions 
                      Copy 
                   </button>
                   <a
-                    href="/web/instructor/sessions/first-session-id/submission?editingMode=true"
+                    href="/web/instructor/sessions/first-session-id/submission"
                   >
                     <button
                       class="btn btn-light btn-sm"
@@ -712,7 +712,7 @@ exports[`SessionsTableComponent > should snap like in sessions page with 2 sessi
                      Copy 
                   </button>
                   <a
-                    href="/web/instructor/sessions/first-session-id/submission?editingMode=true"
+                    href="/web/instructor/sessions/first-session-id/submission"
                   >
                     <button
                       class="btn btn-light btn-sm"

--- a/src/web/app/components/sessions-table/cell-with-group-buttons.component.html
+++ b/src/web/app/components/sessions-table/cell-with-group-buttons.component.html
@@ -27,7 +27,7 @@
   </button>
 
   @if (submissionStatus === FeedbackSessionSubmissionStatus.OPEN && instructorPrivileges.canSubmitSession) {
-    <a [routerLink]="['/web/instructor/sessions', fsId, 'submission']" [queryParams]="{ editingMode: true }">
+    <a [routerLink]="['/web/instructor/sessions', fsId, 'submission']">
       <ng-container *ngTemplateOutlet="submitBtn"></ng-container>
     </a>
   } @else {

--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -784,7 +784,7 @@ exports[`InstructorHomePageComponent > should snap with one course with one feed
                                    Copy 
                                 </button>
                                 <a
-                                  href="/web/instructor/sessions/first-session-id/submission?editingMode=true"
+                                  href="/web/instructor/sessions/first-session-id/submission"
                                 >
                                   <button
                                     class="btn btn-light btn-sm"

--- a/src/web/app/pages-instructor/instructor.routes.ts
+++ b/src/web/app/pages-instructor/instructor.routes.ts
@@ -1,5 +1,4 @@
 import { type Routes } from '@angular/router';
-import { Intent } from '../../types/api-request';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 
 const routes: Routes = [
@@ -111,7 +110,7 @@ const routes: Routes = [
             (m) => m.SessionSubmissionPageComponent,
           ),
         data: {
-          intent: Intent.INSTRUCTOR_SUBMISSION,
+          entityType: 'instructor',
         },
       },
       {
@@ -121,7 +120,7 @@ const routes: Routes = [
             (m) => m.SessionResultPageComponent,
           ),
         data: {
-          intent: Intent.INSTRUCTOR_RESULT,
+          entityType: 'instructor',
         },
       },
       {

--- a/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-result-page/__snapshots__/session-result-page.component.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`SessionResultPageComponent > should snap when previewing results 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -18,7 +17,6 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading="false"
@@ -149,7 +147,6 @@ exports[`SessionResultPageComponent > should snap when previewing results 1`] = 
 
 exports[`SessionResultPageComponent > should snap when session results failed to load 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -165,7 +162,6 @@ exports[`SessionResultPageComponent > should snap when session results failed to
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed={[Function Boolean]}
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading="false"
@@ -300,7 +296,6 @@ exports[`SessionResultPageComponent > should snap when session results failed to
 
 exports[`SessionResultPageComponent > should snap with an open feedback session with no questions 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -316,7 +311,6 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading="false"
@@ -448,7 +442,6 @@ exports[`SessionResultPageComponent > should snap with an open feedback session 
 
 exports[`SessionResultPageComponent > should snap with default fields 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -464,7 +457,6 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading="false"
@@ -596,7 +588,6 @@ exports[`SessionResultPageComponent > should snap with default fields 1`] = `
 
 exports[`SessionResultPageComponent > should snap with session details and results are loading 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -612,7 +603,6 @@ exports[`SessionResultPageComponent > should snap with session details and resul
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading={[Function Boolean]}
   isFeedbackSessionDetailsLoading={[Function Boolean]}
   isFeedbackSessionResultsLoading={[Function Boolean]}
@@ -676,7 +666,6 @@ exports[`SessionResultPageComponent > should snap with session details and resul
 
 exports[`SessionResultPageComponent > should snap with session details loaded and results are loading 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -692,7 +681,6 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading={[Function Boolean]}
@@ -824,7 +812,6 @@ exports[`SessionResultPageComponent > should snap with session details loaded an
 
 exports[`SessionResultPageComponent > should snap with user that is logged in and using session link 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail={[Function String]}
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -840,7 +827,6 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading="false"
@@ -973,7 +959,6 @@ exports[`SessionResultPageComponent > should snap with user that is logged in an
 
 exports[`SessionResultPageComponent > should snap with user that is not logged in and using session link 1`] = `
 <tm-session-result-page
-  Intent={[Function Object]}
   accountEmail=""
   authService={[Function _AuthService]}
   backendUrl={[Function String]}
@@ -989,7 +974,6 @@ exports[`SessionResultPageComponent > should snap with user that is not logged i
   formattedSessionOpeningTime=""
   hasFeedbackSessionResultsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isCourseLoading="false"
   isFeedbackSessionDetailsLoading="false"
   isFeedbackSessionResultsLoading="false"

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -4,18 +4,16 @@
     <div class="col-12 text-center text-break">
       <h4>
         Previewing Session Results as
-        @if (intent === Intent.STUDENT_RESULT) {
+        @if (entityType === 'student') {
           <span>student</span>
-        }
-        @if (intent === Intent.INSTRUCTOR_RESULT) {
+        } @else {
           <span>instructor</span>
         }
         {{ personName }} ({{ personEmail }})
-        @if (!isPreviewHintExpanded) {
-          <button type="button" class="btn btn-link no-shadow" (click)="isPreviewHintExpanded = true">[more]</button>
-        }
         @if (isPreviewHintExpanded) {
           <button type="button" class="btn btn-link no-shadow" (click)="isPreviewHintExpanded = false">[less]</button>
+        } @else {
+          <button type="button" class="btn btn-link no-shadow" (click)="isPreviewHintExpanded = true">[more]</button>
         }
       </h4>
       @if (isPreviewHintExpanded) {
@@ -90,7 +88,7 @@
   </div>
 </div>
 
-@if (intent === Intent.INSTRUCTOR_RESULT && !isCourseLoading && !isFeedbackSessionDetailsLoading) {
+@if (entityType === 'instructor' && !isCourseLoading && !isFeedbackSessionDetailsLoading) {
   <div class="card bg-light" style="margin-bottom: 20px">
     <div class="card-body">
       If you wish to view the feedback results of the entire course,
@@ -127,7 +125,7 @@
       <tm-question-response-panel
         [questions]="questions"
         [session]="session"
-        [intent]="intent"
+        [entityType]="entityType"
         [regKey]="key"
         [previewAsPerson]="previewAs"
       ></tm-question-response-panel>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -28,7 +28,6 @@ import {
   ResponseVisibleSetting,
   SessionVisibleSetting,
 } from '../../../types/api-output';
-import { Intent } from '../../../types/api-request';
 
 describe('SessionResultPageComponent', () => {
   const testFeedbackSession: FeedbackSession = {
@@ -120,7 +119,6 @@ describe('SessionResultPageComponent', () => {
     component.feedbackSessionId = testQueryParams['fsid'];
     component.key = testQueryParams['key'];
     component.previewAs = testQueryParams['previewAs'];
-    component.intent = Intent.STUDENT_RESULT;
     // Set both loading flags to false initially for testing purposes only
     component.isCourseLoading = false;
     component.isFeedbackSessionDetailsLoading = false;
@@ -202,7 +200,6 @@ describe('SessionResultPageComponent', () => {
   });
 
   it('should snap when previewing results', () => {
-    component.intent = Intent.STUDENT_RESULT;
     component.key = '';
     component.previewAs = 'alice2@tmt.tmt';
     component.personName = 'Alice2';

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -58,9 +58,6 @@ export class SessionResultPageComponent implements OnInit {
   private readonly logService = inject(LogService);
   private readonly ngbModal = inject(NgbModal);
 
-  // enum
-  Intent!: typeof Intent;
-
   retryAttempts!: number;
 
   session: FeedbackSession = {
@@ -91,10 +88,9 @@ export class SessionResultPageComponent implements OnInit {
   courseId = '';
   feedbackSessionName = '';
   @Input({ required: true }) feedbackSessionId!: string;
-  @Input() intent: Intent = Intent.STUDENT_RESULT;
   @Input() key = '';
   @Input() previewAs = '';
-  @Input() entityType = 'student';
+  @Input() entityType: 'student' | 'instructor' = 'student';
   accountEmail = '';
   visibilityRecipient: FeedbackVisibilityType = FeedbackVisibilityType.RECIPIENT;
 
@@ -108,18 +104,11 @@ export class SessionResultPageComponent implements OnInit {
   private readonly backendUrl: string = environment.backendUrl;
 
   constructor() {
-    this.Intent = Intent;
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
     this.retryAttempts = DEFAULT_NUMBER_OF_RETRY_ATTEMPTS;
   }
 
   ngOnInit(): void {
-    if (this.intent === Intent.INSTRUCTOR_RESULT) {
-      this.entityType = 'instructor';
-    }
-    if (this.entityType === 'instructor') {
-      this.intent = Intent.INSTRUCTOR_RESULT;
-    }
     // withComponentInputBinding() can reset @Input() defaults to undefined; restore the 'student' default
     this.entityType ||= 'student';
 
@@ -135,8 +124,8 @@ export class SessionResultPageComponent implements OnInit {
           this.navigationService.navigateWithErrorMessage('/web/front', 'You are not authorized to view this page.');
           return;
         }
-        if (this.key && this.entityType !== 'instructor') {
-          this.authService.getAuthRegkeyValidity(this.key, this.intent).subscribe({
+        if (this.key && this.entityType === 'student') {
+          this.authService.getAuthRegkeyValidity(this.key, this.getResultIntent()).subscribe({
             next: (resp: RegkeyValidity) => {
               if (resp.isAllowedAccess) {
                 if (resp.isUsed) {
@@ -193,7 +182,7 @@ export class SessionResultPageComponent implements OnInit {
   private loadCourseInfo(): void {
     this.isCourseLoading = true;
     let request: Observable<CourseView>;
-    switch (this.intent) {
+    switch (this.getResultIntent()) {
       case Intent.STUDENT_RESULT:
         if (this.previewAs) {
           request = this.courseService.getCourseAsInstructor(this.courseId);
@@ -332,6 +321,10 @@ export class SessionResultPageComponent implements OnInit {
     this.navigationService.navigateByURL('/web/join', { entityType: this.entityType, key: this.key });
   }
 
+  getResultIntent(): Intent {
+    return this.entityType === 'student' ? Intent.STUDENT_RESULT : Intent.INSTRUCTOR_RESULT;
+  }
+
   navigateToSessionReportPage(): void {
     this.navigationService.navigateByURL(`/web/instructor/sessions/${this.feedbackSessionId}/report`);
   }
@@ -362,7 +355,7 @@ export class SessionResultPageComponent implements OnInit {
    * Logs student activity after student/session details have been fetched.
    */
   logStudentView(): void {
-    if (this.intent !== Intent.STUDENT_RESULT) {
+    if (this.entityType !== 'student') {
       return;
     }
 

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -26,7 +25,6 @@ exports[`SessionSubmissionPageComponent > should snap when feedback session ques
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed={[Function Boolean]}
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
@@ -177,7 +175,6 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -199,7 +196,6 @@ exports[`SessionSubmissionPageComponent > should snap when saving responses 1`] 
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
@@ -347,7 +343,6 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -369,7 +364,6 @@ exports[`SessionSubmissionPageComponent > should snap with default fields 1`] = 
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
@@ -517,7 +511,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail={[Function String]}
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -539,7 +532,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session and 
   formattedSessionOpeningTime={[Function String]}
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading="false"
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
@@ -750,7 +742,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -772,7 +763,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading="false"
   isFeedbackSessionQuestionsLoading="false"
@@ -3818,7 +3808,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -3840,7 +3829,6 @@ exports[`SessionSubmissionPageComponent > should snap with feedback session ques
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading="false"
   isFeedbackSessionQuestionsLoading="false"
@@ -6924,7 +6912,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail={[Function String]}
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -6946,7 +6933,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is logged i
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}
@@ -7096,7 +7082,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
 <tm-session-submission-page
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
-  Intent={[Function Object]}
   accountEmail=""
   allSessionViews={[Function Object]}
   authService={[Function _AuthService]}
@@ -7118,7 +7103,6 @@ exports[`SessionSubmissionPageComponent > should snap with user that is not logg
   formattedSessionOpeningTime=""
   hasFeedbackSessionQuestionsLoadingFailed="false"
   instructorService={[Function _InstructorService]}
-  intent={[Function String]}
   isDownloadingSubmissionReceipt="false"
   isFeedbackSessionLoading={[Function Boolean]}
   isFeedbackSessionQuestionsLoading={[Function Boolean]}

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -2,10 +2,9 @@
   <div class="alert alert-primary border mb-3">
     <div class="fw-semibold mb-1">
       You are moderating responses for
-      @if (intent === Intent.STUDENT_SUBMISSION) {
+      @if (entityType === 'student') {
         <span>student</span>
-      }
-      @if (intent === Intent.INSTRUCTOR_SUBMISSION) {
+      } @else {
         <span>instructor</span>
       }
       {{ personName }} ({{ personEmail }}).
@@ -21,10 +20,9 @@
   <div class="alert alert-primary border mb-3">
     <div class="fw-semibold mb-1">
       You are previewing session as
-      @if (intent === Intent.STUDENT_SUBMISSION) {
+      @if (entityType === 'student') {
         <span>student</span>
-      }
-      @if (intent === Intent.INSTRUCTOR_SUBMISSION) {
+      } @else {
         <span>instructor</span>
       }
       {{ personName }} ({{ personEmail }}).

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -553,7 +553,6 @@ describe('SessionSubmissionPageComponent', () => {
     component = fixture.componentInstance;
     component.feedbackSessionId = testQueryParams.fsid;
     component.key = testQueryParams.key;
-    component.intent = Intent.STUDENT_SUBMISSION;
 
     // Default stubs for all service calls in the loadFeedbackSession pipeline.
     // Individual tests can override these with their own spies.
@@ -663,7 +662,7 @@ describe('SessionSubmissionPageComponent', () => {
   it('should fetch auth info on init', () => {
     vi.spyOn(authService, 'getAuthUser').mockReturnValue(of(testInfo));
     component.ngOnInit();
-    expect(component.intent).toEqual(Intent.STUDENT_SUBMISSION);
+    expect(component.entityType).toEqual('student');
     expect(component.feedbackSessionId).toEqual(testQueryParams.fsid);
     expect(component.key).toEqual(testQueryParams.key);
     expect(component.accountEmail).toEqual(testInfo.user?.accountEmail);

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -97,14 +97,12 @@ export class SessionSubmissionPageComponent implements OnInit {
   // enum
   FeedbackSessionSubmissionStatus!: typeof FeedbackSessionSubmissionStatus;
   FeedbackQuestionType!: typeof FeedbackQuestionType;
-  Intent!: typeof Intent;
 
   @Input({ required: true }) feedbackSessionId!: string;
-  @Input() intent: Intent = Intent.STUDENT_SUBMISSION;
   @Input() key = '';
   @Input() moderatedPerson = '';
   @Input() previewAs = '';
-  @Input() entityType = 'student';
+  @Input() entityType: 'student' | 'instructor' = 'student';
   @Input() moderatedQuestionId = '';
 
   courseId = '';
@@ -150,18 +148,11 @@ export class SessionSubmissionPageComponent implements OnInit {
     this.retryAttempts = DEFAULT_NUMBER_OF_RETRY_ATTEMPTS;
     this.FeedbackSessionSubmissionStatus = FeedbackSessionSubmissionStatus;
     this.FeedbackQuestionType = FeedbackQuestionType;
-    this.Intent = Intent;
     this.allSessionViews = SessionView;
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
   }
 
   ngOnInit(): void {
-    if (this.intent === Intent.INSTRUCTOR_SUBMISSION) {
-      this.entityType = 'instructor';
-    }
-    if (this.entityType === 'instructor') {
-      this.intent = Intent.INSTRUCTOR_SUBMISSION;
-    }
     // withComponentInputBinding() can reset @Input() defaults to undefined; restore the 'student' default
     this.entityType ||= 'student';
     if (this.previewAs) {
@@ -176,8 +167,8 @@ export class SessionSubmissionPageComponent implements OnInit {
         if (auth.user) {
           this.accountEmail = auth.user.accountEmail;
         }
-        if (this.key && !isPreviewOrModeration && this.entityType !== 'instructor') {
-          this.authService.getAuthRegkeyValidity(this.key, this.intent).subscribe({
+        if (this.key && !isPreviewOrModeration && this.entityType === 'student') {
+          this.authService.getAuthRegkeyValidity(this.key, this.getSubmissionIntent()).subscribe({
             next: (resp: RegkeyValidity) => {
               if (resp.isAllowedAccess) {
                 if (resp.isUsed) {
@@ -230,8 +221,9 @@ export class SessionSubmissionPageComponent implements OnInit {
   }
 
   private loadCourseInfoData$(): Observable<CourseView | null> {
+    const intent = this.getSubmissionIntent();
     let request: Observable<CourseView>;
-    switch (this.intent) {
+    switch (intent) {
       case Intent.STUDENT_SUBMISSION:
         if (this.moderatedPerson || this.previewAs) {
           request = this.courseService.getCourseAsInstructor(this.courseId);
@@ -259,7 +251,7 @@ export class SessionSubmissionPageComponent implements OnInit {
    * Loads the name of the person involved in the submission.
    */
   private loadUserData$(): Observable<Student | Instructor | null> {
-    switch (this.intent) {
+    switch (this.getSubmissionIntent()) {
       case Intent.STUDENT_SUBMISSION:
         if (this.moderatedPerson || this.previewAs) {
           const userId = this.moderatedPerson || this.previewAs;
@@ -312,6 +304,10 @@ export class SessionSubmissionPageComponent implements OnInit {
    */
   joinCourseForUnregisteredEntity(): void {
     this.navigationService.navigateByURL('/web/join', { entityType: this.entityType, key: this.key });
+  }
+
+  private getSubmissionIntent(): Intent {
+    return this.entityType === 'student' ? Intent.STUDENT_SUBMISSION : Intent.INSTRUCTOR_SUBMISSION;
   }
 
   /**
@@ -445,7 +441,7 @@ export class SessionSubmissionPageComponent implements OnInit {
     return this.feedbackSessionsService
       .getSessionSubmissionData({
         feedbackSessionId: this.feedbackSessionId,
-        intent: this.intent,
+        intent: this.getSubmissionIntent(),
         key: this.key,
         moderatedPerson: this.moderatedPerson,
         previewAs: this.previewAs,
@@ -807,7 +803,7 @@ export class SessionSubmissionPageComponent implements OnInit {
         this.feedbackSessionId,
         { questionResponses },
         {
-          intent: this.intent,
+          intent: this.getSubmissionIntent(),
           key: this.key,
           moderatedperson: this.moderatedPerson,
         },
@@ -912,7 +908,7 @@ export class SessionSubmissionPageComponent implements OnInit {
     this.submissionReceiptService
       .downloadSubmissionReceipt({
         questionSubmissionForms: this.questionSubmissionForms,
-        intent: this.intent,
+        intent: this.getSubmissionIntent(),
         key: this.key,
         moderatedPerson: this.moderatedPerson,
         feedbackSessionTimezone: this.feedbackSessionTimezone,
@@ -956,7 +952,7 @@ export class SessionSubmissionPageComponent implements OnInit {
     this.feedbackResponsesService
       .deleteGiverComment({
         responseId: recipientSubmissionFormModel.responseId,
-        intent: this.intent,
+        intent: this.getSubmissionIntent(),
         key: this.key,
         moderatedPerson: this.moderatedPerson,
       })
@@ -1120,7 +1116,7 @@ export class SessionSubmissionPageComponent implements OnInit {
    * Logs student activity after student/session details have been fetched.
    */
   logStudentAccess(): void {
-    if (this.intent !== Intent.STUDENT_SUBMISSION) {
+    if (this.entityType !== 'student') {
       return;
     }
 
@@ -1141,7 +1137,7 @@ export class SessionSubmissionPageComponent implements OnInit {
    * Logs student submission after successful response submission.
    */
   logStudentSubmission(): void {
-    if (this.intent !== Intent.STUDENT_SUBMISSION) {
+    if (this.entityType !== 'student') {
       return;
     }
 

--- a/src/web/app/pages-student/student.routes.ts
+++ b/src/web/app/pages-student/student.routes.ts
@@ -26,6 +26,9 @@ const routes: Routes = [
           import('../pages-session/session-result-page/session-result-page.component').then(
             (m) => m.SessionResultPageComponent,
           ),
+        data: {
+          entityType: 'student',
+        },
       },
       {
         path: ':feedbackSessionId/submission',
@@ -33,6 +36,9 @@ const routes: Routes = [
           import('../pages-session/session-submission-page/session-submission-page.component').then(
             (m) => m.SessionSubmissionPageComponent,
           ),
+        data: {
+          entityType: 'student',
+        },
       },
     ],
   },

--- a/src/web/app/pages-student/student.routes.ts
+++ b/src/web/app/pages-student/student.routes.ts
@@ -1,5 +1,4 @@
 import { type Routes } from '@angular/router';
-import { Intent } from '../../types/api-request';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 
 const routes: Routes = [
@@ -27,9 +26,6 @@ const routes: Routes = [
           import('../pages-session/session-result-page/session-result-page.component').then(
             (m) => m.SessionResultPageComponent,
           ),
-        data: {
-          intent: Intent.STUDENT_RESULT,
-        },
       },
       {
         path: ':feedbackSessionId/submission',
@@ -37,9 +33,6 @@ const routes: Routes = [
           import('../pages-session/session-submission-page/session-submission-page.component').then(
             (m) => m.SessionSubmissionPageComponent,
           ),
-        data: {
-          intent: Intent.STUDENT_SUBMISSION,
-        },
       },
     ],
   },


### PR DESCRIPTION
<!-- Before opening a PR, please ensure you have read our contributor guidelines -->
<!-- at https://teammates.github.io/teammates/contributing/guidelines.html. -->

<!-- PR title: Copy-and-paste the name of the issue this PR is fixing, -->
<!-- and include the issue number in front in square brackets. -->
<!-- e.g. [#3942] Remove unnecessary System.out.printlns from Java files -->

<!-- Add the issue number to the "Fixes" keyword below. -->

Part of #14353

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->
<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. -->

Following the changes in #14354, we can now assume that the "public" submission page is only for students.

This PR removes Intent, in favour of a single entityType input for both pages.

