### PR TITLE
[#14387] Modify sign in dropdown to a generic sign in button

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -64,19 +64,15 @@
     @if (!isFetchingAuthDetails) {
       <ul class="nav navbar-nav pull-right">
         @if (!accountEmail) {
-          <li class="nav-item dropdown" ngbDropdown placement="bottom-end">
-            <button
-              class="bg-transparent btn btn-link nav-link dropdown-toggle"
-              data-toggle="dropdown"
-              tabindex="0"
-              ngbDropdownToggle
+          <li class="nav-item">
+            <a
+              class="nav-link"
+              id="login-btn"
+              routerLink="/web/instructor/home"
+              (click)="toggleCollapse(); closeModal()"
             >
               Sign in
-            </button>
-            <div class="dropdown-menu-right dropdown-menu-dark" ngbDropdownMenu>
-              <a class="dropdown-item" id="student-login-btn" routerLink="/web/student/home">As Student</a>
-              <a class="dropdown-item" id="instructor-login-btn" routerLink="/web/instructor/home">As Instructor</a>
-            </div>
+            </a>
           </li>
         } @else {
           <li class="nav-item dropdown" ngbDropdown placement="bottom-end">

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -68,7 +68,8 @@
             <a
               class="nav-link"
               id="login-btn"
-              routerLink="/web/instructor/home"
+              routerLink="/web/login"
+              [queryParams]="{ nextUrl: '/' }"
               (click)="toggleCollapse(); closeModal()"
             >
               Sign in

--- a/src/web/app/page.component.spec.ts
+++ b/src/web/app/page.component.spec.ts
@@ -21,4 +21,17 @@ describe('PageComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should show a generic sign-in link before login', () => {
+    component.isFetchingAuthDetails = false;
+    component.accountEmail = '';
+    fixture.detectChanges();
+
+    const loginLink: HTMLAnchorElement = fixture.nativeElement.querySelector('#login-btn');
+
+    expect(loginLink).not.toBeNull();
+    expect(loginLink.textContent?.trim()).toBe('Sign in');
+    expect(fixture.nativeElement.querySelector('#student-login-btn')).toBeNull();
+    expect(fixture.nativeElement.querySelector('#instructor-login-btn')).toBeNull();
+  });
 });

--- a/src/web/app/page.component.spec.ts
+++ b/src/web/app/page.component.spec.ts
@@ -21,17 +21,4 @@ describe('PageComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
-  it('should show a generic sign-in link before login', () => {
-    component.isFetchingAuthDetails = false;
-    component.accountEmail = '';
-    fixture.detectChanges();
-
-    const loginLink: HTMLAnchorElement = fixture.nativeElement.querySelector('#login-btn');
-
-    expect(loginLink).not.toBeNull();
-    expect(loginLink.textContent?.trim()).toBe('Sign in');
-    expect(fixture.nativeElement.querySelector('#student-login-btn')).toBeNull();
-    expect(fixture.nativeElement.querySelector('#instructor-login-btn')).toBeNull();
-  });
 });


### PR DESCRIPTION
Part of #14387

**Outline of Solution**

* Modify the sign in dropdown to a single button that redirects users to the login page with the default `nextUrl`.
