### PR TITLE
[#14327] Remove send invite functionality from instructor search page

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
@@ -75,7 +75,6 @@ public class InstructorCourseDetailsPageE2ETest extends BaseE2ETestCase {
         studentRecordsPage.verifyIsCorrectPage(course.getId(), studentToView.getName());
         studentRecordsPage.goBack();
 
-        
         ______TS("remind all students to join");
         detailsPage.remindAllToJoin();
 

--- a/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
+++ b/src/e2e/java/teammates/e2e/cases/InstructorCourseDetailsPageE2ETest.java
@@ -75,10 +75,7 @@ public class InstructorCourseDetailsPageE2ETest extends BaseE2ETestCase {
         studentRecordsPage.verifyIsCorrectPage(course.getId(), studentToView.getName());
         studentRecordsPage.goBack();
 
-        ______TS("send invite");
-        detailsPage.sendInvite(student3.getEmail());
-        detailsPage.verifyStatusMessage("An email has been sent to " + student3.getEmail());
-
+        
         ______TS("remind all students to join");
         detailsPage.remindAllToJoin();
 

--- a/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
+++ b/src/web/app/components/student-list/__snapshots__/student-list.component.spec.ts.snap
@@ -381,12 +381,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                   </a>
                   <button
                     class="btn btn-light btn-sm btn-margin-right custom-button"
-                    id="btn-send-invite--0"
-                  >
-                     Send Invite 
-                  </button>
-                  <button
-                    class="btn btn-light btn-sm btn-margin-right custom-button"
                     id="btn-delete--0"
                   >
                      Delete 
@@ -446,12 +440,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                   >
                      Edit 
                   </a>
-                  <button
-                    class="btn btn-light btn-sm btn-margin-right custom-button"
-                    id="btn-send-invite--1"
-                  >
-                     Send Invite 
-                  </button>
                   <button
                     class="btn btn-light btn-sm btn-margin-right custom-button"
                     id="btn-delete--1"
@@ -806,12 +794,6 @@ exports[`StudentListComponent > should snap with enable remind button set to tru
                   >
                      Edit 
                   </a>
-                  <button
-                    class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
-                    id="btn-send-invite--0"
-                  >
-                     Send Invite 
-                  </button>
                   <button
                     class="btn btn-light btn-sm btn-margin-right custom-button disabled mouse-hover-only"
                     id="btn-delete--0"

--- a/src/web/app/components/student-list/cell-with-actions.component.html
+++ b/src/web/app/components/student-list/cell-with-actions.component.html
@@ -1,36 +1,55 @@
 <div class="text-center">
-  <a class="btn btn-light btn-sm btn-margin-right custom-button" [id]="'btn-view-details-' + courseId + '-' + idx"
+  <a
+    class="btn btn-light btn-sm btn-margin-right custom-button"
+    [id]="'btn-view-details-' + courseId + '-' + idx"
     [ngbTooltip]="'View the details of the student'"
-    [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'details']">
+    [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'details']"
+  >
     View
   </a>
 
-  <a class="btn btn-light btn-sm btn-margin-right custom-button" [id]="'btn-edit-details-' + courseId + '-' + idx"
-    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }" [ngbTooltip]="
+  <a
+    class="btn btn-light btn-sm btn-margin-right custom-button"
+    [id]="'btn-edit-details-' + courseId + '-' + idx"
+    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
+    [ngbTooltip]="
       instructorPrivileges.canModifyStudent
         ? 'Use this to edit the details of this student. To edit multiple students' +
           ' in one go, you can use the enroll page: ' +
           'Simply enroll students using the updated data and existing data will be updated accordingly'
         : 'You do not have the permissions to access this feature'
-    " [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'edit']">
+    "
+    [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'edit']"
+  >
     Edit
   </a>
 
-  <button id="btn-delete-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right custom-button"
-    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }" [ngbTooltip]="
+  <button
+    id="btn-delete-{{ courseId }}-{{ idx }}"
+    class="btn btn-light btn-sm btn-margin-right custom-button"
+    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
+    [ngbTooltip]="
       instructorPrivileges.canModifyStudent
         ? 'Delete the student and the corresponding submissions from the course'
         : 'You do not have the permissions to access this feature'
-    " [disabled]="!isActionButtonsEnabled" (click)="removeStudentFromCourse()">
+    "
+    [disabled]="!isActionButtonsEnabled"
+    (click)="removeStudentFromCourse()"
+  >
     Delete
   </button>
 
-  <a class="btn btn-light btn-sm btn-margin-right custom-button" [id]="'btn-view-records-' + courseId + '-' + idx"
-    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }" [ngbTooltip]="
+  <a
+    class="btn btn-light btn-sm btn-margin-right custom-button"
+    [id]="'btn-view-records-' + courseId + '-' + idx"
+    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
+    [ngbTooltip]="
       instructorPrivileges.canModifyStudent
         ? 'View all data about this student'
         : 'You do not have the permissions to access this feature'
-    " [routerLink]="['/web/instructor/students', courseId, userId, 'records']">
+    "
+    [routerLink]="['/web/instructor/students', courseId, userId, 'records']"
+  >
     All Records
   </a>
 </div>

--- a/src/web/app/components/student-list/cell-with-actions.component.html
+++ b/src/web/app/components/student-list/cell-with-actions.component.html
@@ -1,72 +1,36 @@
 <div class="text-center">
-  <a
-    class="btn btn-light btn-sm btn-margin-right custom-button"
-    [id]="'btn-view-details-' + courseId + '-' + idx"
+  <a class="btn btn-light btn-sm btn-margin-right custom-button" [id]="'btn-view-details-' + courseId + '-' + idx"
     [ngbTooltip]="'View the details of the student'"
-    [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'details']"
-  >
+    [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'details']">
     View
   </a>
-  <a
-    class="btn btn-light btn-sm btn-margin-right custom-button"
-    [id]="'btn-edit-details-' + courseId + '-' + idx"
-    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
-    [ngbTooltip]="
+
+  <a class="btn btn-light btn-sm btn-margin-right custom-button" [id]="'btn-edit-details-' + courseId + '-' + idx"
+    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }" [ngbTooltip]="
       instructorPrivileges.canModifyStudent
         ? 'Use this to edit the details of this student. To edit multiple students' +
           ' in one go, you can use the enroll page: ' +
           'Simply enroll students using the updated data and existing data will be updated accordingly'
         : 'You do not have the permissions to access this feature'
-    "
-    [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'edit']"
-  >
+    " [routerLink]="['/web/instructor/courses', courseId, 'students', userId, 'edit']">
     Edit
   </a>
-  @if (enableRemindButton) {
-    <ng-container>
-      <button
-        id="btn-send-invite-{{ courseId }}-{{ idx }}"
-        class="btn btn-light btn-sm btn-margin-right custom-button"
-        [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
-        [disabled]="!isActionButtonsEnabled"
-        [ngbTooltip]="
-          instructorPrivileges.canModifyStudent
-            ? 'Email an invitation to the student requesting him/her to join the course using his/her' +
-              ' account. Note: Students can use TEAMMATES without \'joining\',' +
-              ' but a joined student can access extra features'
-            : 'You do not have the permissions to access this feature'
-        "
-        (click)="remindStudentFromCourse()"
-      >
-        Send Invite
-      </button>
-    </ng-container>
-  }
-  <button
-    id="btn-delete-{{ courseId }}-{{ idx }}"
-    class="btn btn-light btn-sm btn-margin-right custom-button"
-    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
-    [ngbTooltip]="
+
+  <button id="btn-delete-{{ courseId }}-{{ idx }}" class="btn btn-light btn-sm btn-margin-right custom-button"
+    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }" [ngbTooltip]="
       instructorPrivileges.canModifyStudent
         ? 'Delete the student and the corresponding submissions from the course'
         : 'You do not have the permissions to access this feature'
-    "
-    [disabled]="!isActionButtonsEnabled"
-    (click)="removeStudentFromCourse()"
-  >
+    " [disabled]="!isActionButtonsEnabled" (click)="removeStudentFromCourse()">
     Delete
   </button>
-  <a
-    class="btn btn-light btn-sm btn-margin-right custom-button"
-    [id]="'btn-view-records-' + courseId + '-' + idx"
-    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }"
-    [ngbTooltip]="
+
+  <a class="btn btn-light btn-sm btn-margin-right custom-button" [id]="'btn-view-records-' + courseId + '-' + idx"
+    [ngClass]="{ 'disabled mouse-hover-only': !instructorPrivileges.canModifyStudent }" [ngbTooltip]="
       instructorPrivileges.canModifyStudent
         ? 'View all data about this student'
         : 'You do not have the permissions to access this feature'
-    "
-    [routerLink]="['/web/instructor/students', courseId, userId, 'records']"
-  >
+    " [routerLink]="['/web/instructor/students', courseId, userId, 'records']">
     All Records
   </a>
 </div>

--- a/src/web/app/components/student-list/student-list.component.spec.ts
+++ b/src/web/app/components/student-list/student-list.component.spec.ts
@@ -4,11 +4,8 @@ import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
 import { StudentListComponent, StudentListRowModel } from './student-list.component';
-import { CourseService } from '../../../services/course.service';
 import { SimpleModalService } from '../../../services/simple-modal.service';
-import { StatusMessageService } from '../../../services/status-message.service';
 import { createBuilder, studentBuilder } from '../../../test-helpers/generic-builder';
 import { createMockNgbModalRef } from '../../../test-helpers/mock-ngb-modal-ref';
 import { JoinState } from '../../../types/api-output';
@@ -18,8 +15,6 @@ describe('StudentListComponent', () => {
   let component: StudentListComponent;
   let fixture: ComponentFixture<StudentListComponent>;
   let simpleModalService: SimpleModalService;
-  let courseService: CourseService;
-  let statusMessageService: StatusMessageService;
 
   const studentListRowModelBuilder = createBuilder<StudentListRowModel>({
     student: studentBuilder.build(),
@@ -56,8 +51,6 @@ describe('StudentListComponent', () => {
 
     fixture = TestBed.createComponent(StudentListComponent);
     simpleModalService = TestBed.inject(SimpleModalService);
-    courseService = TestBed.inject(CourseService);
-    statusMessageService = TestBed.inject(StatusMessageService);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -296,7 +289,7 @@ describe('StudentListComponent', () => {
 
   it(
     'should snap with enable remind button set to true, one student yet to join when not allowed to modify' +
-      ' student',
+    ' student',
     () => {
       component.studentModels = [
         {
@@ -470,33 +463,7 @@ describe('StudentListComponent', () => {
     expect(fixture).toMatchSnapshot();
   });
 
-  it('should display "Send Invite" button when a student has not joined the course', () => {
-    component.enableRemindButton = true;
-    component.studentModels = [
-      {
-        student: {
-          name: 'tester',
-          teamName: 'Team 1',
-          teamId: 'team-1',
-          email: 'tester@tester.com',
-          joinState: JoinState.NOT_JOINED,
-          sectionName: 'Tutorial Group 1',
-          sectionId: 'section-1',
-          courseId: 'text-exa.demo',
-          courseName: 'Test Course',
-          institute: 'Test Institute',
-          userId: 'student-022',
-        },
-        isAllowedToModifyStudent: true,
-      },
-    ];
 
-    fixture.detectChanges();
-
-    const buttons = fixture.debugElement.queryAll(By.css('button'));
-    const sendInviteButton = buttons.find((button) => button.nativeElement.textContent.includes('Send Invite'));
-    expect(sendInviteButton).toBeTruthy();
-  });
 
   it('hasSection: should return true when there are sections in the course', () => {
     const studentOne = studentBuilder.sectionName('None').build();
@@ -520,36 +487,7 @@ describe('StudentListComponent', () => {
     expect(component.hasSection()).toBe(false);
   });
 
-  it('openReminderModal: should display warning when reminding student to join course', async () => {
-    const promise: Promise<void> = Promise.resolve();
-    const mockModalRef = createMockNgbModalRef({}, promise);
-    const modalSpy = vi.spyOn(simpleModalService, 'openConfirmationModal').mockReturnValue(mockModalRef);
 
-    const reminderStudentFromCourseSpy = vi.spyOn(component, 'remindStudentFromCourse');
-
-    const student = studentBuilder.build();
-    student.joinState = JoinState.NOT_JOINED;
-    const studentModel = studentListRowModelBuilder.student(student).build();
-    component.enableRemindButton = true;
-    component.studentModels = [studentModel];
-
-    fixture.detectChanges();
-
-    const buttonGroup = getButtonGroupByStudentEmail(studentModel.student.email);
-    const sendInviteButton = getButtonByText(buttonGroup, 'Send Invite');
-
-    sendInviteButton?.nativeElement.click();
-
-    await promise;
-
-    const expectedModalContent = `Usually, there is no need to use this feature because
-          TEAMMATES sends an automatic invite to students at the opening time of each session.
-          Send a join request to <strong>${studentModel.student.email}</strong> anyway?`;
-    expect(modalSpy).toHaveBeenCalledTimes(1);
-    expect(modalSpy).toHaveBeenLastCalledWith('Send join request?', SimpleModalType.INFO, expectedModalContent);
-
-    expect(reminderStudentFromCourseSpy).toHaveBeenCalledWith(studentModel.student.userId);
-  });
 
   it('openDeleteModal: should display warning when deleting student from course', async () => {
     const promise: Promise<void> = Promise.resolve();
@@ -582,36 +520,9 @@ describe('StudentListComponent', () => {
     expect(component.students).not.toContain(studentModel);
   });
 
-  it(
-    'remindStudentFromCourse: should call statusMessageService.showSuccessToast with' + 'correct message upon success',
-    () => {
-      const successMessage = 'success';
-      vi.spyOn(courseService, 'remindUserForJoin').mockReturnValue(of({ message: successMessage }));
-      const studentId = 'test-user-id';
 
-      const statusMessageServiceSpy = vi.spyOn(statusMessageService, 'showSuccessToast');
 
-      component.remindStudentFromCourse(studentId);
 
-      expect(statusMessageServiceSpy).toHaveBeenLastCalledWith(successMessage);
-    },
-  );
-
-  it('remindStudentFromCourse: should call statusMessageService.showErrorToast with correct message upon error', () => {
-    const errorMessage = 'error';
-    vi.spyOn(courseService, 'remindUserForJoin').mockReturnValue(
-      throwError(() => ({
-        error: { message: errorMessage },
-      })),
-    );
-    const studentId = 'test-user-id';
-
-    const statusMessageServiceSpy = vi.spyOn(statusMessageService, 'showErrorToast');
-
-    component.remindStudentFromCourse(studentId);
-
-    expect(statusMessageServiceSpy).toHaveBeenLastCalledWith(errorMessage);
-  });
 
   it('setRowData: should highlight partial matches when enabled', () => {
     component.isPartialMatchHighlightingEnabled = true;

--- a/src/web/app/components/student-list/student-list.component.spec.ts
+++ b/src/web/app/components/student-list/student-list.component.spec.ts
@@ -289,7 +289,7 @@ describe('StudentListComponent', () => {
 
   it(
     'should snap with enable remind button set to true, one student yet to join when not allowed to modify' +
-    ' student',
+      ' student',
     () => {
       component.studentModels = [
         {
@@ -463,8 +463,6 @@ describe('StudentListComponent', () => {
     expect(fixture).toMatchSnapshot();
   });
 
-
-
   it('hasSection: should return true when there are sections in the course', () => {
     const studentOne = studentBuilder.sectionName('None').build();
     const studentTwo = studentBuilder.sectionName('section-one').build();
@@ -486,8 +484,6 @@ describe('StudentListComponent', () => {
 
     expect(component.hasSection()).toBe(false);
   });
-
-
 
   it('openDeleteModal: should display warning when deleting student from course', async () => {
     const promise: Promise<void> = Promise.resolve();
@@ -519,10 +515,6 @@ describe('StudentListComponent', () => {
     expect(removeStudentFromCourseSpy).toHaveBeenCalledWith(studentModel);
     expect(component.students).not.toContain(studentModel);
   });
-
-
-
-
 
   it('setRowData: should highlight partial matches when enabled', () => {
     component.isPartialMatchHighlightingEnabled = true;

--- a/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
+++ b/src/web/app/pages-admin/admin-notifications-page/__snapshots__/admin-notifications-page.component.spec.ts.snap
@@ -440,6 +440,11 @@ exports[`AdminNotificationsPageComponent > should snap when notification edit fo
                           >
                             23:59H
                           </option>
+                          <option
+                            value="24: Object"
+                          >
+                            21:30H
+                          </option>
                         </select>
                       </div>
                     </tm-datetimepicker>
@@ -613,6 +618,11 @@ exports[`AdminNotificationsPageComponent > should snap when notification edit fo
                             value="0: Object"
                           >
                             23:59H
+                          </option>
+                          <option
+                            value="24: Object"
+                          >
+                            18:30H
                           </option>
                         </select>
                       </div>
@@ -1105,6 +1115,11 @@ exports[`AdminNotificationsPageComponent > should snap when notifications are lo
                           >
                             23:59H
                           </option>
+                          <option
+                            value="24: Object"
+                          >
+                            21:30H
+                          </option>
                         </select>
                       </div>
                     </tm-datetimepicker>
@@ -1278,6 +1293,11 @@ exports[`AdminNotificationsPageComponent > should snap when notifications are lo
                             value="0: Object"
                           >
                             23:59H
+                          </option>
+                          <option
+                            value="24: Object"
+                          >
+                            18:30H
                           </option>
                         </select>
                       </div>
@@ -1777,6 +1797,11 @@ exports[`AdminNotificationsPageComponent > should snap when notifications failed
                           >
                             23:59H
                           </option>
+                          <option
+                            value="24: Object"
+                          >
+                            21:30H
+                          </option>
                         </select>
                       </div>
                     </tm-datetimepicker>
@@ -1950,6 +1975,11 @@ exports[`AdminNotificationsPageComponent > should snap when notifications failed
                             value="0: Object"
                           >
                             23:59H
+                          </option>
+                          <option
+                            value="24: Object"
+                          >
+                            18:30H
                           </option>
                         </select>
                       </div>
@@ -2447,6 +2477,11 @@ exports[`AdminNotificationsPageComponent > should snap with default view 1`] = `
                           >
                             23:59H
                           </option>
+                          <option
+                            value="24: Object"
+                          >
+                            21:30H
+                          </option>
                         </select>
                       </div>
                     </tm-datetimepicker>
@@ -2620,6 +2655,11 @@ exports[`AdminNotificationsPageComponent > should snap with default view 1`] = `
                             value="0: Object"
                           >
                             23:59H
+                          </option>
+                          <option
+                            value="24: Object"
+                          >
+                            18:30H
                           </option>
                         </select>
                       </div>

--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -582,12 +582,6 @@ exports[`InstructorCourseDetailsPageComponent > should snap with a course with o
                           </a>
                           <button
                             class="btn btn-light btn-sm btn-margin-right custom-button"
-                            id="btn-send-invite-CS101-0"
-                          >
-                             Send Invite 
-                          </button>
-                          <button
-                            class="btn btn-light btn-sm btn-margin-right custom-button"
                             id="btn-delete-CS101-0"
                           >
                              Delete 


### PR DESCRIPTION
Fixes #14327

## Outline of Solution
- Removed the "Send Invite" button from the instructor search page.
- Removed the related tests.
- Updated the affected snapshot.