### PR TITLE
[#14366] Rename regenerate key button to regenerate links

### DIFF
--- a/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.html
+++ b/src/web/app/pages-admin/admin-search-page/admin-student-search-table/admin-student-search-table.component.html
@@ -74,7 +74,7 @@
                 @if (isRegeneratingStudentKeys[i]) {
                   <tm-ajax-loading></tm-ajax-loading>
                 }
-                Regenerate key
+                Regenerate Links
               </button>
             </td>
           </tr>


### PR DESCRIPTION
Fixes #14366

### Summary

Renamed the "Regenerate Key" button to "Regenerate Links" on the admin search page.