### PR TITLE
[#14261] Link up front and back-end login method handling

### DIFF
--- a/src/main/java/teammates/ui/servlets/LoginServlet.java
+++ b/src/main/java/teammates/ui/servlets/LoginServlet.java
@@ -46,13 +46,20 @@ public class LoginServlet extends AuthServlet {
             return;
         }
 
-        LoginMethodHandler loginHandler;
-        if (Config.isDevServerLoginEnabled()) {
-            loginHandler = getLoginHandler(LoginMethod.DEV_SERVER);
-        } else {
-            loginHandler = getLoginHandler(LoginMethod.GOOGLE);
+        LoginMethod loginMethod;
+        try {
+            loginMethod = LoginMethod.fromString(req.getParameter("loginMethod"));
+        } catch (IllegalArgumentException e) {
+            resp.sendError(HttpStatus.SC_BAD_REQUEST);
+            return;
         }
 
+        if (!Config.isSupportedLoginMethod(loginMethod)) {
+            resp.sendError(HttpStatus.SC_BAD_REQUEST);
+            return;
+        }
+
+        LoginMethodHandler loginHandler = getLoginHandler(loginMethod);
         try {
             String redirectUrl = loginHandler.handleLogin(req, nextUrl);
             redirectUrl = resp.encodeRedirectURL(redirectUrl);

--- a/src/test/java/teammates/ui/servlets/LoginServletTest.java
+++ b/src/test/java/teammates/ui/servlets/LoginServletTest.java
@@ -62,29 +62,21 @@ public class LoginServletTest extends BaseTestCase {
 
     @Test
     public void doGet_noAuthCookie_redirectsToLoginHandlerUrl() throws Exception {
+        req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
         when(loginHandler.handleLogin(any(), eq("/"))).thenReturn("/oauthLogin");
 
-        try (MockedStatic<Config> mockConfig = mockStatic(Config.class,
-                Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
-            mockConfig.when(Config::isDevServerLoginEnabled).thenReturn(false);
-
-            servlet.doGet(req, resp);
-        }
+        servlet.doGet(req, resp);
 
         assertEquals("/oauthLogin", resp.getRedirectUrl());
     }
 
     @Test
     public void doGet_loginHandlerThrows_returnsInternalServerError() throws Exception {
+        req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
         when(loginHandler.handleLogin(any(), eq("/")))
                 .thenThrow(new AuthException("Login failed"));
 
-        try (MockedStatic<Config> mockConfig = mockStatic(Config.class,
-                Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
-            mockConfig.when(Config::isDevServerLoginEnabled).thenReturn(false);
-
-            servlet.doGet(req, resp);
-        }
+        servlet.doGet(req, resp);
 
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, resp.getStatus());
     }
@@ -109,13 +101,13 @@ public class LoginServletTest extends BaseTestCase {
     @Test
     public void doGet_validCookieForMissingAccount_redirectsToLoginHandlerUrl() throws Exception {
         req.addCookie(getAuthCookie(UUID.randomUUID()));
+        req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
         when(accountsLogic.getAccount(any())).thenReturn(null);
         when(loginHandler.handleLogin(any(), eq("/"))).thenReturn("/oauthLogin");
 
-        try (MockedStatic<Config> mockConfig = mockStatic(Config.class,
+        try (MockedStatic<Config> ignored = mockStatic(Config.class,
                 Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS));
                 MockedStatic<HibernateUtil> mockHibernateUtil = mockStatic(HibernateUtil.class)) {
-            mockConfig.when(Config::isDevServerLoginEnabled).thenReturn(false);
             mockHibernateUtil.when(HibernateUtil::beginTransaction).thenAnswer(invocation -> null);
             mockHibernateUtil.when(HibernateUtil::commitTransaction).thenAnswer(invocation -> null);
 
@@ -128,16 +120,35 @@ public class LoginServletTest extends BaseTestCase {
     @Test
     public void doGet_invalidCookie_redirectsToLoginHandlerUrl() throws Exception {
         req.addCookie(new Cookie(Const.SecurityConfig.AUTH_COOKIE_NAME, "not-an-auth-cookie"));
+        req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
         when(loginHandler.handleLogin(any(), eq("/"))).thenReturn("/oauthLogin");
+
+        servlet.doGet(req, resp);
+
+        assertEquals("/oauthLogin", resp.getRedirectUrl());
+    }
+
+    @Test
+    public void doGet_invalidLoginMethod_returnsBadRequest() throws Exception {
+        req.addParam("loginMethod", "invalid-method");
+
+        servlet.doGet(req, resp);
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, resp.getStatus());
+    }
+
+    @Test
+    public void doGet_unsupportedLoginMethod_returnsBadRequest() throws Exception {
+        req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
 
         try (MockedStatic<Config> mockConfig = mockStatic(Config.class,
                 Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
-            mockConfig.when(Config::isDevServerLoginEnabled).thenReturn(false);
+            mockConfig.when(() -> Config.isSupportedLoginMethod(LoginMethod.GOOGLE)).thenReturn(false);
 
             servlet.doGet(req, resp);
         }
 
-        assertEquals("/oauthLogin", resp.getRedirectUrl());
+        assertEquals(HttpStatus.SC_BAD_REQUEST, resp.getStatus());
     }
 
     private static Cookie getAuthCookie(UUID accountId) {

--- a/src/test/java/teammates/ui/servlets/LoginServletTest.java
+++ b/src/test/java/teammates/ui/servlets/LoginServletTest.java
@@ -65,7 +65,9 @@ public class LoginServletTest extends BaseTestCase {
         req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
         when(loginHandler.handleLogin(any(), eq("/"))).thenReturn("/oauthLogin");
 
-        servlet.doGet(req, resp);
+        try (MockedStatic<Config> ignored = mockSupportedLoginMethod(LoginMethod.GOOGLE, true)) {
+            servlet.doGet(req, resp);
+        }
 
         assertEquals("/oauthLogin", resp.getRedirectUrl());
     }
@@ -76,7 +78,9 @@ public class LoginServletTest extends BaseTestCase {
         when(loginHandler.handleLogin(any(), eq("/")))
                 .thenThrow(new AuthException("Login failed"));
 
-        servlet.doGet(req, resp);
+        try (MockedStatic<Config> ignored = mockSupportedLoginMethod(LoginMethod.GOOGLE, true)) {
+            servlet.doGet(req, resp);
+        }
 
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, resp.getStatus());
     }
@@ -105,8 +109,7 @@ public class LoginServletTest extends BaseTestCase {
         when(accountsLogic.getAccount(any())).thenReturn(null);
         when(loginHandler.handleLogin(any(), eq("/"))).thenReturn("/oauthLogin");
 
-        try (MockedStatic<Config> ignored = mockStatic(Config.class,
-                Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        try (MockedStatic<Config> ignored = mockSupportedLoginMethod(LoginMethod.GOOGLE, true);
                 MockedStatic<HibernateUtil> mockHibernateUtil = mockStatic(HibernateUtil.class)) {
             mockHibernateUtil.when(HibernateUtil::beginTransaction).thenAnswer(invocation -> null);
             mockHibernateUtil.when(HibernateUtil::commitTransaction).thenAnswer(invocation -> null);
@@ -123,7 +126,9 @@ public class LoginServletTest extends BaseTestCase {
         req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
         when(loginHandler.handleLogin(any(), eq("/"))).thenReturn("/oauthLogin");
 
-        servlet.doGet(req, resp);
+        try (MockedStatic<Config> ignored = mockSupportedLoginMethod(LoginMethod.GOOGLE, true)) {
+            servlet.doGet(req, resp);
+        }
 
         assertEquals("/oauthLogin", resp.getRedirectUrl());
     }
@@ -141,10 +146,7 @@ public class LoginServletTest extends BaseTestCase {
     public void doGet_unsupportedLoginMethod_returnsBadRequest() throws Exception {
         req.addParam("loginMethod", LoginMethod.GOOGLE.getMethod());
 
-        try (MockedStatic<Config> mockConfig = mockStatic(Config.class,
-                Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS))) {
-            mockConfig.when(() -> Config.isSupportedLoginMethod(LoginMethod.GOOGLE)).thenReturn(false);
-
+        try (MockedStatic<Config> ignored = mockSupportedLoginMethod(LoginMethod.GOOGLE, false)) {
             servlet.doGet(req, resp);
         }
 
@@ -157,4 +159,10 @@ public class LoginServletTest extends BaseTestCase {
         return new Cookie(Const.SecurityConfig.AUTH_COOKIE_NAME, cookieValue);
     }
 
+    private static MockedStatic<Config> mockSupportedLoginMethod(LoginMethod method, boolean isSupported) {
+        MockedStatic<Config> mockConfig = mockStatic(Config.class,
+                Mockito.withSettings().defaultAnswer(Answers.CALLS_REAL_METHODS));
+        mockConfig.when(() -> Config.isSupportedLoginMethod(method)).thenReturn(isSupported);
+        return mockConfig;
+    }
 }

--- a/src/web/app/components/login-method-buttons-container/login-method-buttons-container.component.spec.ts
+++ b/src/web/app/components/login-method-buttons-container/login-method-buttons-container.component.spec.ts
@@ -26,7 +26,7 @@ describe('LoginMethodButtonsContainerComponent', () => {
     const getCompleteLoginUrl = component as unknown as { getCompleteLoginUrl: (method: LoginMethod) => string };
 
     expect(getCompleteLoginUrl.getCompleteLoginUrl(LoginMethod.GOOGLE)).toBe(
-      `${environment.backendUrl}/login?nextUrl=%2Fweb%2Fstudent%2Fhome&method=google`,
+      `${environment.backendUrl}/login?nextUrl=%2Fweb%2Fstudent%2Fhome&loginMethod=google`,
     );
   });
 

--- a/src/web/app/components/login-method-buttons-container/login-method-buttons-container.component.ts
+++ b/src/web/app/components/login-method-buttons-container/login-method-buttons-container.component.ts
@@ -32,7 +32,7 @@ export class LoginMethodButtonsContainerComponent {
   private getCompleteLoginUrl(method: LoginMethod): string {
     const url = new URL(this.backendLoginUrl, globalThis.location.origin);
     url.searchParams.set('nextUrl', this.nextUrl() || '/');
-    url.searchParams.set('method', method);
+    url.searchParams.set('loginMethod', method);
     return url.toString();
   }
 }

--- a/src/web/route-guards/role.guard.ts
+++ b/src/web/route-guards/role.guard.ts
@@ -2,7 +2,6 @@ import { CanActivate, CanActivateChild, ActivatedRouteSnapshot, RouterStateSnaps
 import { AuthService } from '../services/auth.service';
 import { inject, Injectable } from '@angular/core';
 import { AuthInfo } from '../types/api-output';
-import { environment } from '../environments/environment';
 import { map } from 'rxjs/operators';
 
 export enum UserRole {
@@ -21,7 +20,6 @@ export enum UserRole {
 })
 export class RoleGuard implements CanActivate, CanActivateChild {
   private authService = inject(AuthService);
-  private backendUrl: string = environment.backendUrl;
   private router = inject(Router);
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
@@ -30,7 +28,7 @@ export class RoleGuard implements CanActivate, CanActivateChild {
     return this.authService.getAuthUser(state.url).pipe(
       map((authInfo: AuthInfo) => {
         if (!authInfo.user) {
-          return this.redirectToLogin(authInfo, this.backendUrl);
+          return this.redirectToLogin(state.url);
         }
 
         // Authenticated user without role requirement.
@@ -66,9 +64,8 @@ export class RoleGuard implements CanActivate, CanActivateChild {
     );
   }
 
-  private redirectToLogin(authInfo: AuthInfo, backendUrl: string) {
-    globalThis.location.href = `${backendUrl}${authInfo.loginUrl}`;
-    return false;
+  private redirectToLogin(nextUrl: string) {
+    return this.router.createUrlTree(['/web/login'], { queryParams: { nextUrl: nextUrl } });
   }
 
   private redirectToUnauthorized(expectedRole: UserRole) {


### PR DESCRIPTION
Fixes #14261

**Outline of Solution**

* Redirect to login page when authentication fails.
* `LoginServlet` reads the loginMethod for further handling.
* Add tests for `LoginServlet`.
