### PR TITLE
[#14397] Add instructions on how to become an instructor in Getting Started page

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -15,12 +15,11 @@
         <h2 id="become-instructor">Become an instructor</h2>
         <div>
           <p>
-            To create courses in TEAMMATES, you must first have an instructor account. If you do not have one, you can
-            request an instructor account by filling in the
-            <a routerLink="/web/front/request">instructor account request form</a>.
+            To create courses in TEAMMATES, you must have an instructor account. If you do not already have one, you can
+            request one by filling out this <a routerLink="/web/front/request">request form</a>.
           </p>
           <p>
-            After you submit the request, we will verify your affiliation with your institution and notify you via email
+            After submitting your request, we will verify your affiliation with your institution and notify you by email
             once your account has been approved.
           </p>
         </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -12,6 +12,20 @@
         <div class="separate-content-holder">
           <hr />
         </div>
+        <h2 id="become-instructor">Become an instructor</h2>
+        <div>
+          <p>
+            To create courses in TEAMMATES, you must first have an instructor account.
+            If you do not have one, you can request an instructor account by filling in the
+            <a routerLink="/web/front/request">instructor account request form</a>.
+          </p>
+          <p>
+            After you submit the request, we will verify your affiliation with your institution and notify you via email once your account has been approved.
+          </p>
+        </div>
+        <div class="separate-content-holder">
+          <hr />
+        </div>
         <h2 id="course-setup">1. Set up a course</h2>
         <div>
           <p>
@@ -369,6 +383,9 @@
         </b>
       </p>
       <ul class="nav nav-pills flex-column">
+        <li class="nav-item">
+          <a (click)="jumpTo('become-instructor')" [routerLink]="[]">Become an instructor</a>
+        </li>
         <li class="nav-item">
           <a (click)="jumpTo('course-setup')" [routerLink]="[]">Set up a course</a>
         </li>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -15,12 +15,13 @@
         <h2 id="become-instructor">Become an instructor</h2>
         <div>
           <p>
-            To create courses in TEAMMATES, you must first have an instructor account.
-            If you do not have one, you can request an instructor account by filling in the
+            To create courses in TEAMMATES, you must first have an instructor account. If you do not have one, you can
+            request an instructor account by filling in the
             <a routerLink="/web/front/request">instructor account request form</a>.
           </p>
           <p>
-            After you submit the request, we will verify your affiliation with your institution and notify you via email once your account has been approved.
+            After you submit the request, we will verify your affiliation with your institution and notify you via email
+            once your account has been approved.
           </p>
         </div>
         <div class="separate-content-holder">


### PR DESCRIPTION
Fixes #14397

**Outline of Solution**

Added a "Become an instructor" prerequisite section to the instructor Getting Started page ([instructor-help-getting-started.component.html](file:///c:/Users/SSAFY/opensource/teammates/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html)):
* Explained how new users can request an instructor account and added a redirection link to the request form (`/web/front/request`).
* Added a corresponding sidebar link on the Getting Started page to jump directly to this section.